### PR TITLE
Fix `make -f docker.Makefile cross` doing more than it should

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -27,7 +27,7 @@ shell: build_dev_image ## run a shell in the docker build image
 	docker run -ti --rm $(DEV_IMAGE_NAME) bash
 
 cross: create_bin ## cross-compile binaries (linux, darwin, windows)
-	docker build --target=$* -t $(CROSS_IMAGE_NAME)  .
+	docker build --target=cross -t $(CROSS_IMAGE_NAME)  .
 	docker create --name $(CROSS_CTNR_NAME) $(CROSS_IMAGE_NAME) noop
 	docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-linux
 	docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-darwin


### PR DESCRIPTION
Before this fix, the target being empty, it would build the whole
`Dockerfile` instead of just the `cross` target.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>