### PR TITLE
examples.wordpress: Fix compose-file.

### DIFF
--- a/examples/wordpress/wordpress.dockerapp/docker-compose.yml
+++ b/examples/wordpress/wordpress.dockerapp/docker-compose.yml
@@ -10,9 +10,9 @@ services:
       MYSQL_USER: ${mysql.user.name}
       MYSQL_PASSWORD: ${mysql.user.password}
     volumes:
-       - source: volume
-         target: /var/lib/mysql
-         type: volume
+      - source: db_data
+        target: /var/lib/mysql
+        type: volume
     networks:
        - overlay
     deploy:
@@ -40,7 +40,8 @@ services:
       - mysql
 
 volumes:
-  db_data: ${volumes.db_data.name}
+  db_data:
+    name: ${volumes.db_data.name}
 
 networks:
   overlay:


### PR DESCRIPTION
**- What I did**

Fix the `docker-compose.yml` (WordPress example) so the example can be rendered.

**- How I did it**

Use the correct format for volumes in `docker-compose.yml`.

**- How to verify it**

`docker-app render examples/wordpress/wordpress.dockerapp`

**- Description for the changelog**

WordPress example now renders correctly.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/35453452/41527760-6b03cab8-72e8-11e8-8b7e-fb0d4ad56c3b.png)
