### PR TITLE
Update outdated examples (single-file, helm, etc.) 

### DIFF
--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -15,13 +15,19 @@ $ ls -l
 -rw-r--r-- 1 hello-world.dockerapp
 $ cat hello-world.dockerapp
 # This section contains your application metadata.
+# Version of the application
 version: 0.1.0
+# Name of the application
 name: hello-world
-description: ""
-namespace: ""
+# A short description of the application
+description:
+# Namespace to use when pushing to a registry. This is typically your Hub username.
+#namespace: myHubUsername
+# List of application maitainers with name and email for each
 maintainers:
-- name: dimrok
-  email: ""
+  - name: user
+    email:
+# Specify false here if your application doesn't support Swarm or Kubernetes
 targets:
   swarm: true
   kubernetes: true
@@ -39,7 +45,7 @@ Open `hello-world.dockerapp` with your favorite text editor.
 
 ### Edit metadata
 
-Edit the `description` and `maintainers` fields in the metadata section.
+Edit the `description`, `namespace` and `maintainers` fields in the metadata section.
 
 ### Add variables to the compose file
 
@@ -75,7 +81,7 @@ In the settings section, add every variables with the default value you want, e.
 ---
 # This section contains the default values for your application settings.
 port: 8080
-text: hello world!
+text: Hello, World!
 ```
 
 ### Render
@@ -86,11 +92,11 @@ Create a `render` directory and redirect the output of `docker-app render ...` t
 
 ```bash
 $ mkdir -p render
-$ docker-app render -s text="hello user" > render/docker-compose.yml
+$ docker-app render -s text="Hello user!" > render/docker-compose.yml
 ```
 
 ### Deploy
 
-You directly deploy your application by running `docker-app deploy --set text="hello user!"` or you can use the rendered version and run `docker stack deploy render/docker-compose.yml`.
+You directly deploy your application by running `docker-app deploy --set text="Hello user!"` or you can use the rendered version and run `docker stack deploy render/docker-compose.yml`.
 
 `http://<ip_of_your_node>:8080` will display your message, e.g. http://127.0.0.1:8080 if you deployed locally.

--- a/examples/hello-world/hello-world.dockerapp
+++ b/examples/hello-world/hello-world.dockerapp
@@ -1,21 +1,23 @@
-#
-# Metadata.
-#
+# This section contains your application metadata.
+# Version of the application
 version: 0.1.0
+# Name of the application
 name: hello-world
-description: "Hello world!"
-namespace: "myhubuser"
+# A short description of the application
+description: "Hello, World!"
+# Namespace to use when pushing to a registry. This is typically your Hub username.
+namespace: myHubUsername
+# List of application maitainers with name and email for each
 maintainers:
-- name: user
-  email: "user@email.com"
+  - name: user
+    email: "user@email.com"
+# Specify false here if your application doesn't support Swarm or Kubernetes
 targets:
   swarm: true
   kubernetes: true
 
 --
-#
-# Services.
-#
+# This section contains the Compose file that describes your application services.
 version: "3.6"
 services:
   hello:
@@ -25,8 +27,6 @@ services:
       - ${port}:5678
 
 --
-#
-# Settings.
-#
+# This section contains the default values for your application settings.
 port: 8080
-text: hello world!
+text: Hello, World!

--- a/examples/voting-app/README.md
+++ b/examples/voting-app/README.md
@@ -2,15 +2,16 @@
 
 ### Initialize project
 
-In this example, we will create an app from the existing Docker sample `example-voting-app`. First download the project [here](https://github.com/dockersamples/example-voting-app).
+In this example, we will create an app from the existing Docker sample `example-voting-app`. First download the `docker-stack.yml` [here](https://github.com/dockersamples/example-voting-app) ([direct link](https://raw.githubusercontent.com/dockersamples/example-voting-app/master/docker-stack.yml)
 
-Initialize the project using `docker-app init voting-app --compose-file example-voting-app/docker-stack.yml`.
+Initialize the project using `docker-app init voting-app --compose-file docker-stack.yml`.
 
 ### Edit metadata
 
 Go to `voting-app.dockerapp/` and open `metadata.yml` and fill the following fields:
 - description
 - maintainers
+- namespace
 
 ### Add variables to the compose file
 
@@ -37,7 +38,7 @@ Change default replicas, from:
 [voting-app.dockerapp/docker-compose.yml](voting-app.dockerapp/docker-compose.yml):
 ```yml
 [...]
-vote:
+  vote:
     image: ${vote.image.name}:${vote.image.tag}
     ports:
       - ${vote.port}:80
@@ -174,79 +175,4 @@ result:
 
 ### Wrap everything in a Makefile
 
-Add a Makefile to simplify rendering, deploying and killing your app.
-
----
-
-[voting-app.dockerapp/Makefile](voting-app.dockerapp/Makefile):
-```Makefile
-# Input.
-SETTINGS_DIR ?= settings
-APP_NAME := voting-app
-
-# Output.
-DEVELOPMENT_DIR := build/development
-PRODUCTION_DIR := build/production
-PACK := $(APP_NAME).pack
-
-#
-# Cleanup.
-#
-cleanup/production:
-	@rm -rf $(PRODUCTION_DIR)
-
-cleanup/development:
-	@rm -rf $(DEVELOPMENT_DIR)
-
-cleanup: cleanup/production cleanup/development
-
-#
-# Render.
-#
-render/production: cleanup/production
-	@mkdir -p $(PRODUCTION_DIR)
-	docker-app render --settings-files $(SETTINGS_DIR)/production.yml > $(PRODUCTION_DIR)/docker-compose.yml
-
-render/development: cleanup/development
-	@mkdir -p $(DEVELOPMENT_DIR)
-	docker-app render --settings-files $(SETTINGS_DIR)/development.yml > $(DEVELOPMENT_DIR)/docker-compose.yml
-
-render: render/production render/development
-
-#
-# Stop.
-#
-stop/production:
-	docker stack rm ${APP_NAME}
-
-stop/development:
-	docker stack rm ${APP_NAME}-dev
-
-stop: stop/production stop/development
-
-#
-# Deploy.
-#
-deploy/production: render/production stop/production
-	docker-app deploy --settings-files $(SETTINGS_DIR)/production.yml
-
-deploy/development: render/development stop/development
-	docker-app deploy --settings-files $(SETTINGS_DIR)/development.yml
-
-#
-# Pack.
-#
-pack:
-	docker-app pack -o $(PACK)
-
-#
-# Helm.
-#
-helm/production:
-	docker-app helm --settings-files $(SETTINGS_DIR)/production.yml
-
-helm/development:
-	docker-app helm --settings-files $(SETTINGS_DIR)/development.yml
-```
-
-You can add more commands, depending on your needs.
+Add a Makefile to simplify rendering, deploying and killing your app, see [voting-app.dockerapp/Makefile](voting-app.dockerapp/Makefile).

--- a/examples/voting-app/voting-app.dockerapp/metadata.yml
+++ b/examples/voting-app/voting-app.dockerapp/metadata.yml
@@ -1,9 +1,16 @@
+# Version of the application
 version: 0.1.0
+# Name of the application
 name: voting-app
+# A short description of the application
 description: "Dogs or cats?"
+# Namespace to use when pushing to a registry. This is typically your Hub username.
+namespace: myHubUsername
+# List of application maitainers with name and email for each
 maintainers:
-- name: dimrok
-  email: "antony.mechin@docker.com"
+  - name: user
+    email: user@email.com
+# Specify false here if your application doesn't support Swarm or Kubernetes
 targets:
   swarm: true
   kubernetes: true


### PR DESCRIPTION
closes #242.

The examples were built with an old version of `docker-app`. 

**- What I did**

Update the generated files to match with the new version of `docker-app`. 

**- How I did it**

Follow the readme instructions for each example and update the readme and generated files. 

**- How to verify it**

Go through examples.

**- Description for the changelog**

Update examples to use version 0.3.0

**- A picture of a cute animal (not mandatory but encouraged)**

![36290265_10157559410268957_3090392255538659328_n](https://user-images.githubusercontent.com/3359376/42045282-7355b616-7afb-11e8-8a80-ff6bc66b915c.jpg)
