### PR TITLE
Fix YAML document separator

### DIFF
--- a/e2e/testdata/init-singlefile.dockerapp
+++ b/e2e/testdata/init-singlefile.dockerapp
@@ -18,7 +18,7 @@ targets:
   swarm: true
   kubernetes: true
 
---
+---
 # This section contains the Compose file that describes your application services.
 version: "3.2"
 services:
@@ -26,7 +26,7 @@ services:
     image: nginx:${NGINX_VERSION}
     command: nginx $NGINX_ARGS
 
---
+---
 # This section contains the default values for your application settings.
 NGINX_ARGS: FILL ME
 NGINX_VERSION: latest

--- a/examples/hello-world/hello-world.dockerapp
+++ b/examples/hello-world/hello-world.dockerapp
@@ -16,7 +16,7 @@ targets:
   swarm: true
   kubernetes: true
 
---
+---
 # This section contains the Compose file that describes your application services.
 version: "3.6"
 services:
@@ -26,7 +26,7 @@ services:
     ports:
       - ${port}:5678
 
---
+---
 # This section contains the default values for your application settings.
 port: 8080
 text: Hello, World!

--- a/internal/packager/extract.go
+++ b/internal/packager/extract.go
@@ -164,7 +164,7 @@ func extractSingleFile(appname, appDir string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to read single-file application package")
 	}
-	parts := strings.Split(string(data), "\n--")
+	parts := strings.Split(string(data), "\n---")
 	if len(parts) != 3 {
 		return fmt.Errorf("malformed single-file application: expected 3 documents")
 	}

--- a/internal/packager/split.go
+++ b/internal/packager/split.go
@@ -37,7 +37,7 @@ func Merge(appname string, target io.Writer) error {
 		}
 		target.Write(input)
 		if i != 2 {
-			io.WriteString(target, "\n--\n")
+			io.WriteString(target, "\n---\n")
 		}
 	}
 	return nil


### PR DESCRIPTION
According to http://yaml.org/spec/1.2/spec.html#id2760395 the separator between 2 documents is '---', not '--'

![image](https://user-images.githubusercontent.com/31478878/42173673-23730504-7e20-11e8-94e3-8e4517722a3f.png)
