### PR TITLE
[WIP] - Fix helm chart name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,13 @@ RUN apk add --no-cache \
   git \
   curl \
   util-linux \
-  coreutils
+  coreutils \
+  openssl
+
+RUN curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh && \
+    chmod 700 get_helm.sh && \
+    ./get_helm.sh
+
 RUN curl -Ls https://download.docker.com/linux/static/$DOCKERCLI_CHANNEL/x86_64/docker-$DOCKERCLI_VERSION.tgz | \
   tar -xz docker/docker && \
   mv docker/docker /usr/bin/docker

--- a/e2e/binary_test.go
+++ b/e2e/binary_test.go
@@ -263,8 +263,8 @@ func TestPackBinary(t *testing.T) {
 	cwd, err := os.Getwd()
 	assert.NilError(t, err)
 	os.Chdir(tempDir)
-	result = icmd.RunCommand(dockerApp, "helm", "test")
-	result.Assert(t, icmd.Success)
+	assertCommand(t, dockerApp, "helm", "test")
+	assertCommand(t, "helm", "lint", "test.chart")
 	_, err = os.Stat("test.chart/Chart.yaml")
 	assert.NilError(t, err)
 	os.Mkdir("output", 0755)
@@ -278,6 +278,7 @@ func TestPackBinary(t *testing.T) {
 func TestHelmBinary(t *testing.T) {
 	dockerApp, _ := getBinary(t)
 	assertCommand(t, dockerApp, "helm", "helm", "-s", "myapp.nginx_version=2")
+	assertCommand(t, "helm", "lint", "helm.chart")
 	chart, _ := ioutil.ReadFile("helm.chart/Chart.yaml")
 	values, _ := ioutil.ReadFile("helm.chart/values.yaml")
 	stack, _ := ioutil.ReadFile("helm.chart/templates/stack.yaml")
@@ -289,6 +290,7 @@ func TestHelmBinary(t *testing.T) {
 func TestHelmV1Beta1Binary(t *testing.T) {
 	dockerApp, _ := getBinary(t)
 	assertCommand(t, dockerApp, "helm", "helm", "-s", "myapp.nginx_version=2", "--stack-version", "v1beta1")
+	assertCommand(t, "helm", "lint", "helm.chart")
 	chart, _ := ioutil.ReadFile("helm.chart/Chart.yaml")
 	values, _ := ioutil.ReadFile("helm.chart/values.yaml")
 	stack, _ := ioutil.ReadFile("helm.chart/templates/stack.yaml")

--- a/e2e/helm.chart/Chart.yaml
+++ b/e2e/helm.chart/Chart.yaml
@@ -3,5 +3,5 @@ keywords: []
 maintainers:
 - name: bearclaw <bearclaw@bearclaw.com>
 - name: bob <bob@bob.com>
-name: myapp.chart
+name: helm.chart
 version: 0.1.0

--- a/e2e/helm.chart/Chart.yaml
+++ b/e2e/helm.chart/Chart.yaml
@@ -3,5 +3,5 @@ keywords: []
 maintainers:
 - name: bearclaw <bearclaw@bearclaw.com>
 - name: bob <bob@bob.com>
-name: myapp
+name: myapp.chart
 version: 0.1.0

--- a/e2e/helm.dockerapp/metadata.yml
+++ b/e2e/helm.dockerapp/metadata.yml
@@ -1,5 +1,5 @@
 version: 0.1.0
-name: myapp
+name: helm
 description: ""
 maintainers:
   - name: bearclaw

--- a/e2e/testdata/helm-expected.chart/Chart.yaml
+++ b/e2e/testdata/helm-expected.chart/Chart.yaml
@@ -3,5 +3,5 @@ keywords: []
 maintainers:
 - name: bearclaw <bearclaw@bearclaw.com>
 - name: bob <bob@bob.com>
-name: myapp.chart
+name: helm.chart
 version: 0.1.0

--- a/e2e/testdata/helm-expected.chart/Chart.yaml
+++ b/e2e/testdata/helm-expected.chart/Chart.yaml
@@ -3,5 +3,5 @@ keywords: []
 maintainers:
 - name: bearclaw <bearclaw@bearclaw.com>
 - name: bob <bob@bob.com>
-name: myapp
+name: myapp.chart
 version: 0.1.0

--- a/e2e/testdata/helm-expected.chart/values.yaml
+++ b/e2e/testdata/helm-expected.chart/values.yaml
@@ -1,6 +1,6 @@
 aport: 10000
 app:
-  name: myapp
+  name: helm
   version: 0.1.0
 dport: 12000
 memory: "100000000"

--- a/internal/renderer/helm.go
+++ b/internal/renderer/helm.go
@@ -60,7 +60,7 @@ type helmMeta struct {
 
 func toHelmMeta(meta *types.AppMetadata) (*helmMeta, error) {
 	res := &helmMeta{
-		Name:        meta.Name,
+		Name:        meta.Name + ".chart",
 		Version:     meta.Version,
 		Description: meta.Description,
 	}


### PR DESCRIPTION
close #242.

**- What I did**

Make generated helm charts correct (lintable).

**- How I did it**

Rename the chart name to match the name of the chart folder.

**- How to verify it**

```
$ cd $GOPATH/src/github/docker/app
$ docker-app helm examples/wordpress/wordpress.dockerapp
$ ls
[...]
drwxr-xr-x  3 dimrok dimrok  4096 juin  29 14:28 wordpress.chart
$ helm lint wordpress.chart
==> Linting wordpress.chart
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures
```

Before:
```
$ helm lint wordpress.chart
==> Linting wordpress.chart
[ERROR] Chart.yaml: directory name (wordpress.chart) and chart name (wordpress) must be the same
[INFO] Chart.yaml: icon is recommended

Error: 1 chart(s) linted, 1 chart(s) failed
```

**- Description for the changelog**

Fix helm chart name.

**- A picture of a cute animal (not mandatory but encouraged)**

![lwov19gx6r611](https://user-images.githubusercontent.com/3359376/42093647-560bb03a-7bad-11e8-80f8-fabe2c4a9650.jpg)
(credits: u/tmmurad on Reddit)