### PR TITLE
Simplify lint target

### DIFF
--- a/Dockerfile.lint
+++ b/Dockerfile.lint
@@ -1,7 +1,7 @@
 ARG ALPINE_VERSION=3.7
 ARG GO_VERSION=1.10.1
 
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS lint-base
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION}
 RUN apk add --no-cache \
     curl \
     git
@@ -26,8 +26,4 @@ ENV DISABLE_WARN_OUTSIDE_CONTAINER=1
 ENTRYPOINT ["/usr/local/bin/gometalinter"]
 CMD ["--config=gometalinter.json", "./..."]
 
-FROM lint-base AS lint-volume
-VOLUME ["/go/src/github.com/docker/app"]
-
-FROM lint-base AS lint-image
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test check: lint unit-test e2e-test
 
 lint:
 	@echo "Linting..."
-	@tar -c Dockerfile.lint gometalinter.json | docker build -t $(IMAGE_NAME)-lint $(IMAGE_BUILD_ARGS) -f Dockerfile.lint - --target=lint-volume > /dev/null
+	@tar -c Dockerfile.lint gometalinter.json | docker build -t $(IMAGE_NAME)-lint $(IMAGE_BUILD_ARGS) -f Dockerfile.lint - > /dev/null
 	@docker run --rm -v $(CWD):$(PKG_PATH):ro,cached $(IMAGE_NAME)-lint
 
 e2e-test: bin
@@ -106,7 +106,7 @@ COV_LABEL := com.docker.app.cov-run=$(TAG)
 
 ci-lint:
 	@echo "Linting..."
-	docker build -t $(IMAGE_NAME)-lint:$(TAG) $(IMAGE_BUILD_ARGS) -f Dockerfile.lint . --target=lint-image
+	docker build -t $(IMAGE_NAME)-lint:$(TAG) $(IMAGE_BUILD_ARGS) -f Dockerfile.lint .
 	docker run --rm $(IMAGE_NAME)-lint:$(TAG)
 
 ci-test:


### PR DESCRIPTION
The multi-stage dockerfile is not needed

Signed-off-by: Vincent Demeester <vincent@sbr.pm>