### PR TITLE
Do not show success message if the save operation failed 

### DIFF
--- a/cmd/docker-app/save.go
+++ b/cmd/docker-app/save.go
@@ -21,7 +21,7 @@ func saveCmd() *cobra.Command {
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			imageName, err := packager.Save(firstOrEmpty(args), opts.namespace, opts.tag)
-			if imageName != "" {
+			if imageName != "" && err == nil {
 				fmt.Printf("Saved application as image: %s\n", imageName)
 			}
 			return err


### PR DESCRIPTION
## Before

```bash
$ docker-app save examples/voting-app/voting-app.dockerapp
[...] an error [...]
Saved application as image: voting-app.dockerapp:0.1.0
Error: exit status 1
```

## Now
```bash
$ docker-app save examples/voting-app/voting-app.dockerapp
[...] an error [...]
Error: exit status 1
```