### PR TITLE
Remove `renderer` package dependency from `image` package

### DIFF
--- a/cmd/docker-app/image-add.go
+++ b/cmd/docker-app/image-add.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/image"
 	"github.com/docker/app/internal/packager"
+	"github.com/docker/app/internal/renderer"
 	"github.com/spf13/cobra"
 )
 
@@ -35,7 +36,11 @@ subdirectory.`,
 			if err != nil {
 				return err
 			}
-			if err := image.Add(appname, args[1:], imageAddComposeFiles, imageAddSettingsFile, d); err != nil {
+			config, err := renderer.Render(appname, imageAddComposeFiles, imageAddSettingsFile, d)
+			if err != nil {
+				return err
+			}
+			if err := image.Add(appname, args[1:], config); err != nil {
 				return err
 			}
 			// check if source was a tarball

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -7,7 +7,8 @@ import (
 	"path/filepath"
 
 	"github.com/docker/app/internal"
-	"github.com/docker/app/internal/renderer"
+	composetypes "github.com/docker/cli/cli/compose/types"
+	"github.com/pkg/errors"
 )
 
 func contains(list []string, needle string) bool {
@@ -20,12 +21,10 @@ func contains(list []string, needle string) bool {
 }
 
 // Add add service images to the app package
-func Add(appname string, services []string, composeFiles []string, settingsFile []string, env map[string]string) error {
-	config, err := renderer.Render(appname, composeFiles, settingsFile, env)
-	if err != nil {
-		return err
+func Add(appname string, services []string, config *composetypes.Config) error {
+	if err := os.Mkdir(filepath.Join(appname, "images"), 0755); err != nil {
+		return errors.Wrap(err, "cannot create 'images' folder")
 	}
-	os.Mkdir(filepath.Join(appname, "images"), 0755)
 	for _, s := range config.Services {
 		if len(services) != 0 && !contains(services, s.Name) {
 			continue


### PR DESCRIPTION
- Simplifies the `image.Add` signature
- Separate responsabilities :)

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
