### PR TITLE
Remove `parseSettings` and use `docker/cli` code to parse key=value env

### DIFF
--- a/cmd/docker-app/deploy.go
+++ b/cmd/docker-app/deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/stack"
 	"github.com/docker/cli/cli/command/stack/options"
+	cliopts "github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -58,10 +59,7 @@ func runDeploy(dockerCli command.Cli, flags *pflag.FlagSet, appname string, opts
 	if err != nil {
 		return err
 	}
-	d, err := parseSettings(opts.deployEnv)
-	if err != nil {
-		return err
-	}
+	d := cliopts.ConvertKVStringsToMap(opts.deployEnv)
 	rendered, err := render.Render(appname, opts.deployComposeFiles, opts.deploySettingsFiles, d)
 	if err != nil {
 		return err

--- a/cmd/docker-app/helm.go
+++ b/cmd/docker-app/helm.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/internal/render"
 	"github.com/docker/cli/cli"
+	cliopts "github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
 )
 
@@ -30,10 +31,7 @@ func helmCmd() *cobra.Command {
 				return err
 			}
 			defer cleanup()
-			d, err := parseSettings(helmEnv)
-			if err != nil {
-				return err
-			}
+			d := cliopts.ConvertKVStringsToMap(helmEnv)
 			if stackVersion != render.V1Beta1 && stackVersion != render.V1Beta2 {
 				return fmt.Errorf("invalid stack version %q (accepted values: %s, %s)", stackVersion, render.V1Beta1, render.V1Beta2)
 			}

--- a/cmd/docker-app/image-add.go
+++ b/cmd/docker-app/image-add.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/app/internal/image"
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/internal/render"
+	cliopts "github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
 )
 
@@ -31,11 +32,7 @@ subdirectory.`,
 				return err
 			}
 			defer cleanup()
-
-			d, err := parseSettings(imageAddEnv)
-			if err != nil {
-				return err
-			}
+			d := cliopts.ConvertKVStringsToMap(imageAddEnv)
 			config, err := render.Render(appname, imageAddComposeFiles, imageAddSettingsFile, d)
 			if err != nil {
 				return err

--- a/cmd/docker-app/render.go
+++ b/cmd/docker-app/render.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/app/internal/render"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	cliopts "github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -32,10 +33,7 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 				return err
 			}
 			defer cleanup()
-			d, err := parseSettings(renderEnv)
-			if err != nil {
-				return err
-			}
+			d := cliopts.ConvertKVStringsToMap(renderEnv)
 			rendered, err := render.Render(appname, renderComposeFiles, renderSettingsFile, d)
 			if err != nil {
 				return err

--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/docker/app/internal"
 	"github.com/docker/cli/cli/command"
 	log "github.com/sirupsen/logrus"
@@ -62,19 +59,4 @@ func firstOrEmpty(list []string) string {
 		return list[0]
 	}
 	return ""
-}
-
-func parseSettings(s []string) (map[string]string, error) {
-	d := make(map[string]string)
-	for _, v := range s {
-		kv := strings.SplitN(v, "=", 2)
-		if len(kv) != 2 {
-			return nil, fmt.Errorf("Missing '=' in setting '%s', expected KEY=VALUE", v)
-		}
-		if _, ok := d[kv[0]]; ok {
-			return nil, fmt.Errorf("Duplicate command line setting: '%s'", kv[0])
-		}
-		d[kv[0]] = kv[1]
-	}
-	return d, nil
 }


### PR DESCRIPTION
The behavior changes slightly : it doesn't error out now. This means :
- if there is a duplicated key (i.e. multiple time the same flag), the last one wins
- if the key is empty, well it's empty. We could either do the same as `docker/cli` (i.e. use the environment variable to populate it or just ignore it). Also right now `FOO=` and `FOO` are handled the same (i.e. `empty` value), we can use another function if we want to be able to distinguish the two.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
