### PR TITLE
Lookup default permutation of app folder before literal name

### DIFF
--- a/packager/extract.go
+++ b/packager/extract.go
@@ -89,12 +89,13 @@ func Extract(appname string) (string, func(), error) {
 		}
 	}
 	originalAppname := appname
-	// try verbatim first
+
+	// try appending our extension
+	appname = utils.DirNameFromAppName(appname)
 	s, err := os.Stat(appname)
 	if err != nil {
-		// try appending our extension
-		appname = utils.DirNameFromAppName(appname)
-		s, err = os.Stat(appname)
+		// try verbatim
+		s, err = os.Stat(originalAppname)
 	}
 	if err != nil {
 		// look for a docker image
@@ -102,7 +103,7 @@ func Extract(appname string) (string, func(), error) {
 	}
 	if s.IsDir() {
 		// directory: already decompressed
-		return appname, noop, nil
+		return s.Name(), noop, nil
 	}
 	// not a dir: single-file or a tarball package, extract that in a temp dir
 	tempDir, err := ioutil.TempDir("", "dockerapp")


### PR DESCRIPTION
Since `docker-app init foobar` creates a `foobar.docker-app` folder by default `docker-app <cmd> foobar` should look for `foobar.docker-app/` _before_ `foobar/`.

This is relevant especially for Python projects where it is conventional for the project/package name to be used as the source folder name.