### PR TITLE
Allow creating helm chart for v1beta1 spec of Compose-Kubernetes

### DIFF
--- a/cmd/docker-app/helm.go
+++ b/cmd/docker-app/helm.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/internal/renderer"
@@ -9,11 +11,11 @@ import (
 )
 
 var (
-	beta1            bool
 	helmComposeFiles []string
 	helmSettingsFile []string
 	helmEnv          []string
 	helmRender       bool
+	stackVersion     string
 )
 
 func helmCmd() *cobra.Command {
@@ -32,7 +34,10 @@ func helmCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return renderer.Helm(appname, helmComposeFiles, helmSettingsFile, d, helmRender, beta1)
+			if stackVersion != "v1beta2" && stackVersion != "v1beta1" {
+				return fmt.Errorf("invalid stack version %q (accepted values: v1beta1, v1beta2)", stackVersion)
+			}
+			return renderer.Helm(appname, helmComposeFiles, helmSettingsFile, d, helmRender, stackVersion)
 		},
 	}
 	if internal.Experimental == "on" {
@@ -44,6 +49,6 @@ be rendered instead of exported as a template.`
 	}
 	cmd.Flags().StringArrayVarP(&helmSettingsFile, "settings-files", "f", []string{}, "Override settings files")
 	cmd.Flags().StringArrayVarP(&helmEnv, "set", "s", []string{}, "Override settings values")
-	cmd.Flags().BoolVarP(&beta1, "beta1", "b", false, "Use an older specification to produce a chart compatible with Docker UCP 2.0")
+	cmd.Flags().StringVarP(&stackVersion, "stack-version", "", "v1beta2", "Version of the stack specification for the produced helm chart")
 	return cmd
 }

--- a/cmd/docker-app/helm.go
+++ b/cmd/docker-app/helm.go
@@ -34,8 +34,8 @@ func helmCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if stackVersion != "v1beta2" && stackVersion != "v1beta1" {
-				return fmt.Errorf("invalid stack version %q (accepted values: v1beta1, v1beta2)", stackVersion)
+			if stackVersion != renderer.V1Beta1 && stackVersion != renderer.V1Beta2 {
+				return fmt.Errorf("invalid stack version %q (accepted values: %s, %s)", stackVersion, renderer.V1Beta1, renderer.V1Beta2)
 			}
 			return renderer.Helm(appname, helmComposeFiles, helmSettingsFile, d, helmRender, stackVersion)
 		},
@@ -49,6 +49,6 @@ be rendered instead of exported as a template.`
 	}
 	cmd.Flags().StringArrayVarP(&helmSettingsFile, "settings-files", "f", []string{}, "Override settings files")
 	cmd.Flags().StringArrayVarP(&helmEnv, "set", "s", []string{}, "Override settings values")
-	cmd.Flags().StringVarP(&stackVersion, "stack-version", "", "v1beta2", "Version of the stack specification for the produced helm chart")
+	cmd.Flags().StringVarP(&stackVersion, "stack-version", "", renderer.V1Beta2, "Version of the stack specification for the produced helm chart")
 	return cmd
 }

--- a/cmd/docker-app/helm.go
+++ b/cmd/docker-app/helm.go
@@ -9,6 +9,7 @@ import (
 )
 
 var (
+	beta1            bool
 	helmComposeFiles []string
 	helmSettingsFile []string
 	helmEnv          []string
@@ -31,7 +32,7 @@ func helmCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return renderer.Helm(appname, helmComposeFiles, helmSettingsFile, d, helmRender)
+			return renderer.Helm(appname, helmComposeFiles, helmSettingsFile, d, helmRender, beta1)
 		},
 	}
 	if internal.Experimental == "on" {
@@ -43,5 +44,6 @@ be rendered instead of exported as a template.`
 	}
 	cmd.Flags().StringArrayVarP(&helmSettingsFile, "settings-files", "f", []string{}, "Override settings files")
 	cmd.Flags().StringArrayVarP(&helmEnv, "set", "s", []string{}, "Override settings values")
+	cmd.Flags().BoolVarP(&beta1, "beta1", "b", false, "Use an older specification to produce a chart compatible with Docker UCP 2.0")
 	return cmd
 }

--- a/e2e/binary_test.go
+++ b/e2e/binary_test.go
@@ -297,6 +297,11 @@ func TestHelmV1Beta1Binary(t *testing.T) {
 	golden.Assert(t, string(stack), "helm-expected.chart/templates/stack-v1beta1.yaml")
 }
 
+func TestHelmInvalidStackVersionBinary(t *testing.T) {
+	dockerApp, _ := getBinary(t)
+	assertCommandFailureOutput(t, "invalid-stack-version.golden", dockerApp, "helm", "helm", "--stack-version", "foobar")
+}
+
 func TestSplitMergeBinary(t *testing.T) {
 	dockerApp, hasExperimental := getBinary(t)
 	if !hasExperimental {

--- a/e2e/binary_test.go
+++ b/e2e/binary_test.go
@@ -286,6 +286,17 @@ func TestHelmBinary(t *testing.T) {
 	golden.Assert(t, string(stack), "helm-expected.chart/templates/stack.yaml")
 }
 
+func TestHelmV1Beta1Binary(t *testing.T) {
+	dockerApp, _ := getBinary(t)
+	assertCommand(t, dockerApp, "helm", "helm", "-s", "myapp.nginx_version=2", "--stack-version", "v1beta1")
+	chart, _ := ioutil.ReadFile("helm.chart/Chart.yaml")
+	values, _ := ioutil.ReadFile("helm.chart/values.yaml")
+	stack, _ := ioutil.ReadFile("helm.chart/templates/stack.yaml")
+	golden.Assert(t, string(chart), "helm-expected.chart/Chart.yaml")
+	golden.Assert(t, string(values), "helm-expected.chart/values.yaml")
+	golden.Assert(t, string(stack), "helm-expected.chart/templates/stack-v1beta1.yaml")
+}
+
 func TestSplitMergeBinary(t *testing.T) {
 	dockerApp, hasExperimental := getBinary(t)
 	if !hasExperimental {

--- a/e2e/testdata/helm-expected.chart/templates/stack-v1beta1.yaml
+++ b/e2e/testdata/helm-expected.chart/templates/stack-v1beta1.yaml
@@ -1,0 +1,75 @@
+objectmeta:
+  annotations: {}
+  clustername: ""
+  creationtimestamp: "0001-01-01T00:00:00Z"
+  deletiongraceperiodseconds: null
+  deletiontimestamp: null
+  finalizers: []
+  generatename: ""
+  generation: 0
+  initializers: null
+  labels: {}
+  name: helm
+  namespace: default
+  ownerreferences: []
+  resourceversion: ""
+  selflink: ""
+  uid: ""
+spec:
+  composefile: |
+    version: "3.4"
+    services:
+      app-watcher:
+        image: {{.Values.watcher.image}}
+      debug:
+        deploy:
+          resources:
+            limits:
+              memory:
+                valuetemplate: {{.Values.memory}}
+        healthcheck:
+          test:
+          - /ping
+          - debug
+          timeout:
+            valuetemplate: {{.Values.timeout}}
+          interval:
+            value: 2m0s
+        image: busybox:latest
+        ports:
+        - mode: ingress
+          target:
+            valuetemplate: {{.Values.aport}}
+          protocol: tcp
+        - mode: ingress
+          target:
+            valuetemplate: {{.Values.sport}}
+          published:
+            valuetemplate: {{.Values.dport}}
+          protocol: tcp
+        template_privileged:
+          valuetemplate: {{.Values.privileged}}
+        read_only:
+          valuetemplate: {{.Values.read_only}}
+        stdin_open:
+          valuetemplate: {{.Values.stdin_open}}
+        tty:
+          valuetemplate: {{.Values.tty}}
+      front:
+        deploy:
+          replicas:
+            valuetemplate: {{.Values.myapp.nginx_replicas}}
+        image: nginx:{{.Values.myapp.nginx_version}}
+      monitor:
+        command:
+        - monitor
+        - --source
+        - {{.Values.app.name}}-{{.Values.app.version}}
+        - $dollar
+        image: busybox:latest
+status:
+  message: ""
+  phase: ""
+typemeta:
+  apiversion: v1beta1
+  kind: stacks.compose.docker.com

--- a/e2e/testdata/invalid-stack-version.golden
+++ b/e2e/testdata/invalid-stack-version.golden
@@ -1,0 +1,1 @@
+Error: invalid stack version "foobar" (accepted values: v1beta1, v1beta2)

--- a/internal/renderer/helm.go
+++ b/internal/renderer/helm.go
@@ -39,6 +39,13 @@ post-process the serialized yaml to replace all 'template_'-prefixed keys
 with the appropriate content (value or template)
 */
 
+const (
+	// V1Beta1 is the string identifier for the v1beta1 version of the stack spec
+	V1Beta1 = "v1beta1"
+	// V1Beta2 is the string identifier for the v1beta2 version of the stack spec
+	V1Beta2 = "v1beta2"
+)
+
 type helmMaintainer struct {
 	Name string
 }
@@ -219,7 +226,7 @@ func helmRender(appname string, targetDir string, composeFiles []string, setting
 		stack = v1beta2.Stack{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "stacks.compose.docker.com",
-				APIVersion: "v1beta2",
+				APIVersion: V1Beta2,
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: internal.AppNameFromDir(appname),
@@ -234,7 +241,7 @@ func helmRender(appname string, targetDir string, composeFiles []string, setting
 		stack = v1beta1.Stack{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "stacks.compose.docker.com",
-				APIVersion: "v1beta1",
+				APIVersion: V1Beta1,
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: internal.AppNameFromDir(appname),
@@ -268,7 +275,7 @@ func makeStack(appname string, targetDir string, data []byte, beta1 bool) error 
 		stack = templatev1beta2.Stack{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "stacks.compose.docker.com",
-				APIVersion: "v1beta2",
+				APIVersion: V1Beta2,
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      internal.AppNameFromDir(appname),
@@ -284,7 +291,7 @@ func makeStack(appname string, targetDir string, data []byte, beta1 bool) error 
 		stack = v1beta1.Stack{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "stacks.compose.docker.com",
-				APIVersion: "v1beta1",
+				APIVersion: V1Beta1,
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      internal.AppNameFromDir(appname),
@@ -318,7 +325,7 @@ func makeStack(appname string, targetDir string, data []byte, beta1 bool) error 
 // Helm renders an app as an Helm Chart
 func Helm(appname string, composeFiles []string, settingsFile []string, env map[string]string, render bool, stackVersion string) error {
 	targetDir := internal.AppNameFromDir(appname) + ".chart"
-	beta1 := stackVersion == "v1beta1"
+	beta1 := stackVersion == V1Beta1
 	if err := os.Mkdir(targetDir, 0755); err != nil && !os.IsExist(err) {
 		return errors.Wrap(err, "failed to create Chart directory")
 	}

--- a/internal/renderer/helm.go
+++ b/internal/renderer/helm.go
@@ -316,8 +316,9 @@ func makeStack(appname string, targetDir string, data []byte, beta1 bool) error 
 }
 
 // Helm renders an app as an Helm Chart
-func Helm(appname string, composeFiles []string, settingsFile []string, env map[string]string, render, beta1 bool) error {
+func Helm(appname string, composeFiles []string, settingsFile []string, env map[string]string, render bool, stackVersion string) error {
 	targetDir := internal.AppNameFromDir(appname) + ".chart"
+	beta1 := stackVersion == "v1beta1"
 	if err := os.Mkdir(targetDir, 0755); err != nil && !os.IsExist(err) {
 		return errors.Wrap(err, "failed to create Chart directory")
 	}


### PR DESCRIPTION
Fixes #243 

**- What I did**

Allow users to produce a v1beta1-compatible Helm chart using `docker-app helm`

**- How I did it**

Added a ~~`--beta1` (shorthand `-b`)~~ `--stack-version` flag to the `helm` subcommand.

**- How to verify it**

```
# cd into directory with docker-compose.yml
docker-app init foo
docker-app helm --stack-version v1beta1
cat foo.chart/templates/stack.yaml
## output should be v1beta1
```

**- Description for the changelog**

It is now possible to generate v1beta1-compatible helm charts using `docker-app helm`
