### PR TITLE
Fix some Makefile portability issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,6 @@
 *.dockerapp
 *.tar.gz
 _build/
-bin/docker-app-*
+bin/docker-app-windows.exe
+bin/docker-app-darwin
+bin/docker-app-e2e-*

--- a/Dockerfile.gradle
+++ b/Dockerfile.gradle
@@ -1,3 +1,3 @@
 FROM gradle:jdk8
-COPY bin/docker-app /usr/local/bin/docker-app
+COPY bin/docker-app-linux /usr/local/bin/docker-app
 COPY --chown=gradle:gradle integrations/gradle .

--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,12 @@ coverage-bin:
 
 coverage-test-unit:
 	@echo "Running unit tests (coverage)..."
-	mkdir -p _build/cov
+	@$(call mkdir,_build/cov)
 	$(GO_TEST) -cover -test.coverprofile=_build/cov/unit.out $(shell go list ./... | grep -vE '/e2e')
 
 coverage-test-e2e: coverage-bin
 	@echo "Running e2e tests (coverage)..."
-	mkdir -p _build/cov
+	@$(call mkdir,_build/cov)
 	DOCKERAPP_BINARY=../e2e/coverage-bin $(GO_TEST) -v ./e2e
 
 coverage: coverage-test-unit coverage-test-e2e
@@ -64,7 +64,9 @@ coverage: coverage-test-unit coverage-test-e2e
 	go tool cover -html _build/cov/all.out -o _build/cov/coverage.html
 
 clean:
-	rm -Rf ./bin ./_build docker-app-*.tar.gz
+	$(call rm,bin)
+	$(call rm,_build)
+	$(call rm,docker-app-*.tar.gz)
 
 .PHONY: cross e2e-cross test check lint test-unit test-e2e coverage coverage-bin coverage-test-unit coverage-test-e2e clean
 .DEFAULT: all

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -10,23 +10,16 @@ IMAGE_BUILD_ARGS := \
 PKG_PATH := /go/src/$(PKG_NAME)
 
 .DEFAULT: all
-all: bin/$(BIN_NAME) test
+all: cross test
 
 create_bin:
-	@mkdir -p bin
+	@$(call mkdir,bin)
 
 build_dev_image:
 	docker build --target=dev -t $(IMAGE_NAME)-dev $(IMAGE_BUILD_ARGS) .
 
 shell: build_dev_image
 	docker run -ti --rm $(IMAGE_NAME)-dev bash
-
-bin/%: create_bin
-	docker build --target=$* -t $(IMAGE_NAME)-bin $(IMAGE_BUILD_ARGS) .
-	( containerID=$$(docker create $(IMAGE_NAME)-bin noop); \
-		docker cp $$containerID:$(PKG_PATH)/bin/$*$(EXEC_EXT) $@; \
-		docker rm $$containerID )
-	@chmod +x $@
 
 cross: create_bin
 	docker build --target=$* -t $(IMAGE_NAME)-cross $(IMAGE_BUILD_ARGS) .
@@ -35,9 +28,9 @@ cross: create_bin
 	docker cp $(containerID):$(PKG_PATH)/bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-darwin
 	docker cp $(containerID):$(PKG_PATH)/bin/$(BIN_NAME)-windows.exe bin/$(BIN_NAME)-windows.exe
 	docker rm $(containerID)
-	@chmod +x bin/$(BIN_NAME)-linux
-	@chmod +x bin/$(BIN_NAME)-darwin
-	@chmod +x bin/$(BIN_NAME)-windows.exe
+	@$(call chmod,+x,bin/$(BIN_NAME)-linux)
+	@$(call chmod,+x,bin/$(BIN_NAME)-darwin)
+	@$(call chmod,+x,bin/$(BIN_NAME)-windows.exe)
 
 e2e-cross: create_bin
 	docker build --target=e2e-cross -t $(IMAGE_NAME)-e2e-cross $(IMAGE_BUILD_ARGS) .
@@ -46,9 +39,9 @@ e2e-cross: create_bin
 	docker cp $(containerID):$(PKG_PATH)/bin/$(BIN_NAME)-e2e-darwin bin/$(BIN_NAME)-e2e-darwin
 	docker cp $(containerID):$(PKG_PATH)/bin/$(BIN_NAME)-e2e-windows.exe bin/$(BIN_NAME)-e2e-windows.exe
 	docker rm $(containerID)
-	@chmod +x bin/$(BIN_NAME)-e2e-linux
-	@chmod +x bin/$(BIN_NAME)-e2e-darwin
-	@chmod +x bin/$(BIN_NAME)-e2e-windows.exe
+	@$(call chmod,+x,bin/$(BIN_NAME)-e2e-linux)
+	@$(call chmod,+x,bin/$(BIN_NAME)-e2e-darwin)
+	@$(call chmod,+x,bin/$(BIN_NAME)-e2e-windows.exe)
 
 tars:
 	tar czf bin/$(BIN_NAME)-linux.tar.gz -C bin $(BIN_NAME)-linux
@@ -68,13 +61,13 @@ test-e2e: build_dev_image
 
 COV_LABEL := com.docker.app.cov-run=$(TAG)
 coverage: build_dev_image
-	mkdir -p _build
-	(containerID=$$(docker run -v /var/run:/var/run:ro  -tid $(IMAGE_NAME)-dev make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} coverage); \
-		docker logs -f $$containerID; \
-		docker cp $$containerID:$(PKG_PATH)/_build/cov/ ./_build/ci-cov; \
-		docker rm $$containerID)
+	@$(call mkdir,_build)
+	$(eval containerID=$(shell docker run -v /var/run:/var/run:ro -tid $(IMAGE_NAME)-dev make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} coverage))
+	docker logs -f $(containerID)
+	docker cp $(containerID):$(PKG_PATH)/_build/cov/ ./_build/ci-cov
+	docker rm $(containerID)
 
-gradle-test: bin/$(BIN_NAME)
+gradle-test: cross
 	docker build -t $(IMAGE_NAME)-bin -f Dockerfile.gradle .
 	docker run --rm $(IMAGE_NAME)-bin bash -c "./gradlew --stacktrace build && cd example && gradle renderIt"
 


### PR DESCRIPTION
This should make it possible to compile on a vanilla windows command shell.
It would be great if someone on linux and darwin could test the PR before we merge it.

I believe the only remaining glitch would be that on windows
```
BUILDTIME := unknown
```