### PR TITLE
version: Dump config. e2e: exposes hasExperimental for future use.

### DIFF
--- a/e2e/binary_test.go
+++ b/e2e/binary_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/gotestyourself/gotestyourself/assert"
@@ -18,22 +19,24 @@ import (
 )
 
 var (
-	dockerApp = ""
+	dockerApp       = ""
+	hasExperimental = false
 )
 
-func getBinary(t *testing.T) string {
+func getBinary(t *testing.T) (string, bool) {
 	if dockerApp != "" {
-		return dockerApp
+		return dockerApp, hasExperimental
 	}
 	binName := findBinary()
 	if binName == "" {
 		t.Error("cannot locate docker-app binary")
 	}
 	cmd := exec.Command(binName, "version")
-	err := cmd.Run()
+	output, err := cmd.CombinedOutput()
 	assert.NilError(t, err, "failed to execute %s", binName)
 	dockerApp = binName
-	return dockerApp
+	hasExperimental = strings.Contains(string(output), "Experimental: on")
+	return dockerApp, hasExperimental
 }
 
 func findBinary() string {

--- a/internal/version.go
+++ b/internal/version.go
@@ -16,9 +16,11 @@ var (
 // FullVersion returns a string of version information.
 func FullVersion() string {
 	res := []string{
-		fmt.Sprintf("Version:    %s", Version),
-		fmt.Sprintf("Git commit: %s", GitCommit),
-		fmt.Sprintf("OS/Arch:    %s/%s", runtime.GOOS, runtime.GOARCH),
+		fmt.Sprintf("Version:      %s", Version),
+		fmt.Sprintf("Git commit:   %s", GitCommit),
+		fmt.Sprintf("OS/Arch:      %s/%s", runtime.GOOS, runtime.GOARCH),
+		fmt.Sprintf("Experimental: %s", Experimental),
+		fmt.Sprintf("Renderers:    %s", Renderers),
 	}
 	return strings.Join(res, "\n")
 }


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>