### PR TITLE
Simplify and enhance docker.Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 *.dockerapp
 *.tar.gz
 _build/
-bin/docker-app-windows.exe
-bin/docker-app-darwin
-bin/docker-app-e2e-*
+bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache \
   make\
   git \
   curl \
-  util-linux
+  util-linux \
+  coreutils
 RUN curl -Ls https://download.docker.com/linux/static/$DOCKERCLI_CHANNEL/x86_64/docker-$DOCKERCLI_VERSION.tgz | \
   tar -xz docker/docker && \
-  ls -l . && \
   mv docker/docker /usr/bin/docker
 
 WORKDIR /go/src/github.com/docker/app/
@@ -23,22 +23,10 @@ RUN curl -o /usr/bin/dep -L https://github.com/golang/dep/releases/download/${DE
     chmod +x /usr/bin/dep
 COPY . .
 
-FROM dev AS docker-app
-ARG COMMIT=unknown
-ARG TAG=unknown
-ARG BUILDTIME=unknown
-RUN make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} bin/docker-app
-
 # FIXME(vdemeester) change from docker-app to dev once buildkit is merged in moby/docker
-FROM docker-app AS cross
-ARG COMMIT=unknown
-ARG TAG=unknown
-ARG BUILDTIME=unknown
-RUN make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} cross
+FROM dev AS cross
+RUN make cross
 
 # FIXME(vdemeester) change from docker-app to dev once buildkit is merged in moby/docker
 FROM cross AS e2e-cross
-ARG COMMIT=unknown
-ARG TAG=unknown
-ARG BUILDTIME=unknown
-RUN make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} e2e-cross
+RUN make e2e-cross

--- a/Dockerfile.lint
+++ b/Dockerfile.lint
@@ -5,7 +5,8 @@ FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION}
 RUN apk add --no-cache \
     curl \
     git \
-    make
+    make \
+    coreutils
 
 ENV GOMETALITER_VERSION=2.0.5
 ENV NAKEDRECT_SHA=c0e305a4f690fed163d47628bcc06a6d5655bf92
@@ -23,7 +24,5 @@ RUN git clone https://github.com/alexkohler/nakedret.git /go/src/github.com/alex
 
 WORKDIR /go/src/github.com/docker/app
 ENV CGO_ENABLED=0
-ARG BUILDTIME=unknown
-ENV BUILDTIME=${BUILDTIME}
 
 COPY . .

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -12,11 +12,6 @@ CROSS_CTNR_NAME := $(BIN_NAME)-cross-$(TAG)
 E2E_CROSS_CTNR_NAME := $(BIN_NAME)-e2e-cross-$(TAG)
 COV_CTNR_NAME := $(BIN_NAME)-cov-$(TAG)
 
-IMAGE_BUILD_ARGS := \
-    --build-arg COMMIT=$(COMMIT) \
-    --build-arg TAG=$(TAG)       \
-    --build-arg BUILDTIME=$(BUILDTIME)
-
 PKG_PATH := /go/src/$(PKG_NAME)
 
 .DEFAULT: all
@@ -26,13 +21,13 @@ create_bin:
 	@$(call mkdir,bin)
 
 build_dev_image:
-	docker build --target=dev -t $(DEV_IMAGE_NAME) $(IMAGE_BUILD_ARGS) .
+	docker build --target=dev -t $(DEV_IMAGE_NAME) .
 
 shell: build_dev_image
 	docker run -ti --rm $(DEV_IMAGE_NAME) bash
 
 cross: create_bin
-	docker build --target=$* -t $(CROSS_IMAGE_NAME) $(IMAGE_BUILD_ARGS) .
+	docker build --target=$* -t $(CROSS_IMAGE_NAME)  .
 	docker create --name $(CROSS_CTNR_NAME) $(CROSS_IMAGE_NAME) noop
 	docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-linux
 	docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-darwin
@@ -43,7 +38,7 @@ cross: create_bin
 	@$(call chmod,+x,bin/$(BIN_NAME)-windows.exe)
 
 e2e-cross: create_bin
-	docker build --target=e2e-cross -t $(E2E_CROSS_IMAGE_NAME) $(IMAGE_BUILD_ARGS) .
+	docker build --target=e2e-cross -t $(E2E_CROSS_IMAGE_NAME)  .
 	docker create --name $(E2E_CROSS_CTNR_NAME) $(E2E_CROSS_IMAGE_NAME) noop
 	docker cp $(E2E_CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-e2e-linux bin/$(BIN_NAME)-e2e-linux
 	docker cp $(E2E_CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-e2e-darwin bin/$(BIN_NAME)-e2e-darwin
@@ -64,30 +59,30 @@ tars:
 test: test-unit test-e2e
 
 test-unit: build_dev_image
-	docker run --rm $(DEV_IMAGE_NAME) make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} test-unit
+	docker run --rm $(DEV_IMAGE_NAME) make test-unit
 
 test-e2e: build_dev_image
-	docker run -v /var/run:/var/run:ro --rm $(DEV_IMAGE_NAME) make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} bin/$(BIN_NAME) test-e2e
+	docker run -v /var/run:/var/run:ro --rm $(DEV_IMAGE_NAME) make bin/$(BIN_NAME) test-e2e
 
 COV_LABEL := com.docker.app.cov-run=$(TAG)
 coverage: build_dev_image
 	@$(call mkdir,_build)
-	docker run -v /var/run:/var/run:ro --name $(COV_CTNR_NAME) -tid $(DEV_IMAGE_NAME) make COMMIT=${COMMIT} TAG=${TAG} BUILDTIME=${BUILDTIME} coverage
+	docker run -v /var/run:/var/run:ro --name $(COV_CTNR_NAME) -tid $(DEV_IMAGE_NAME) make COMMIT=${COMMIT} TAG=${TAG} coverage
 	docker logs -f $(COV_CTNR_NAME)
 	docker cp $(COV_CTNR_NAME):$(PKG_PATH)/_build/cov/ ./_build/ci-cov
 	docker rm $(COV_CTNR_NAME)
 
 gradle-test:
-	docker build -t $(GRADLE_IMAGE_NAME) -f Dockerfile.gradle .
+	tar cf - Dockerfile.gradle bin/docker-app-linux integrations/gradle | docker build -t $(GRADLE_IMAGE_NAME) -f Dockerfile.gradle -
 	docker run --rm $(GRADLE_IMAGE_NAME) bash -c "./gradlew --stacktrace build && cd example && gradle renderIt"
 
 lint:
 	$(info Linting...)
-	docker build -t $(LINT_IMAGE_NAME) $(IMAGE_BUILD_ARGS) -f Dockerfile.lint .
+	docker build -t $(LINT_IMAGE_NAME) -f Dockerfile.lint .
 	docker run --rm $(LINT_IMAGE_NAME) make lint
 
 vendor: build_dev_image
 	$(info Vendoring...)
-	docker run --rm $(DEV_IMAGE_NAME) sh -c "make BUILDTIME=${BUILDTIME} vendor && hack/check-git-diff vendor"
+	docker run --rm $(DEV_IMAGE_NAME) sh -c "make vendor && hack/check-git-diff vendor"
 
 .PHONY: lint test-e2e test-unit test cross e2e-cross coverage gradle-test shell build_dev_image tars vendor


### PR DESCRIPTION
- Don't specify it as a `Dockerfile` build-arg (to not invalidate
  cache)
- Add coreutils to the `dev` image so that GNU date is available in
  there.
- Remove `docker-app` target as it's not used anymore.
- Ignore `bin/` completly, helps quite a lot for the build cache.
- Use *stdin* docker build for gradle to add `bin/docker-app-linux` to
  the context.

Binaries build time drop from ~4m to ~2m50s

Signed-off-by: Vincent Demeester <vincent@sbr.pm>