### PR TITLE
Fix toGoTemplate to support complex expressions as well

### DIFF
--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -258,6 +258,8 @@ const (
 	V1Beta1 = "v1beta1"
 	// V1Beta2 is the string identifier for the v1beta2 version of the stack spec
 	V1Beta2 = "v1beta2"
+	// based on https://github.com/docker/compose/blob/1.21.2/compose/config/interpolation.py#L93-L104
+	envVarRegex = `(^|[^$])\$(?:(?P<named>[_a-zA-Z][_a-zA-Z0-9.]*)|{(?P<braced>[_a-zA-Z][_a-zA-Z0-9.]*)(?:(?P<sep>:?[-?])[^}]*)?})`
 )
 
 type helmMaintainer struct {
@@ -321,8 +323,8 @@ func filterVariables(s map[string]interface{}, variables []string, prefix string
 
 // toGoTemplate converts $foo and ${foo} into {{.foo}}
 func toGoTemplate(template string) (string, error) {
-	re := regexp.MustCompile(`(^|[^$])\${?([a-zA-Z0-9_.]+)}?`)
-	template = re.ReplaceAllString(template, "$1{{.Values.$2}}")
+	re := regexp.MustCompile(envVarRegex)
+	template = re.ReplaceAllString(template, "$1{{.Values.$named$braced}}")
 	template = strings.Replace(template, "$$", "$", -1)
 	return template, nil
 }

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -1,0 +1,14 @@
+package helm
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestToGoTemplate(t *testing.T) {
+	vars := `$VAR ${HELLO} ${WORLD:-world} ${FOOBAR?errbaz} $$`
+	result, err := toGoTemplate(vars)
+	assert.NilError(t, err)
+	assert.Equal(t, result, "{{.Values.VAR}} {{.Values.HELLO}} {{.Values.WORLD}} {{.Values.FOOBAR}} $")
+}


### PR DESCRIPTION
**- What I did**

Fixed the helm chart generation to produce properly formatted charts when source Compose has complex variable expressions (e.g. `${VAR:-default}` or `${VAR?err}`)

**- How I did it**

Updated the regular expression used by `toGoTemplate` to use a more accurate version.

**- How to verify it**

See unit test in `helm_test.go`

**- Description for the changelog**

- Improved template substitution for generated helm charts

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1086876/42007779-b8304ffa-7a36-11e8-89bd-36762bcac2d8.png)
