### PR TITLE
split, merge: Handle in-place conversion, move out of experimental.

### DIFF
--- a/cmd/docker-app/merge.go
+++ b/cmd/docker-app/merge.go
@@ -1,29 +1,66 @@
 package main
 
 import (
+	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 var mergeOutputFile string
 
+// Check appname directory for extra files and return them
+func extraFiles(appname string) ([]string, error) {
+	files, err := ioutil.ReadDir(appname)
+	if err != nil {
+		return nil, err
+	}
+	var res []string
+	for _, f := range files {
+		hit := false
+		for _, afn := range internal.FileNames {
+			if afn == f.Name() {
+				hit = true
+				break
+			}
+		}
+		if !hit {
+			res = append(res, f.Name())
+		}
+	}
+	return res, nil
+}
+
 func mergeCmd(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "merge [<app-name>] [-o output_dir]",
+		Use:   "merge [<app-name>] [-o output_file]",
 		Short: "Merge the application as a single file multi-document YAML",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			appname, cleanup, err := packager.Extract(firstOrEmpty(args))
+			extractedApp, err := packager.ExtractWithOrigin(firstOrEmpty(args))
 			if err != nil {
 				return err
 			}
-			defer cleanup()
+			defer extractedApp.Cleanup()
+			inPlace := mergeOutputFile == ""
+			if inPlace {
+				extra, err := extraFiles(extractedApp.AppName)
+				if err != nil {
+					return errors.Wrap(err, "error scanning application directory")
+				}
+				if len(extra) != 0 {
+					return fmt.Errorf("refusing to overwrite %s: extra files would be deleted: %s", extractedApp.OriginalAppName, strings.Join(extra, ","))
+				}
+				mergeOutputFile = extractedApp.OriginalAppName + ".tmp"
+			}
 			var target io.Writer
 			if mergeOutputFile == "-" {
 				target = dockerCli.Out()
@@ -32,13 +69,25 @@ func mergeCmd(dockerCli command.Cli) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				defer target.(io.WriteCloser).Close()
 			}
-			return packager.Merge(appname, target)
+			if err := packager.Merge(extractedApp.AppName, target); err != nil {
+				return err
+			}
+			if mergeOutputFile != "-" {
+				// Need to close for the Rename to work on windows.
+				target.(io.WriteCloser).Close()
+			}
+			if inPlace {
+				if err := os.RemoveAll(extractedApp.OriginalAppName); err != nil {
+					return errors.Wrap(err, "failed to erase previous application")
+				}
+				if err := os.Rename(mergeOutputFile, extractedApp.OriginalAppName); err != nil {
+					return errors.Wrap(err, "failed to rename new application")
+				}
+			}
+			return nil
 		},
 	}
-	if internal.Experimental == "on" {
-		cmd.Flags().StringVarP(&mergeOutputFile, "output", "o", "-", "Output file (default: stdout)")
-	}
+	cmd.Flags().StringVarP(&mergeOutputFile, "output", "o", "", "Output file (default: in-place)")
 	return cmd
 }

--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -38,9 +38,11 @@ func addCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 		initCmd(),
 		inspectCmd(dockerCli),
 		lsCmd(),
+		mergeCmd(dockerCli),
 		pushCmd(),
 		renderCmd(dockerCli),
 		saveCmd(dockerCli),
+		splitCmd(),
 		versionCmd(dockerCli),
 	)
 	if internal.Experimental == "on" {
@@ -48,10 +50,8 @@ func addCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 			imageAddCmd(),
 			imageLoadCmd(),
 			loadCmd(),
-			mergeCmd(dockerCli),
 			packCmd(dockerCli),
 			pullCmd(),
-			splitCmd(),
 			unpackCmd(),
 		)
 	}

--- a/e2e/binary_test.go
+++ b/e2e/binary_test.go
@@ -287,19 +287,19 @@ func TestHelmBinary(t *testing.T) {
 }
 
 func TestSplitMergeBinary(t *testing.T) {
-	dockerApp, hasExperimental := getBinary(t)
-	if !hasExperimental {
-		t.Skip("experimental mode needed for this test")
-	}
+	dockerApp, _ := getBinary(t)
 	app := "render/envvariables"
 	assertCommand(t, dockerApp, "merge", app, "-o", "remerged.dockerapp")
 	defer os.Remove("remerged.dockerapp")
 	// test that inspect works on single-file
 	assertCommandOutput(t, "envvariables-inspect.golden", dockerApp, "inspect", "remerged")
 	// split it
-	assertCommand(t, dockerApp, "split", "remerged", "-o", "splitted.dockerapp")
-	defer os.RemoveAll("splitted.dockerapp")
-	assertCommandOutput(t, "envvariables-inspect.golden", dockerApp, "inspect", "splitted")
+	assertCommand(t, dockerApp, "split", "remerged", "-o", "split.dockerapp")
+	defer os.RemoveAll("split.dockerapp")
+	assertCommandOutput(t, "envvariables-inspect.golden", dockerApp, "inspect", "split")
+	// test inplace
+	assertCommand(t, dockerApp, "merge", "split")
+	assertCommand(t, dockerApp, "split", "split")
 }
 
 func TestImageBinary(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>

**- What I did**

Split and merge commands now support an in-place mode (the default) that overwrites the source.
Also moved them out of experimental.

**- How I did it**

Changed default output for the two commands to the empty string. Expanded Extract() to return the discovered original app name. Use that to provide in-place implementation of split and merge.

**- How to verify it**

Run e2e test suite.

**- Description for the changelog**

- New `split` and `merge` commands to convert between the two source formats.


**- A picture of a cute animal (not mandatory but encouraged)**

![nerim](https://user-images.githubusercontent.com/3638847/41662387-4dd8f99e-74a1-11e8-8773-b8188146ac85.jpg)

