### PR TITLE
Prevent artifacts to be archived for pull requests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,9 @@ pipeline {
                             dir('stash') {
                                 stash name: 'e2e'
                             }
-                            archiveArtifacts '*.tar.gz'
+                            if(!(env.BRANCH_NAME ==~ "PR-\\d+")) {
+                                archiveArtifacts '*.tar.gz'
+                            }
                         } finally {
                             def clean_images = /docker image ls --format "{{.ID}}\t{{.Tag}}" | grep $(git describe --always --dirty) | awk '{print $1}' | xargs docker image rm/
                             sh clean_images


### PR DESCRIPTION
They're not really useful and take a lot of disk space.

Signed-off-by: Mathieu Champlon <mathieu.champlon@docker.com>