### PR TITLE
Simplify package filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ e2e-test: bin
 
 unit-test:
 	@echo "Running unit tests..."
-	$(GO_TEST) $(shell go list ./... | grep -vE '/vendor/|/e2e')
+	$(GO_TEST) $(shell go list ./... | grep -vE '/e2e')
 
 clean:
 	rm -Rf ./_build docker-app-*.tar.gz


### PR DESCRIPTION
Go list excludes 'vendor' by itself.

```bash
$ go list ./...
github.com/docker/lunchbox
github.com/docker/lunchbox/cmd
github.com/docker/lunchbox/constants
github.com/docker/lunchbox/e2e
github.com/docker/lunchbox/image
github.com/docker/lunchbox/internal
github.com/docker/lunchbox/packager
github.com/docker/lunchbox/renderer
github.com/docker/lunchbox/templateconversion
github.com/docker/lunchbox/templateloader
github.com/docker/lunchbox/templatetypes
github.com/docker/lunchbox/templatev1beta2
github.com/docker/lunchbox/types
github.com/docker/lunchbox/utils

$ go list ./... | grep -vE '/e2e'
github.com/docker/lunchbox
github.com/docker/lunchbox/cmd
github.com/docker/lunchbox/constants
github.com/docker/lunchbox/image
github.com/docker/lunchbox/internal
github.com/docker/lunchbox/packager
github.com/docker/lunchbox/renderer
github.com/docker/lunchbox/templateconversion
github.com/docker/lunchbox/templateloader
github.com/docker/lunchbox/templatetypes
github.com/docker/lunchbox/templatev1beta2
github.com/docker/lunchbox/types
github.com/docker/lunchbox/utils
```