### PR TITLE
Update README with the latest docker-app version for WGET

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ More examples are available in the [examples](examples) directory.
 Pre-built binaries are available on [GitHub releases](https://github.com/docker/app/releases) for Windows, Linux and macOS.
 
 ```bash
-wget https://github.com/docker/app/releases/download/0.1.0/docker-app-linux.tar.gz
+wget https://github.com/docker/app/releases/download/v0.2.0/docker-app-linux.tar.gz
 tar xf docker-app-linux.tar.gz
 cp docker-app-linux /usr/local/bin/docker-app
 ```


### PR DESCRIPTION
The WGET link under README seems to be broken. The release page is not captured under GITHUB repository. Hence, updating it to correct link.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I tried following README guide and tried pulling the latest docker-app through the below command:

```
wget https://github.com/docker/app/releases/download/0.1.0/docker-app-linux.tar.gz
```

It failed to work.
```
Connecting to github.com (192.30.253.112:443)
wget: server returned error: HTTP/1.1 404 Not Found
```

There is no RELEASE folder created under the root of GITHUB repository and hence one need to manually type releases/ under the browser to jump to the release information.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

With this pull request, user can follow the right URL to pull the latest docker-app bits from GITHUB repository.


**- A picture of a cute animal (not mandatory but encouraged)**

