### PR TITLE
Update README with Windows limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ tar xf docker-app-linux.tar.gz
 cp docker-app-linux /usr/local/bin/docker-app
 ```
 
+**Note:** To use Application Packages as images (i.e.: `save`, `push`, or `deploy` when package is not present locally) on Windows, one must be in Linux container mode.
 
 ## Integrating with Helm
 

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -195,6 +195,8 @@ spec:
 
 ### Generate distributable app package
 
+**Note:** If using Windows, this only works in Linux container mode.
+
 `docker-app save wordpress` creates a Docker image packaging the relevant configuration files:
 
 ```


### PR DESCRIPTION
Document that we can't manipulate Application Packages as images on Windows when in Windows container mode.