### PR TITLE
Move pipeline job to dedicated worker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ properties([buildDiscarder(logRotator(numToKeepStr: '20'))])
 
 pipeline {
     agent {
-        label 'linux'
+        label 'pipeline'
     }
 
     options {


### PR DESCRIPTION
A new worker with the pipeline label has been created to be dedicated to running the pipeline master job which collects all the logs from the downstream agents. This should prevent the pipeline job to starve and deadlock the workers on the same node.