### PR TITLE
Make ci-lint only depend on Docker

### DIFF
--- a/Dockerfile.lint
+++ b/Dockerfile.lint
@@ -1,8 +1,7 @@
-ARG GO_VERSION=1.10
+ARG GO_VERSION=1.10.1
 ARG RUN_BASE_TAG=3.7
-ARG BUILD_BASE_TAG=${GO_VERSION}-alpine${RUN_BASE_TAG}
 
-FROM golang:${BUILD_BASE_TAG}
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS lint-base
 RUN apk add --no-cache \
     curl \
     git
@@ -26,4 +25,9 @@ ENV CGO_ENABLED=0
 ENV DISABLE_WARN_OUTSIDE_CONTAINER=1
 ENTRYPOINT ["/usr/local/bin/gometalinter"]
 CMD ["--config=gometalinter.json", "./..."]
+
+FROM lint-base AS lint-volume
 VOLUME ["/go/src/github.com/docker/lunchbox"]
+
+FROM lint-base AS lint-image
+COPY . .

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ test check: lint unit-test e2e-test
 
 lint:
 	@echo "Linting..."
-	@tar -c Dockerfile.lint gometalinter.json | docker build -t $(IMAGE_NAME)-lint $(IMAGE_BUILD_ARGS) -f Dockerfile.lint - > /dev/null
-	@docker run --rm -v $(dir $(realpath $(lastword $(MAKEFILE_LIST)))):/go/src/$(PKG_NAME) $(IMAGE_NAME)-lint
+	@tar -c Dockerfile.lint gometalinter.json | docker build -t $(IMAGE_NAME)-lint $(IMAGE_BUILD_ARGS) -f Dockerfile.lint - --target=lint-volume > /dev/null
+	@docker run --rm -v $(dir $(realpath $(lastword $(MAKEFILE_LIST)))):/go/src/$(PKG_NAME):ro $(IMAGE_NAME)-lint
 
 e2e-test:
 	@echo "Running e2e tests..."
@@ -69,9 +69,13 @@ clean:
 # CI #
 ######
 
-ci-lint: lint
+ci-lint:
+	@echo "Linting..."
+	docker build -t $(IMAGE_NAME)-lint $(IMAGE_BUILD_ARGS) -f Dockerfile.lint . --target=lint-image
+	docker run --rm $(IMAGE_NAME)-lint
 
 ci-test:
+	@echo "Testing..."
 	docker build -t $(IMAGE_NAME)-test $(IMAGE_BUILD_ARGS) . --target=test
 
 ci-bin-%:


### PR DESCRIPTION
Fixes `ci-lint` rule mentioned here: https://github.com/docker/lunchbox/issues/13#issuecomment-381972551