### PR TITLE
Lookup default permutation of app folder before literal name

### DIFF
--- a/internal/packager/extract.go
+++ b/internal/packager/extract.go
@@ -104,12 +104,13 @@ func Extract(appname string) (string, func(), error) {
 		}
 	}
 	originalAppname := appname
-	// try verbatim first
+
+	// try appending our extension
+	appname = internal.DirNameFromAppName(appname)
 	s, err := os.Stat(appname)
 	if err != nil {
-		// try appending our extension
-		appname = internal.DirNameFromAppName(appname)
-		s, err = os.Stat(appname)
+		// try verbatim
+		s, err = os.Stat(originalAppname)
 	}
 	if err != nil {
 		// look for a docker image


### PR DESCRIPTION
**- What I did**

Changed the lookup algorithm to prioritize `.docker-app` suffixed folders before literal name folder.

**- How I did it**

Updated the `Extract` method in the `packager` package.

**- How to verify it**

1. Create folder with `foo` subfolder and `docker-compose.yml`
2. Run `docker-app init foo` in folder.
3. Subsequent `docker-app` commands no longer fail.

**- Description for the changelog**

- Lookup algorithm now prioritizes the default permutation of the app folder over the literal name


Re-push / fix of #182 