### PR TITLE
Check that Compose file version is supported during init

### DIFF
--- a/internal/packager/init_test.go
+++ b/internal/packager/init_test.go
@@ -23,7 +23,9 @@ func randomName(prefix string) string {
 }
 
 func TestInitFromComposeFile(t *testing.T) {
-	composeData := `services:
+	composeData := `
+version: '3.0'
+services:
   nginx:
     image: nginx:${NGINX_VERSION}
     command: nginx $NGINX_ARGS
@@ -63,6 +65,49 @@ func TestInitFromInvalidComposeFile(t *testing.T) {
 
 	err = initFromComposeFile(testAppName, "doesnotexist")
 	assert.ErrorContains(t, err, "failed to read")
+}
+
+func TestInitFromV2ComposeFile(t *testing.T) {
+	composeData := `
+version: '2.4'
+services:
+  nginx:
+    image: nginx:${NGINX_VERSION}
+    command: nginx $NGINX_ARGS
+`
+	inputDir := randomName("app_input_")
+	os.Mkdir(inputDir, 0755)
+	ioutil.WriteFile(filepath.Join(inputDir, "docker-compose.yml"), []byte(composeData), 0644)
+	defer os.RemoveAll(inputDir)
+
+	testAppName := randomName("app_")
+	dirName := internal.DirNameFromAppName(testAppName)
+	err := os.Mkdir(dirName, 0755)
+	assert.NilError(t, err)
+	defer os.RemoveAll(dirName)
+
+	err = initFromComposeFile(testAppName, filepath.Join(inputDir, "docker-compose.yml"))
+	assert.ErrorContains(t, err, "unsupported Compose file version")
+}
+
+func TestInitFromV1ComposeFile(t *testing.T) {
+	composeData := `
+nginx:
+  image: nginx
+`
+	inputDir := randomName("app_input_")
+	os.Mkdir(inputDir, 0755)
+	ioutil.WriteFile(filepath.Join(inputDir, "docker-compose.yml"), []byte(composeData), 0644)
+	defer os.RemoveAll(inputDir)
+
+	testAppName := randomName("app_")
+	dirName := internal.DirNameFromAppName(testAppName)
+	err := os.Mkdir(dirName, 0755)
+	assert.NilError(t, err)
+	defer os.RemoveAll(dirName)
+
+	err = initFromComposeFile(testAppName, filepath.Join(inputDir, "docker-compose.yml"))
+	assert.ErrorContains(t, err, "unsupported Compose file version")
 }
 
 func TestWriteMetadataFile(t *testing.T) {


### PR DESCRIPTION
**- What I did**

Code now checks that the Compose file version is supported during init

**- How I did it**

Attempt to read the `version` field of the unmarshaled `docker-compose.yml` file and check its value against the set minimum (3.0) using the semver library

**- How to verify it**

Run the unit tests

**- Description for the changelog**

Running docker-app init with an unsupported version of the Compose file now errors out instead of creating an invalid package.

Re-push of #184 