### PR TITLE
Load settings after `packager.Extract`

### DIFF
--- a/cmd/docker-app/deploy.go
+++ b/cmd/docker-app/deploy.go
@@ -54,6 +54,11 @@ func deployCmd() *cobra.Command {
 }
 
 func runDeploy(appname string, opts deployOptions) error {
+	appname, cleanup, err := packager.Extract(appname)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 	deployOrchestrator := opts.deployOrchestrator
 	if do, ok := os.LookupEnv("DOCKER_ORCHESTRATOR"); ok {
 		deployOrchestrator = do
@@ -65,11 +70,6 @@ func runDeploy(appname string, opts deployOptions) error {
 	if err != nil {
 		return err
 	}
-	appname, cleanup, err := packager.Extract(appname)
-	if err != nil {
-		return err
-	}
-	defer cleanup()
 	rendered, err := renderer.Render(appname, opts.deployComposeFiles, opts.deploySettingsFiles, d)
 	if err != nil {
 		return err

--- a/cmd/docker-app/helm.go
+++ b/cmd/docker-app/helm.go
@@ -22,15 +22,15 @@ func helmCmd() *cobra.Command {
 		Long:  `Generate a Helm chart for the application.`,
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			d, err := parseSettings(helmEnv)
-			if err != nil {
-				return err
-			}
 			appname, cleanup, err := packager.Extract(firstOrEmpty(args))
 			if err != nil {
 				return err
 			}
 			defer cleanup()
+			d, err := parseSettings(helmEnv)
+			if err != nil {
+				return err
+			}
 			return renderer.Helm(appname, helmComposeFiles, helmSettingsFile, d, helmRender)
 		},
 	}

--- a/cmd/docker-app/image-add.go
+++ b/cmd/docker-app/image-add.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/image"
@@ -26,20 +24,17 @@ images it uses, and saves them from the local docker daemon to the images/
 subdirectory.`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			d := make(map[string]string)
-			for _, v := range imageAddEnv {
-				kv := strings.SplitN(v, "=", 2)
-				if len(kv) != 2 {
-					return fmt.Errorf("Malformed env input: '%s'", v)
-				}
-				d[kv[0]] = kv[1]
-			}
 			oappname := args[0]
 			appname, cleanup, err := packager.Extract(oappname)
 			if err != nil {
 				return err
 			}
 			defer cleanup()
+
+			d, err := parseSettings(imageAddEnv)
+			if err != nil {
+				return err
+			}
 			if err := image.Add(appname, args[1:], imageAddComposeFiles, imageAddSettingsFile, d); err != nil {
 				return err
 			}

--- a/cmd/docker-app/render.go
+++ b/cmd/docker-app/render.go
@@ -26,15 +26,15 @@ func renderCmd() *cobra.Command {
 		Long:  `Render the Compose file for the application.`,
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			d, err := parseSettings(renderEnv)
-			if err != nil {
-				return err
-			}
 			appname, cleanup, err := packager.Extract(firstOrEmpty(args))
 			if err != nil {
 				return err
 			}
 			defer cleanup()
+			d, err := parseSettings(renderEnv)
+			if err != nil {
+				return err
+			}
 			rendered, err := renderer.Render(appname, renderComposeFiles, renderSettingsFile, d)
 			if err != nil {
 				return err


### PR DESCRIPTION
If the app doesn't exists, there is no need to *parse* settings in the
first place.

Also removes a small duplication.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
