### PR TITLE
Fix windows make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,12 @@ coverage: coverage-test-unit coverage-test-e2e ## run tests with coverage
 	go tool cover -html _build/cov/all.out -o _build/cov/coverage.html
 
 clean: ## clean build artifacts
-	$(call rm,bin)
-	$(call rm,_build)
+	$(call rmdir,bin)
+	$(call rmdir,_build)
 	$(call rm,docker-app-*.tar.gz)
 
 vendor: ## update vendoring
-	$(call rm,vendor)
+	$(call rmdir,vendor)
 	dep ensure -v
 
 help: ## this help

--- a/vars.mk
+++ b/vars.mk
@@ -10,10 +10,6 @@ RENDERERS := "none"
 
 TAG ?= $(shell git describe --always --dirty 2>/dev/null)
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null)
-CWD = $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
-
-# Used by ci-gradle-test target
-DOCKERAPP_BINARY ?= $(CWD)/bin/$(BIN_NAME)-linux
 
 WINDOWS := no
 ifneq ($(filter cmd.exe powershell.exe,$(subst /, ,$(SHELL))),)


### PR DESCRIPTION
**- What I did**

I fixed the makefiles for the windows platform.

**- How I did it**

I carefully studied make source code and behavior in order to abstract away platform differences.

When invoking commands `make` has two different behaviors depending whether the command is 'simple' or 'complex': for the former it will simply execute it as a process whereas for the latter it will shell it out.
Obviously on Windows executing e.g. `mkdir` as a process fails, whichever shell is actually being used when calling `make`, therefore all commands are now artificially made 'complex' by using pipes or redirections in order to force `make` to shell them out (running make with the `-d` flags shows how make runs each command).

In order to detect which shell is in use, make searches for `sh` in the path and sets the `SHELL` variable accordingly. If `sh` cannot be found the value of the variable will be the unresolved `sh.exe` on Windows and we use this to detect whether make will shell out commands using `sh -c` or fall back to cmd (via a temporary `.bat` file).
This makes it possible to enable the correct implementations for the basic commands (mkdir, rm, etc…).

See also https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html

**- How to verify it**

By calling `make` on Windows from different shells with both a `sh.exe` and no `sh.exe` in path.

**- Description for the changelog**

Fixed make invocation for windows.
