### PR TITLE
Mark test helpers as such…

### DIFF
--- a/e2e/binary_test.go
+++ b/e2e/binary_test.go
@@ -73,6 +73,7 @@ var (
 )
 
 func getBinary(t *testing.T) (string, bool) {
+	t.Helper()
 	if dockerApp != "" {
 		return dockerApp, hasExperimental
 	}
@@ -125,6 +126,7 @@ func runCommand(exe string, args ...string) {
 
 // Run command, assert it succeeds, return its output
 func assertCommand(t *testing.T, exe string, args ...string) []byte {
+	t.Helper()
 	cmd := exec.Command(exe, args...)
 	output, err := cmd.CombinedOutput()
 	assert.NilError(t, err, string(output))
@@ -132,11 +134,13 @@ func assertCommand(t *testing.T, exe string, args ...string) []byte {
 }
 
 func assertCommandOutput(t *testing.T, goldenFile string, cmd string, args ...string) {
+	t.Helper()
 	output := assertCommand(t, cmd, args...)
 	golden.Assert(t, string(output), goldenFile)
 }
 
 func assertCommandFailureOutput(t *testing.T, goldenFile string, exe string, args ...string) {
+	t.Helper()
 	cmd := exec.Command(exe, args...)
 	output, err := cmd.CombinedOutput()
 	assert.Assert(t, err != nil)

--- a/e2e/render_test.go
+++ b/e2e/render_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func gather(t *testing.T, dir string) ([]string, []string, map[string]string) {
+	t.Helper()
 	var (
 		overrides []string
 		settings  []string
@@ -54,6 +55,7 @@ func checkRenderers(appname string, enabled string) bool {
 }
 
 func checkResult(t *testing.T, result string, resultErr error, dir string) {
+	t.Helper()
 	if resultErr != nil {
 		ee := filepath.Join(dir, "expectedError.txt")
 		if _, err := os.Stat(ee); err != nil {
@@ -95,6 +97,7 @@ func TestRender(t *testing.T) {
 // readFile returns the content of the file at the designated path normalizing
 // line endings by removing any \r.
 func readFile(t *testing.T, path string) string {
+	t.Helper()
 	content, err := ioutil.ReadFile(path)
 	assert.NilError(t, err, "missing '"+path+"' file")
 	return strings.Replace(string(content), "\r", "", -1)


### PR DESCRIPTION
> Helper marks the calling function as a test helper function. When
> printing file and line information, that function will be skipped.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>