### PR TITLE
Add version command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG ALPINE_VERSION=3.7
 ARG GO_VERSION=1.10.1
+ARG COMMIT=unknown
 ARG TAG=unknown
 
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
@@ -10,9 +11,11 @@ WORKDIR /go/src/github.com/docker/lunchbox/
 COPY . .
 
 FROM build AS bin-build
+ARG COMMIT
 ARG TAG
-RUN make TAG=${TAG} bin-all
+RUN make COMMIT=${COMMIT} TAG=${TAG} bin-all
 
 FROM build AS test
+ARG COMMIT
 ARG TAG
-RUN make TAG=${TAG} unit-test e2e-test
+RUN make COMMIT=${COMMIT} TAG=${TAG} unit-test e2e-test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PKG_NAME := github.com/docker/lunchbox
 BIN_NAME := docker-app
 
 TAG ?= $(shell git describe --always --dirty)
+COMMIT ?= $(shell git rev-parse --short HEAD)
 
 IMAGE_NAME := docker-app
 
@@ -12,9 +13,12 @@ IMAGE_BUILD_ARGS := \
     --build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
     --build-arg GO_VERSION=$(GO_VERSION) \
     --build-arg BIN_NAME=$(BIN_NAME) \
+    --build-arg COMMIT=$(COMMIT) \
     --build-arg TAG=$(TAG)
 
-LDFLAGS := "-s -w"
+LDFLAGS := "-s -w \
+	-X $(PKG_NAME)/internal.GitCommit=$(COMMIT) \
+	-X $(PKG_NAME)/internal.Version=$(TAG)"
 
 #####################
 # Local Development #
@@ -59,7 +63,7 @@ unit-test:
 	go test $(shell go list ./... | grep -vE '/vendor/|/e2e')
 
 clean:
-	rm -Rf ./_build
+	rm -Rf ./_build docker-app-*.tar.gz
 
 ######
 # CI #

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/docker/lunchbox/internal"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(internal.FullVersion())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+var (
+	// Version is the git tag that this was built from.
+	Version = "unknown"
+	// GitCommit is the commit that this was built from.
+	GitCommit = "unknown"
+)
+
+// FullVersion returns a string of version information.
+func FullVersion() string {
+	res := []string{
+		fmt.Sprintf("Version:    %s", Version),
+		fmt.Sprintf("Git commit: %s", GitCommit),
+		fmt.Sprintf("OS/Arch:    %s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+	return strings.Join(res, "\n")
+}


### PR DESCRIPTION
Adds a simple version command:
```bash
$ docker-app version
Version:    ccddc37
Git commit: ccddc37
OS/Arch:    darwin/amd64
```

**Note:** While this project doesn't have any tags, the version is a commit.