### PR TITLE
Fix gometalinter not recursing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test: test-unit test-e2e ## run all tests
 
 lint: ## run linter(s)
 	@echo "Linting..."
-	@gometalinter --config=gometalinter.json
+	@gometalinter --config=gometalinter.json ./...
 
 test-e2e: bin/$(BIN_NAME) ## run end-to-end tests
 	@echo "Running e2e tests..."

--- a/cmd/docker-app/deploy.go
+++ b/cmd/docker-app/deploy.go
@@ -23,7 +23,7 @@ type deployOptions struct {
 }
 
 // deployCmd represents the deploy command
-func deployCmd(dockerCli *command.DockerCli) *cobra.Command {
+func deployCmd(dockerCli command.Cli) *cobra.Command {
 	var opts deployOptions
 
 	cmd := &cobra.Command{
@@ -48,7 +48,7 @@ func deployCmd(dockerCli *command.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func runDeploy(dockerCli *command.DockerCli, flags *pflag.FlagSet, appname string, opts deployOptions) error {
+func runDeploy(dockerCli command.Cli, flags *pflag.FlagSet, appname string, opts deployOptions) error {
 	appname, cleanup, err := packager.Extract(appname)
 	if err != nil {
 		return err

--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -12,7 +12,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 // FIXME(vdemeester) use command.Cli interface
-func newRootCmd(dockerCli *command.DockerCli) *cobra.Command {
+func newRootCmd(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "docker-app",
 		Short:        "Docker App Packages",
@@ -31,7 +31,7 @@ func newRootCmd(dockerCli *command.DockerCli) *cobra.Command {
 }
 
 // addCommands adds all the commands from cli/command to the root command
-func addCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
+func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 	cmd.AddCommand(
 		deployCmd(dockerCli),
 		helmCmd(),

--- a/e2e/container.go
+++ b/e2e/container.go
@@ -19,12 +19,14 @@ type container struct {
 	container   string
 }
 
+//nolint: deadcode
 func startRegistry(t *testing.T) *container {
 	c := &container{image: "registry:2", privatePort: 5000}
 	c.start(t)
 	return c
 }
 
+//nolint: deadcode
 func startDind(t *testing.T) *container {
 	c := &container{image: "docker:dind", privatePort: 2375}
 	c.start(t)

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -2,6 +2,9 @@
   "Vendor": true,
   "Deadline": "10m",
   "Sort": ["linter", "severity", "path", "line"],
+  "Exclude": [
+    "templateloader"
+  ],
   "EnableGC": true,
   "Linters": {
       "nakedret": {

--- a/internal/names.go
+++ b/internal/names.go
@@ -10,7 +10,7 @@ import (
 const (
 	// AppExtension is the extension used by an application.
 	AppExtension = ".dockerapp"
-	// The label used to distinguish applications from Docker images.
+	// ImageLabel is the label used to distinguish applications from Docker images.
 	ImageLabel = "com.docker.application"
 	// MetadataFileName is metadata file name
 	MetadataFileName = "metadata.yml"
@@ -21,7 +21,7 @@ const (
 )
 
 var (
-	// Application file names, in order.
+	// FileNames lists the application file names, in order.
 	FileNames = []string{MetadataFileName, ComposeFileName, SettingsFileName}
 )
 

--- a/internal/packager/packing.go
+++ b/internal/packager/packing.go
@@ -17,10 +17,9 @@ func tarAdd(tarout *tar.Writer, path, file string) error {
 		return err
 	}
 	h := &tar.Header{
-		Name:     path,
-		Size:     int64(len(payload)),
-		Mode:     0644,
-		Typeflag: tar.TypeReg,
+		Name: path,
+		Size: int64(len(payload)),
+		Mode: 0644,
 	}
 	err = tarout.WriteHeader(h)
 	if err != nil {
@@ -28,16 +27,6 @@ func tarAdd(tarout *tar.Writer, path, file string) error {
 	}
 	_, err = tarout.Write(payload)
 	return err
-}
-
-func tarAddDir(tarout *tar.Writer, path string) error {
-	h := &tar.Header{
-		Name:     path,
-		Size:     0,
-		Typeflag: tar.TypeDir,
-		Mode:     0755,
-	}
-	return tarout.WriteHeader(h)
 }
 
 // Pack packs the app as a single file
@@ -50,13 +39,17 @@ func Pack(appname string, target io.Writer) error {
 		}
 	}
 	// check for images
-	_, err := os.Stat(filepath.Join(appname, "images"))
+	dir := "images"
+	_, err := os.Stat(filepath.Join(appname, dir))
 	if err == nil {
-		err = tarAddDir(tarout, "images")
-		if err != nil {
+		if err := tarout.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeDir,
+			Name:     dir,
+			Mode:     0755,
+		}); err != nil {
 			return err
 		}
-		imageDir, err := os.Open(filepath.Join(appname, "images"))
+		imageDir, err := os.Open(filepath.Join(appname, dir))
 		if err != nil {
 			return err
 		}
@@ -65,7 +58,7 @@ func Pack(appname string, target io.Writer) error {
 			return err
 		}
 		for _, i := range images {
-			err = tarAdd(tarout, filepath.Join("images", i), filepath.Join(appname, "images", i))
+			err = tarAdd(tarout, filepath.Join(dir, i), filepath.Join(appname, dir, i))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**- What I did**

I fixed the invocation of `gometalinter` from the `Makefile`.

**- How I did it**

I added `./...` to the command line to have it check recursively instead of just the top `doc.go` file.

**- How to verify it**

```
$ make lint
Linting...
e2e\container.go:22:1:warning: startRegistry is unused (deadcode)
e2e\container.go:28:1:warning: startDind is unused (deadcode)
internal\templateloader\interpolate.go:67:1:warning: interpolateConfig is unused (deadcode)
internal\templateloader\loader.go:72:1:warning: resolveEnabled is unused (deadcode)
internal\templateloader\merge.go:23:1:warning: merge is unused (deadcode)
internal\names.go:13:2:warning: comment on exported const ImageLabel should be of the form "ImageLabel ..." (golint)
internal\names.go:24:2:warning: comment on exported var FileNames should be of the form "FileNames ..." (golint)
cmd\docker-app\deploy.go:51:16:warning: dockerCli can be github.com/docker/app/vendor/github.com/docker/cli/cli/command.Cli (interfacer)
internal\templateloader\loader.go:885:49:warning: unnecessary conversion (unconvert)
internal\packager\packing.go:33:36:warning: parameter path always receives "images" (unparam)
internal\templateloader\loader.go:772:45:warning: parameter allowNil always receives false (unparam)
internal\templateloader\loader.go:772:33:warning: parameter sep always receives ":" (unparam)
internal\templateloader\interpolate.go:11:5:warning: var interpolateTypeCastMapping is unused (U1000) (unused)
internal\templateloader\interpolate.go:39:6:warning: func iPath is unused (U1000) (unused)
internal\templateloader\interpolate.go:43:6:warning: func servicePath is unused (U1000) (unused)
internal\templateloader\interpolate.go:47:6:warning: func toInt is unused (U1000) (unused)
internal\templateloader\interpolate.go:51:6:warning: func toFloat is unused (U1000) (unused)
internal\templateloader\interpolate.go:67:6:warning: func interpolateConfig is unused (U1000) (unused)
internal\templateloader\loader.go:45:6:warning: func processEnabled is unused (U1000) (unused)
internal\templateloader\loader.go:72:6:warning: func resolveEnabled is unused (U1000) (unused)
internal\templateloader\merge.go:12:6:warning: type specials is unused (U1000) (unused)
internal\templateloader\merge.go:23:6:warning: func merge is unused (U1000) (unused)
internal\templateloader\merge.go:51:6:warning: func mergeServices is unused (U1000) (unused)
internal\templateloader\merge.go:80:6:warning: func toServiceSecretConfigsMap is unused (U1000) (unused)
internal\templateloader\merge.go:92:6:warning: func toServiceConfigObjConfigsMap is unused (U1000) (unused)
internal\templateloader\merge.go:104:6:warning: func toServicePortConfigsMap is unused (U1000) (unused)
internal\templateloader\merge.go:116:6:warning: func toServiceSecretConfigsSlice is unused (U1000) (unused)
internal\templateloader\merge.go:126:6:warning: func toSServiceConfigObjConfigsSlice is unused (U1000) (unused)
internal\templateloader\merge.go:136:6:warning: func toServicePortConfigsSlice is unused (U1000) (unused)
internal\templateloader\merge.go:146:6:warning: type tomapFn is unused (U1000) (unused)
internal\templateloader\merge.go:147:6:warning: type writeValueFromMapFn is unused (U1000) (unused)
internal\templateloader\merge.go:149:6:warning: func safelyMerge is unused (U1000) (unused)
internal\templateloader\merge.go:162:6:warning: func mergeSlice is unused (U1000) (unused)
internal\templateloader\merge.go:179:6:warning: func sliceToMap is unused (U1000) (unused)
internal\templateloader\merge.go:187:6:warning: func mergeLoggingConfig is unused (U1000) (unused)
internal\templateloader\merge.go:203:6:warning: func getLoggingDriver is unused (U1000) (unused)
internal\templateloader\merge.go:207:6:warning: func mapByName is unused (U1000) (unused)
internal\templateloader\merge.go:215:6:warning: func mergeVolumes is unused (U1000) (unused)
internal\templateloader\merge.go:220:6:warning: func mergeNetworks is unused (U1000) (unused)
internal\templateloader\merge.go:225:6:warning: func mergeSecrets is unused (U1000) (unused)
internal\templateloader\merge.go:230:6:warning: func mergeConfigs is unused (U1000) (unused)
make: *** [lint] Error 1
```
