### PR TITLE
As of go 1.10, `-i` on build is not required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,15 +56,15 @@ check_go_env:
 
 bin: check_go_env
 	@echo "Building _build/$(BIN_NAME)$(EXEC_EXT)..."
-	$(GO_BUILD) -ldflags=$(LDFLAGS) -i -o _build/$(BIN_NAME)$(EXEC_EXT)
+	$(GO_BUILD) -ldflags=$(LDFLAGS) -o _build/$(BIN_NAME)$(EXEC_EXT)
 
 bin-all: check_go_env
 	@echo "Building for all platforms..."
-	$(foreach OS, $(OS_LIST), GOOS=$(OS) $(GO_BUILD) -ldflags=$(LDFLAGS) -i -o _build/$(BIN_NAME)-$(OS)$(if $(filter windows, $(OS)),.exe,) || exit 1;)
+	$(foreach OS, $(OS_LIST), GOOS=$(OS) $(GO_BUILD) -ldflags=$(LDFLAGS) -o _build/$(BIN_NAME)-$(OS)$(if $(filter windows, $(OS)),.exe,) || exit 1;)
 
 e2e-all: check_go_env
 	@echo "Building for all platforms..."
-	$(foreach OS, $(OS_LIST), GOOS=$(OS) $(GO_TEST) -c -i -o _build/$(E2E_NAME)-$(OS)$(if $(filter windows, $(OS)),.exe,) ./e2e || exit 1;)
+	$(foreach OS, $(OS_LIST), GOOS=$(OS) $(GO_TEST) -c -o _build/$(E2E_NAME)-$(OS)$(if $(filter windows, $(OS)),.exe,) ./e2e || exit 1;)
 
 test check: lint unit-test e2e-test
 


### PR DESCRIPTION
> The old advice to add the -i flag for speed, as in go build -i or go
> test -i, is no longer necessary: builds run just as fast without -i.

https://golang.org/doc/go1.10#build

`-i` is really a pain in the ass in case of having the go stdlib on a read-only filesystem

Signed-off-by: Vincent Demeester <vincent@sbr.pm>