### PR TITLE
Add docs for --stack-version flag of helm subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ This will create a folder, `<my-application-name>.chart`, in the current directo
 
 _Note that this requires the Compose Kubernetes controller available in Docker for Windows and Docker for Mac, and in Docker Enterprise Edition._
 
+### Helm chart for Docker EE 2.0
+
+In order to create a helm chart that is compatible with version 2.0 of Docker Enterprise Edition, you will need to use the `--stack-version` flag to create a compatible version of the helm chart using `v1beta1` like so:
+
+```bash
+$ docker-app helm --stack-version=v1beta1
+```
+
 ## Single file or directory representation
 
 If you prefer having the three documents in separate YAML files, omit the `-s` option to

--- a/cmd/docker-app/helm.go
+++ b/cmd/docker-app/helm.go
@@ -49,6 +49,6 @@ be rendered instead of exported as a template.`
 	}
 	cmd.Flags().StringArrayVarP(&helmSettingsFile, "settings-files", "f", []string{}, "Override settings files")
 	cmd.Flags().StringArrayVarP(&helmEnv, "set", "s", []string{}, "Override settings values")
-	cmd.Flags().StringVarP(&stackVersion, "stack-version", "", renderer.V1Beta2, "Version of the stack specification for the produced helm chart")
+	cmd.Flags().StringVarP(&stackVersion, "stack-version", "", renderer.V1Beta2, "Version of the stack specification for the produced helm chart (v1beta1 / v1beta2)")
 	return cmd
 }


### PR DESCRIPTION
**- What I did**

Added docs for `--stack-version` option. Complements #247 

**- How I did it**

Used a text editor

**- How to verify it**

```python
#!/usr/bin/python
import urllib2

req = urllib2.Request('https://raw.githubusercontent.com/docker/app/f038ffd08922e252232bfa9661171f2379880465/README.md')
handler = urllib2.urlopen(req)
assert handler.getcode() == 200
data = handler.read()
assert '### Helm chart for Docker UCP 2.0' in data
```

**- A picture of a cute animal (not mandatory but encouraged)**

![バナナネコ ](https://media.giphy.com/media/w85GHRS33e0j6/giphy.gif)