### PR TITLE
Clean artefacts at the start of a Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ node('gcp-linux-worker-0') {
     stage('Build') {
         dir('src/github.com/docker/lunchbox') {
             checkout scm
+            sh 'rm -f *.tar.gz'
             sh 'docker image prune -f'
             sh 'make ci-lint'
             sh 'make ci-test'


### PR DESCRIPTION
Because Jenkins reuses the workspace, so in order to avoid
![image](https://user-images.githubusercontent.com/2386884/38754633-f11b0a1c-3f62-11e8-9cd8-72eeea5319a4.png)
