### PR TITLE
Fix `docker-app` pack regression

### DIFF
--- a/internal/packager/packing.go
+++ b/internal/packager/packing.go
@@ -17,9 +17,10 @@ func tarAdd(tarout *tar.Writer, path, file string) error {
 		return err
 	}
 	h := &tar.Header{
-		Name: path,
-		Size: int64(len(payload)),
-		Mode: 0644,
+		Name:     path,
+		Size:     int64(len(payload)),
+		Mode:     0644,
+		Typeflag: tar.TypeReg,
 	}
 	err = tarout.WriteHeader(h)
 	if err != nil {


### PR DESCRIPTION
`tar.Header` `Typeflag` wasn't set anymore for files, making the
`dockerapp` tar invalid.

https://github.com/docker/app/pull/276/files broke it…
Not covered by tests because we don't test `experimental` builds… a PR to also run test on experimental soon :angel: :wink: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
