### PR TITLE
examples: Remove references to pack and unpack (experimental).

### DIFF
--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -186,34 +186,19 @@ REPOSITORY          TAG                 IMAGE ID            CREATED             
 wordpress.dockerapp   latest              61f8cafb7762        4 minutes ago       1.2kB
 ```
 
-The package can later be retrieved using `docker-app load`:
-
+The image can be pushed to the hub:
 ```
-$ rm -rf wordpress.dockerapp
-$ docker-app load wordpress.dockerapp
-$ tar -tf wordpress.dockerapp  # TODO: should unpack automatically?
-metadata.yml
-docker-compose.yml
-settings.yml
-$ mv wordpress.dockerapp wordpress  # TODO: fix UX
-$ docker-app unpack wordpress
-$ tree wordpress.dockerapp
-./wordpress.dockerapp/
-├── metadata.yml
-├── docker-compose.yml
-└── settings.yml
-
-0 directories, 3 files
+$ docker push --namespace <username> wordpress
+The push refers to repository [docker.io/<username>/wordpress.dockerapp]
+61f8cafb7762: Pushed
+latest: digest: sha256:91b9b526ac1e645e9c89663ff1453c2d7f68535e2dbbca6d4466d365e15ee155 size: 525
 ```
 
-### Archive app package
-
-`docker-app pack wordpress` creates a tar archive containing the relevant configuration files:
+One can now deploy the application using `docker-app deploy`:
 
 ```
-$ docker-app pack wordpress --output myapp.tar
-$ tar -tf myapp.tar
-metadata.yml
-docker-compose.yml
-settings.yml
+$ docker-app deploy <username>/wordpress
+Creating network wordpress_overlay
+Creating service wordpress_mysql
+Creating service wordpress_wordpress
 ```


### PR DESCRIPTION
**- What I did**

Fix issue #253 by removing references to `pack` and `unpack` from the wordpress' readme.

**- How I did it**

N/A.

**- How to verify it**

Consult examples/wordpress/README.md.

**- Description for the changelog**

Remove references to `pack` and `unpack` from example while they are experimental features.

**- A picture of a cute animal (not mandatory but encouraged)**

![36303046_10157558905308957_7287124041637298176_n](https://user-images.githubusercontent.com/3359376/42037300-5b74293c-7ae8-11e8-9a6b-f59ed79047a1.png)

(credits: u/JonathanWithH on Reddit).

