### PR TITLE
Small cmd refactoring to use the same cli helper as docker/cli

### DIFF
--- a/cmd/docker-app/image-add.go
+++ b/cmd/docker-app/image-add.go
@@ -49,8 +49,12 @@ subdirectory.`,
 				}
 			}
 			if !s.IsDir() {
+				target, err := os.Create(oappname)
+				if err != nil {
+					return err
+				}
 				// source was a tarball, rebuild it
-				return packager.Pack(appname, oappname)
+				return packager.Pack(appname, target)
 			}
 			return nil
 		},

--- a/cmd/docker-app/inspect.go
+++ b/cmd/docker-app/inspect.go
@@ -4,11 +4,12 @@ import (
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/internal/renderer"
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
 // inspectCmd represents the inspect command
-func inspectCmd() *cobra.Command {
+func inspectCmd(dockerCli command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:   "inspect [<app-name>]",
 		Short: "Shows metadata and settings for a given application",
@@ -19,7 +20,7 @@ func inspectCmd() *cobra.Command {
 				return err
 			}
 			defer cleanup()
-			return renderer.Inspect(appname)
+			return renderer.Inspect(dockerCli.Out(), appname)
 		},
 	}
 }

--- a/cmd/docker-app/main.go
+++ b/cmd/docker-app/main.go
@@ -2,10 +2,19 @@ package main
 
 import (
 	"os"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/docker/pkg/term"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	cmd := newRootCmd()
+	// Set terminal emulation based on platform as required.
+	stdin, stdout, stderr := term.StdStreams()
+	logrus.SetOutput(stderr)
+
+	dockerCli := command.NewDockerCli(stdin, stdout, stderr, false)
+	cmd := newRootCmd(dockerCli)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/docker-app/merge.go
+++ b/cmd/docker-app/merge.go
@@ -1,21 +1,40 @@
 package main
 
 import (
+	"io"
+	"os"
+
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
 var mergeOutputFile string
 
-func mergeCmd() *cobra.Command {
+func mergeCmd(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "merge [<app-name>] [-o output_dir]",
 		Short: "Merge the application as a single file multi-document YAML",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return packager.Merge(firstOrEmpty(args), mergeOutputFile)
+			appname, cleanup, err := packager.Extract(firstOrEmpty(args))
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			var target io.Writer
+			if mergeOutputFile == "-" {
+				target = dockerCli.Out()
+			} else {
+				target, err = os.Create(mergeOutputFile)
+				if err != nil {
+					return err
+				}
+				defer target.(io.WriteCloser).Close()
+			}
+			return packager.Merge(appname, target)
 		},
 	}
 	if internal.Experimental == "on" {

--- a/cmd/docker-app/pack.go
+++ b/cmd/docker-app/pack.go
@@ -1,20 +1,43 @@
 package main
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var packOutputFile string
 
-func packCmd() *cobra.Command {
+func packCmd(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pack [<app-name>] [-o output_file]",
 		Short: "Pack the application as a single file",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return packager.Pack(firstOrEmpty(args), packOutputFile)
+			appname := firstOrEmpty(args)
+			appname, cleanup, err := packager.Extract(appname)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			var target io.Writer
+			if packOutputFile == "-" {
+				if terminal.IsTerminal(int(dockerCli.Out().FD())) {
+					return fmt.Errorf("Refusing to output to a terminal, use a shell redirect or the '-o' option")
+				}
+			} else {
+				target, err = os.Create(packOutputFile)
+				if err != nil {
+					return err
+				}
+			}
+			return packager.Pack(appname, target)
 		},
 	}
 	cmd.Flags().StringVarP(&packOutputFile, "output", "o", "-", "Output file (- for stdout)")

--- a/cmd/docker-app/render.go
+++ b/cmd/docker-app/render.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/internal/renderer"
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -19,7 +20,7 @@ var (
 	renderOutput       string
 )
 
-func renderCmd() *cobra.Command {
+func renderCmd(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "render <app-name> [-s key=value...] [-f settings-file...]",
 		Short: "Render the Compose file for the application",
@@ -44,7 +45,7 @@ func renderCmd() *cobra.Command {
 				return err
 			}
 			if renderOutput == "-" {
-				fmt.Print(string(res))
+				fmt.Fprint(dockerCli.Out(), string(res))
 			} else {
 				f, err := os.Create(renderOutput)
 				if err != nil {

--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -5,36 +5,14 @@ import (
 	"strings"
 
 	"github.com/docker/app/internal"
+	"github.com/docker/cli/cli/command"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-var (
-	commands = []*cobra.Command{
-		deployCmd(),
-		helmCmd(),
-		initCmd(),
-		inspectCmd(),
-		lsCmd(),
-		pushCmd(),
-		renderCmd(),
-		saveCmd(),
-		versionCmd(),
-	}
-	experimentalCommands = []*cobra.Command{
-		imageAddCmd(),
-		imageLoadCmd(),
-		loadCmd(),
-		mergeCmd(),
-		packCmd(),
-		pullCmd(),
-		splitCmd(),
-		unpackCmd(),
-	}
-)
-
 // rootCmd represents the base command when called without any subcommands
-func newRootCmd() *cobra.Command {
+// FIXME(vdemeester) use command.Cli interface
+func newRootCmd(dockerCli *command.DockerCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "docker-app",
 		Short:        "Docker App Packages",
@@ -48,15 +26,35 @@ func newRootCmd() *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().BoolVar(&internal.Debug, "debug", false, "Enable debug mode")
-	for _, c := range commands {
-		cmd.AddCommand(c)
-	}
-	if internal.Experimental == "on" {
-		for _, c := range experimentalCommands {
-			cmd.AddCommand(c)
-		}
-	}
+	addCommands(cmd, dockerCli)
 	return cmd
+}
+
+// addCommands adds all the commands from cli/command to the root command
+func addCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
+	cmd.AddCommand(
+		deployCmd(dockerCli),
+		helmCmd(),
+		initCmd(),
+		inspectCmd(dockerCli),
+		lsCmd(),
+		pushCmd(),
+		renderCmd(dockerCli),
+		saveCmd(dockerCli),
+		versionCmd(dockerCli),
+	)
+	if internal.Experimental == "on" {
+		cmd.AddCommand(
+			imageAddCmd(),
+			imageLoadCmd(),
+			loadCmd(),
+			mergeCmd(dockerCli),
+			packCmd(dockerCli),
+			pullCmd(),
+			splitCmd(),
+			unpackCmd(),
+		)
+	}
 }
 
 func firstOrEmpty(list []string) string {

--- a/cmd/docker-app/save.go
+++ b/cmd/docker-app/save.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +14,7 @@ type saveOptions struct {
 	tag       string
 }
 
-func saveCmd() *cobra.Command {
+func saveCmd(dockerCli command.Cli) *cobra.Command {
 	var opts saveOptions
 	cmd := &cobra.Command{
 		Use:   "save [<app-name>]",
@@ -22,7 +23,7 @@ func saveCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			imageName, err := packager.Save(firstOrEmpty(args), opts.namespace, opts.tag)
 			if imageName != "" && err == nil {
-				fmt.Printf("Saved application as image: %s\n", imageName)
+				fmt.Fprintf(dockerCli.Out(), "Saved application as image: %s\n", imageName)
 			}
 			return err
 		},

--- a/cmd/docker-app/split.go
+++ b/cmd/docker-app/split.go
@@ -15,11 +15,16 @@ func splitCmd() *cobra.Command {
 		Short: "Split a single-file application into multiple files",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return packager.Split(firstOrEmpty(args), splitOutputDir)
+			appname, cleanup, err := packager.Extract(firstOrEmpty(args))
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			return packager.Split(appname, splitOutputDir)
 		},
 	}
 	if internal.Experimental == "on" {
-		cmd.Flags().StringVarP(&splitOutputDir, "output", "o", "-", "Output directory")
+		cmd.Flags().StringVarP(&splitOutputDir, "output", "o", ".", "Output directory")
 	}
 	return cmd
 }

--- a/cmd/docker-app/version.go
+++ b/cmd/docker-app/version.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 
 	"github.com/docker/app/internal"
+	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
-func versionCmd() *cobra.Command {
+func versionCmd(dockerCli command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(internal.FullVersion())
+			fmt.Fprintln(dockerCli.Out(), internal.FullVersion())
 		},
 	}
 }

--- a/internal/packager/init.go
+++ b/internal/packager/init.go
@@ -3,6 +3,7 @@ package packager
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -70,7 +71,13 @@ func Init(name string, composeFile string, description string, maintainers []str
 		return err
 	}
 	defer os.RemoveAll(temp)
-	return Merge(temp, dirName)
+	var target io.Writer
+	target, err = os.Create(dirName)
+	if err != nil {
+		return err
+	}
+	defer target.(io.WriteCloser).Close()
+	return Merge(temp, target)
 }
 
 func initFromScratch(name string) error {

--- a/internal/packager/split.go
+++ b/internal/packager/split.go
@@ -9,12 +9,7 @@ import (
 
 // Split converts an app package to the split version
 func Split(appname string, outputDir string) error {
-	appname, cleanup, err := Extract(appname)
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-	err = os.Mkdir(outputDir, 0755)
+	err := os.Mkdir(outputDir, 0755)
 	if err != nil {
 		return err
 	}
@@ -33,22 +28,7 @@ func Split(appname string, outputDir string) error {
 }
 
 // Merge converts an app-package to the single-file merged version
-func Merge(appname string, outputFile string) error {
-	appname, cleanup, err := Extract(appname)
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-	var target io.Writer
-	if outputFile == "-" {
-		target = os.Stdout
-	} else {
-		target, err = os.Create(outputFile)
-		if err != nil {
-			return err
-		}
-		defer target.(io.WriteCloser).Close()
-	}
+func Merge(appname string, target io.Writer) error {
 	names := []string{"metadata.yml", "docker-compose.yml", "settings.yml"}
 	for i, n := range names {
 		input, err := ioutil.ReadFile(filepath.Join(appname, n))

--- a/internal/renderer/inspect.go
+++ b/internal/renderer/inspect.go
@@ -2,8 +2,8 @@ package renderer
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"sort"
 	"text/tabwriter"
@@ -14,7 +14,7 @@ import (
 )
 
 // Inspect dumps the metadata of an app
-func Inspect(appname string) error {
+func Inspect(out io.Writer, appname string) error {
 	metaFile := filepath.Join(appname, "metadata.yml")
 	metaContent, err := ioutil.ReadFile(metaFile)
 	if err != nil {
@@ -43,16 +43,16 @@ func Inspect(appname string) error {
 	sort.Slice(settingsKeys, func(i, j int) bool { return settingsKeys[i] < settingsKeys[j] })
 	// build maintainers string
 	maintainers := meta.Maintainers.String()
-	fmt.Printf("%s %s\n", meta.Name, meta.Version)
+	fmt.Fprintf(out, "%s %s\n", meta.Name, meta.Version)
 	if maintainers != "" {
-		fmt.Printf("Maintained by: %s\n", maintainers)
-		fmt.Println("")
+		fmt.Fprintf(out, "Maintained by: %s\n", maintainers)
+		fmt.Fprintln(out, "")
 	}
 	if meta.Description != "" {
-		fmt.Printf("%s\n", meta.Description)
-		fmt.Println("")
+		fmt.Fprintf(out, "%s\n", meta.Description)
+		fmt.Fprintln(out, "")
 	}
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
 	fmt.Fprintln(w, "Setting\tDefault")
 	fmt.Fprintln(w, "-------\t-------")
 	for _, k := range settingsKeys {


### PR DESCRIPTION
- This makes it easier to unit test sub-commands.
- This will help us share more code with docker/cli in the near
  future.

This also contains some `refactoring` on `packager` and `render`
packages, mainly for input/output handling.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
