### PR TITLE
Makefile, CI enhancements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 *.dockerapp
 *.tar.gz
 _build/
+bin/docker-app-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.tar.gz
 *.dockerapp
 _build/
+bin/
 !examples/simple/*.dockerapp
 .gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,41 @@
 ARG ALPINE_VERSION=3.7
 ARG GO_VERSION=1.10.2
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
+ARG DOCKERCLI_VERSION=18.03.1-ce
+ARG DOCKERCLI_CHANNEL=edge
+RUN apk add --no-cache \
+  bash \
+  make\
+  git \
+  curl \
+  util-linux
+RUN curl -Ls https://download.docker.com/linux/static/$DOCKERCLI_CHANNEL/x86_64/docker-$DOCKERCLI_VERSION.tgz | \
+  tar -xz docker/docker && \
+  ls -l . && \
+  mv docker/docker /usr/bin/docker
+
+WORKDIR /go/src/github.com/docker/app/
+
+FROM build AS dev
+COPY . .
+
+FROM dev AS docker-app
 ARG COMMIT=unknown
 ARG TAG=unknown
 ARG BUILDTIME=unknown
+RUN make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} bin/docker-app
 
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
-RUN apk add --no-cache \
-  bash \
-  build-base \
-  docker \
-  git \
-  util-linux
-WORKDIR /go/src/github.com/docker/app/
-COPY . .
-
-FROM build AS bin-build
-ARG COMMIT
-ARG TAG
+# FIXME(vdemeester) change from docker-app to dev once buildkit is merged in moby/docker
+FROM docker-app AS cross
+ARG COMMIT=unknown
+ARG TAG=unknown
 ARG BUILDTIME=unknown
-RUN make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} bin-all e2e-all
+RUN make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} cross
 
-FROM build AS test
-ARG COMMIT
-ARG TAG
+# FIXME(vdemeester) change from docker-app to dev once buildkit is merged in moby/docker
+FROM cross AS e2e-cross
+ARG COMMIT=unknown
+ARG TAG=unknown
 ARG BUILDTIME=unknown
-RUN make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} unit-test
+RUN make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} e2e-cross

--- a/Dockerfile.gradle
+++ b/Dockerfile.gradle
@@ -1,0 +1,3 @@
+FROM gradle:jdk8
+COPY bin/docker-app /usr/local/bin/docker-app
+COPY --chown=gradle:gradle integrations/gradle .

--- a/Dockerfile.lint
+++ b/Dockerfile.lint
@@ -4,7 +4,8 @@ ARG GO_VERSION=1.10.2
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION}
 RUN apk add --no-cache \
     curl \
-    git
+    git \
+    make
 
 ENV GOMETALITER_VERSION=2.0.5
 ENV NAKEDRECT_SHA=c0e305a4f690fed163d47628bcc06a6d5655bf92
@@ -22,8 +23,7 @@ RUN git clone https://github.com/alexkohler/nakedret.git /go/src/github.com/alex
 
 WORKDIR /go/src/github.com/docker/app
 ENV CGO_ENABLED=0
-ENV DISABLE_WARN_OUTSIDE_CONTAINER=1
-ENTRYPOINT ["/usr/local/bin/gometalinter"]
-CMD ["--config=gometalinter.json", "./..."]
+ARG BUILDTIME=unknown
+ENV BUILDTIME=${BUILDTIME}
 
 COPY . .

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -1,0 +1,86 @@
+include vars.mk
+
+IMAGE_NAME := docker-app
+
+IMAGE_BUILD_ARGS := \
+    --build-arg COMMIT=$(COMMIT) \
+    --build-arg TAG=$(TAG)       \
+    --build-arg BUILDTIME=$(BUILDTIME)
+
+PKG_PATH := /go/src/$(PKG_NAME)
+
+.DEFAULT: all
+all: bin test
+
+create_bin:
+	@mkdir -p bin
+
+build_dev_image:
+	docker build --target=dev -t $(IMAGE_NAME)-dev $(IMAGE_BUILD_ARGS) .
+
+shell: build_dev_image
+	docker run -ti --rm $(IMAGE_NAME)-dev bash
+
+bin/%: create_bin
+	docker build --target=$* -t $(IMAGE_NAME)-bin $(IMAGE_BUILD_ARGS) .
+	( containerID=$$(docker create $(IMAGE_NAME)-bin noop); \
+		docker cp $$containerID:$(PKG_PATH)/bin/$*$(EXEC_EXT) $@; \
+		docker rm $$containerID )
+	@chmod +x $@
+
+cross: create_bin
+	docker build --target=$* -t $(IMAGE_NAME)-cross $(IMAGE_BUILD_ARGS) .
+	( containerID=$$(docker create $(IMAGE_NAME)-cross noop); \
+		docker cp $$containerID:$(PKG_PATH)/bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-linux; \
+		docker cp $$containerID:$(PKG_PATH)/bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-darwin ; \
+		docker cp $$containerID:$(PKG_PATH)/bin/$(BIN_NAME)-windows.exe bin/$(BIN_NAME)-windows.exe; \
+		docker rm $$containerID )
+	@chmod +x bin/$(BIN_NAME)-linux
+	@chmod +x bin/$(BIN_NAME)-darwin
+	@chmod +x bin/$(BIN_NAME)-windows.exe
+
+e2e-cross: create_bin
+	docker build --target=e2e-cross -t $(IMAGE_NAME)-e2e-cross $(IMAGE_BUILD_ARGS) .
+	( containerID=$$(docker create $(IMAGE_NAME)-e2e-cross noop); \
+		docker cp $$containerID:$(PKG_PATH)/bin/$(BIN_NAME)-e2e-linux bin/$(BIN_NAME)-e2e-linux; \
+		docker cp $$containerID:$(PKG_PATH)/bin/$(BIN_NAME)-e2e-darwin bin/$(BIN_NAME)-e2e-darwin ; \
+		docker cp $$containerID:$(PKG_PATH)/bin/$(BIN_NAME)-e2e-windows.exe bin/$(BIN_NAME)-e2e-windows.exe; \
+		docker rm $$containerID )
+	@chmod +x bin/$(BIN_NAME)-e2e-linux
+	@chmod +x bin/$(BIN_NAME)-e2e-darwin
+	@chmod +x bin/$(BIN_NAME)-e2e-windows.exe
+
+tars:
+	tar czf bin/$(BIN_NAME)-linux.tar.gz -C bin $(BIN_NAME)-linux
+	tar czf bin/$(BIN_NAME)-e2e-linux.tar.gz -C bin $(BIN_NAME)-e2e-linux
+	tar czf bin/$(BIN_NAME)-darwin.tar.gz -C bin $(BIN_NAME)-darwin
+	tar czf bin/$(BIN_NAME)-e2e-darwin.tar.gz -C bin $(BIN_NAME)-e2e-darwin
+	tar czf bin/$(BIN_NAME)-windows.tar.gz -C bin $(BIN_NAME)-windows.exe
+	tar czf bin/$(BIN_NAME)-e2e-windows.tar.gz -C bin $(BIN_NAME)-e2e-windows.exe
+
+test: test-unit test-e2e
+
+test-unit: build_dev_image
+	docker run --rm $(IMAGE_NAME)-dev make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} test-unit
+
+test-e2e: build_dev_image
+	docker run -v /var/run:/var/run:ro --rm $(IMAGE_NAME)-dev make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} bin/$(BIN_NAME) test-e2e
+
+COV_LABEL := com.docker.app.cov-run=$(TAG)
+coverage: build_dev_image
+	mkdir -p _build
+	(containerID=$$(docker run -v /var/run:/var/run:ro  -tid $(IMAGE_NAME)-dev make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} coverage); \
+		docker logs -f $$containerID; \
+		docker cp $$containerID:$(PKG_PATH)/_build/cov/ ./_build/ci-cov; \
+		docker rm $$containerID)
+
+gradle-test: bin/$(BIN_NAME)
+	docker build -t $(IMAGE_NAME)-bin -f Dockerfile.gradle .
+	docker run --rm $(IMAGE_NAME)-bin bash -c "./gradlew --stacktrace build && cd example && gradle renderIt"
+
+lint:
+	@echo "Linting..."
+	docker build -t $(IMAGE_NAME)-lint:$(TAG) $(IMAGE_BUILD_ARGS) -f Dockerfile.lint .
+	docker run --rm $(IMAGE_NAME)-lint:$(TAG) make lint
+
+.PHONY: lint test-e2e test-unit test cross e2e-cross coverage gradle-test shell build_dev_image tars

--- a/e2e/binary_test.go
+++ b/e2e/binary_test.go
@@ -100,8 +100,8 @@ func findBinary() string {
 		os.Getenv("DOCKERAPP_BINARY"),
 		"./docker-app-" + runtime.GOOS + binExt(),
 		"./docker-app" + binExt(),
-		"../_build/docker-app-" + runtime.GOOS + binExt(),
-		"../_build/docker-app" + binExt(),
+		"../bin/docker-app-" + runtime.GOOS + binExt(),
+		"../bin/docker-app" + binExt(),
 	}
 	for _, binName := range binNames {
 		if _, err := os.Stat(binName); err == nil {

--- a/vars.mk
+++ b/vars.mk
@@ -1,0 +1,38 @@
+PKG_NAME := github.com/docker/app
+BIN_NAME := docker-app
+E2E_NAME := $(BIN_NAME)-e2e
+
+# Enable experimental features. "on" or "off"
+EXPERIMENTAL := off
+
+# Comma-separated list of renderers
+RENDERERS := "none"
+
+TAG ?= $(shell git describe --always --dirty 2>/dev/null)
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null)
+CWD = $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
+# Used by ci-gradle-test target
+DOCKERAPP_BINARY ?= $(CWD)/bin/$(BIN_NAME)-linux
+
+ifeq ($(BUILDTIME),)
+  BUILDTIME := ${shell date --utc --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/'}
+endif
+ifeq ($(BUILDTIME),)
+  BUILDTIME := ${shell gdate --utc --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/'}
+endif
+ifeq ($(BUILDTIME),)
+  $(error unable to set BUILDTIME, ensure that you have GNU date installed or set manually)
+endif
+
+LDFLAGS := "-s -w \
+	-X $(PKG_NAME)/internal.GitCommit=$(COMMIT) \
+	-X $(PKG_NAME)/internal.Version=$(TAG)      \
+	-X $(PKG_NAME)/internal.Experimental=$(EXPERIMENTAL) \
+	-X $(PKG_NAME)/internal.Renderers=$(RENDERERS) \
+	-X $(PKG_NAME)/internal.BuildTime=$(BUILDTIME)"
+
+EXEC_EXT :=
+ifeq ($(OS),Windows_NT)
+    EXEC_EXT := .exe
+endif


### PR DESCRIPTION
It's an overall rewrite of the `Makefile`, with a split for
`docker`-enabled targets. It should be simpler to maintain.

- `Makefile` is go dev oriented (no containerization) and
  `docker.Makefile` is it's containerized version (and use `make …`
  inside)
- `docker.Makefile` is used for the CI (but can be used locally too)
- Move binaries build to `bin/*` and rewrite those target
- Temporarly comment some stages as this is not optimal with the
  current state of support in Moby. Once we have a buildkit enabled
  build in docker, some stages should be better optimized
- Create a `Dockerfile` for the gradle test
- Update the `Jenkinsfile` to run less time the same builds

```bash
$ make bin/docker-app
CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/docker/app/internal.GitCommit=9f9ef39 -X github.com/docker/app/internal.Version=0.1.0-161-g9f9ef39 -X github.com/docker/app/internal.Experimental=off -X github.com/docker/app/internal.Renderers="none" -X github.com/docker/app/internal.BuildTime=2018-06-06T13:27:16.129889122+00:00" -o bin/docker-app ./cmd/docker-app
$ make bin/docker-app-windows.exe
GOOS=windows CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/docker/app/internal.GitCommit=9f9ef39 -X github.com/docker/app/internal.Version=0.1.0-161-g9f9ef39 -X github.com/docker/app/internal.Experimental=off -X github.com/docker/app/internal.Renderers="none" -X github.com/docker/app/internal.BuildTime=2018-06-06T13:27:26.240764705+00:00" -o bin/docker-app-windows.exe ./cmd/docker-app
$ make cross
GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/docker/app/internal.GitCommit=9f9ef39 -X github.com/docker/app/internal.Version=0.1.0-161-g9f9ef39 -X github.com/docker/app/internal.Experimental=off -X github.com/docker/app/internal.Renderers="none" -X github.com/docker/app/internal.BuildTime=2018-06-06T13:27:31.808210764+00:00" -o bin/docker-app-linux ./cmd/docker-app
GOOS=darwin CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/docker/app/internal.GitCommit=9f9ef39 -X github.com/docker/app/internal.Version=0.1.0-161-g9f9ef39 -X github.com/docker/app/internal.Experimental=off -X github.com/docker/app/internal.Renderers="none" -X github.com/docker/app/internal.BuildTime=2018-06-06T13:27:31.808210764+00:00" -o bin/docker-app-darwin ./cmd/docker-app
GOOS=windows CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/docker/app/internal.GitCommit=9f9ef39 -X github.com/docker/app/internal.Version=0.1.0-161-g9f9ef39 -X github.com/docker/app/internal.Experimental=off -X github.com/docker/app/internal.Renderers="none" -X github.com/docker/app/internal.BuildTime=2018-06-06T13:27:31.808210764+00:00" -o bin/docker-app-windows.exe ./cmd/docker-app
$ CGO_ENABLED=0 go test github.com/docker/app github.com/docker/app/cmd/docker-app github.com/docker/app/constants github.com/docker/app/image github.com/docker/app/internal github.com/docker/app/packager github.com/docker/app/renderer github.com/docker/app/templateconversion github.com/docker/app/templateloader github.com/docker/app/templatetypes github.com/docker/app/templatev1beta2 github.com/docker/app/types github.com/docker/app/utils
# […]
CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/docker/app/internal.GitCommit=9f9ef39 -X github.com/docker/app/internal.Version=0.1.0-161-g9f9ef39 -X github.com/docker/app/internal.Experimental=off -X github.com/docker/app/internal.Renderers="none" -X github.com/docker/app/internal.BuildTime=2018-06-06T13:28:10.754595638+00:00" -o bin/docker-app ./cmd/docker-app
Running e2e tests...
CGO_ENABLED=0 go test ./e2e/
ok      github.com/docker/app/e2e       6.002s
$ make lint
Linting..
# […]

$ make -f docker.Makefile bin/docker-app
docker build --target=docker-app -t docker-app-bin --build-arg COMMIT=9f9ef39 --build-arg TAG=0.1.0-161-g9f9ef39-dirty --build-arg BUILDTIME=2018-06-06T13:29:15.637503081+00:00 .
Sending build context to Docker daemon     44MB
# […]
( containerID=$(docker create docker-app noop); \
        docker cp $containerID:/go/src/github.com/docker/app/bin/docker-app bin/docker-app; \
        docker rm $containerID )
4bd8b705ca76b6cc9d9092e20ede6e19049048fad7545b614c096f234047101
$ make -f docker.Makefile test
# […]
docker run --rm docker-app-dev make test-unit
Running unit tests...
CGO_ENABLED=0 go test github.com/docker/app github.com/docker/app/cmd/docker-app github.com/docker/app/constants github.com/docker/app/image github.com/docker/app/internal github.com/docker/app/packager github.com/docker/app/renderer github.com/docker/app/templateconversion github.com/docker/app/templateloader github.com/docker/app/templatetypes github.com/docker/app/templatev1beta2 github.com/docker/app/types github.com/docker/app/utils
?       github.com/docker/app   [no test files]
?       github.com/docker/app/cmd/docker-app    [no test files]
# […]
docker run -v /var/run:/var/run:ro --rm docker-app-dev make bin/docker-app test-e2e
Running e2e tests...
CGO_ENABLED=0 go test ./e2e/
ok      github.com/docker/app/e2e       6.002s
$ make -f docker.Makefile lint
# […]
Successfully tagged docker-app-lint:0.1.0-161-g9f9ef39-dirty
docker run --rm docker-app-lint:0.1.0-161-g9f9ef39-dirty make lint
Linting...
```

It's `wip` because I still need to handle the `release` case in the `Jenkinsfile`, builds on top of https://github.com/docker/app/pull/190.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>