### PR TITLE
Extract: clean path, mainly to remove eventual trailing separator.

### DIFF
--- a/internal/packager/extract.go
+++ b/internal/packager/extract.go
@@ -118,7 +118,7 @@ func ExtractWithOrigin(appname string) (ExtractedApp, error) {
 		}
 	}
 	originalAppname := appname
-
+	appname = filepath.Clean(appname)
 	// try appending our extension
 	appname = internal.DirNameFromAppName(appname)
 	s, err := os.Stat(appname)


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>

Fixes #258 

**- What I did**

Call filepath.Clean from Extract to remove trailing slash.

**- How I did it**
NA
**- How to verify it**

See #258 

**- Description for the changelog**

- Properly sanitize application path passed on the CLI.

**- A picture of a cute animal (not mandatory but encouraged)**

![quema](https://user-images.githubusercontent.com/3638847/42097078-70ccd610-7bb7-11e8-9a02-6570000dded7.jpg)


