### PR TITLE
renderer: set gotemplate to err on missing variable.

### DIFF
--- a/renderer/render.go
+++ b/renderer/render.go
@@ -80,6 +80,7 @@ func applyRenderers(data []byte, renderers []string, settings map[string]interfa
 			if err != nil {
 				return nil, err
 			}
+			tmpl.Option("missingkey=error")
 			yaml := bytes.NewBuffer(nil)
 			err = tmpl.Execute(yaml, settings)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>