### PR TITLE
Fix lint on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+*.sh text eol=lf
+*.go text eol=lf
+*.exe binary


### PR DESCRIPTION
With gofmt outputting files with \n, the easiest remains to leave all go files with \n and rely on the IDE and linters to make sure it stays like that.

Signed-off-by: Mathieu Champlon <mathieu.champlon@docker.com>