### PR TITLE
Implement `docker-app fork`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 _build/
 bin/
 !examples/simple/*.dockerapp
+!e2e/**/*.dockerapp
 .gradle
 coverage.html
 cover.out

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Found an app on a remote registry you'd like to modify to better suit your needs
 $ docker-app fork remote/hello.dockerapp:1.0.0 mine/hello2 -m "Bob Dylan:bob@aol.com"
 ```
 
-This command will create a local, editable copy of the app on your system. By default, the copy is created inside the current directory ; you may use the `--path` flag to configure a different destination.
+This command will create a local, editable copy of the app on your system. By default, the copy is created inside the current directory; you may use the `--path` flag to configure a different destination.
 
 For example, the following will create the `/opt/myapps/hello2.dockerapp` folder containing the forked app's files:
 
@@ -243,6 +243,7 @@ Usage:
 Available Commands:
   completion  Generates bash completion scripts
   deploy      Deploy or update an application
+  fork        Create a fork of an existing application to be modified
   helm        Generate a Helm chart
   init        Start building a Docker application
   inspect     Shows metadata and settings for a given application

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ This command will create a local, editable copy of the app on your system. By de
 For example, the following will create the `/opt/myapps/hello2.dockerapp` folder containing the forked app's files:
 
 ```bash
-$ docker-app fork remote/hello.dockerapp:1.0.0 mine/hello2 -p /opt/myapps
+$ docker-app fork remote/hello.dockerapp:1.0.0 mine/hello2 --path /opt/myapps
 ```
 
 ## Next steps

--- a/README.md
+++ b/README.md
@@ -204,6 +204,22 @@ $ docker pull myHubUser/hello.dockerapp:latest
 $ docker-app inspect myHubUser/hello
 ```
 
+## Forking an existing image
+
+Found an app on a remote registry you'd like to modify to better suit your needs? Use the `fork` subcommand:
+
+```bash
+$ docker-app fork remote/hello.dockerapp:1.0.0 mine/hello2 -m "Bob Dylan:bob@aol.com"
+```
+
+This command will create a local, editable copy of the app on your system. By default, the copy is created inside the current directory ; you may use the `--path` flag to configure a different destination.
+
+For example, the following will create the `/opt/myapps/hello2.dockerapp` folder containing the forked app's files:
+
+```bash
+$ docker-app fork remote/hello.dockerapp:1.0.0 mine/hello2 -p /opt/myapps
+```
+
 ## Next steps
 
 We have lots of ideas for making Compose-based applications easier to share and reuse, and making applications a first-class part of the Docker toolchain. Please let us know what you think about this initial release and about any of the ideas below:

--- a/cmd/docker-app/fork.go
+++ b/cmd/docker-app/fork.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/docker/app/internal/packager"
+	"github.com/docker/cli/cli"
+	"github.com/spf13/cobra"
+)
+
+var (
+	forkMaintainers []string
+	outputDir       string
+)
+
+func forkCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fork <origin-name> <fork-name> [-p outputdir] [-m name:email ...]",
+		Short: "Create a fork of an existing application to be modified",
+		Args:  cli.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return packager.Fork(args[0], args[1], outputDir, forkMaintainers)
+		},
+	}
+	cmd.Flags().StringArrayVarP(&forkMaintainers, "maintainer", "m", []string{}, "Maintainer (name:email) (optional)")
+	cmd.Flags().StringVarP(&outputDir, "path", "p", ".", "Directory where the application will be extracted")
+
+	return cmd
+}

--- a/cmd/docker-app/fork.go
+++ b/cmd/docker-app/fork.go
@@ -13,11 +13,15 @@ var (
 
 func forkCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "fork <origin-name> <fork-name> [-p outputdir] [-m name:email ...]",
+		Use:   "fork <origin-name> [fork-name] [-p outputdir] [-m name:email ...]",
 		Short: "Create a fork of an existing application to be modified",
-		Args:  cli.ExactArgs(2),
+		Args:  cli.RequiresRangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return packager.Fork(args[0], args[1], outputDir, forkMaintainers)
+			forkName := ""
+			if len(args) >= 2 {
+				forkName = args[1]
+			}
+			return packager.Fork(args[0], forkName, outputDir, forkMaintainers)
 		},
 	}
 	cmd.Flags().StringArrayVarP(&forkMaintainers, "maintainer", "m", []string{}, "Maintainer (name:email) (optional)")

--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -43,6 +43,7 @@ func newRootCmd(dockerCli *command.DockerCli) *cobra.Command {
 func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 	cmd.AddCommand(
 		deployCmd(dockerCli),
+		forkCmd(),
 		helmCmd(),
 		initCmd(),
 		inspectCmd(dockerCli),

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/types"
+	yaml "gopkg.in/yaml.v2"
 
 	"gotest.tools/assert"
 	"gotest.tools/fs"
@@ -311,4 +313,50 @@ func TestImageBinary(t *testing.T) {
 	// various commands from an image
 	assertCommand(t, dockerApp, "inspect", "alice/envvariables:0.1.0")
 	assertCommand(t, dockerApp, "inspect", "alice/envvariables.dockerapp:0.1.0")
+}
+
+func TestForkBinary(t *testing.T) {
+	dockerApp, _ := getDockerAppBinary(t)
+	r := startRegistry(t)
+	defer r.stop(t)
+	registry := r.getAddress(t)
+	assertCommand(t, dockerApp, "save", "--namespace", registry+"/acmecorp", "fork/simple")
+	assertCommand(t, dockerApp, "push", "--namespace", registry+"/acmecorp", "fork/simple")
+
+	tempDir, err := ioutil.TempDir("", "dockerapptest")
+	assert.NilError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	assertCommand(t, dockerApp, "fork", registry+"/acmecorp/simple.dockerapp:1.1.0-beta1", "acmecorp/scarlet.devil", "-p", tempDir, "-m", "Remilia Scarlet:remilia@acmecorp.cool")
+	metadata, err := ioutil.ReadFile(filepath.Join(tempDir, "scarlet.devil.dockerapp", "metadata.yml"))
+	assert.NilError(t, err)
+	var decodedMeta types.AppMetadata
+	err = yaml.Unmarshal(metadata, &decodedMeta)
+	assert.NilError(t, err)
+	var expected = types.AppMetadata{
+		Name:        "scarlet.devil",
+		Namespace:   "acmecorp",
+		Version:     "1.1.0-beta1",
+		Description: "new fancy webapp with microservices",
+		Maintainers: types.Maintainers{
+			{Name: "Remilia Scarlet", Email: "remilia@acmecorp.cool"},
+		},
+		Targets: types.ApplicationTarget{
+			Swarm:      true,
+			Kubernetes: false,
+		},
+		Parents: types.Parents{
+			{
+				Name:      "simple",
+				Namespace: "acmecorp",
+				Version:   "1.1.0-beta1",
+				Maintainers: types.Maintainers{
+					{Name: "John Developer", Email: "john.dev@acmecorp.cool"},
+					{Name: "Jane Developer", Email: "jane.dev@acmecorp.cool"},
+				},
+			},
+		},
+	}
+
+	assert.DeepEqual(t, decodedMeta, expected)
 }

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 
 	"github.com/docker/app/internal"
-	"github.com/docker/app/internal/types"
-	yaml "gopkg.in/yaml.v2"
 
 	"gotest.tools/assert"
 	"gotest.tools/fs"
@@ -332,29 +330,10 @@ func TestForkBinary(t *testing.T) {
 	assert.NilError(t, err)
 
 	golden.Assert(t, string(metadata), "expected-fork-metadata.golden")
-	var decodedMeta types.AppMetadata
-	err = yaml.Unmarshal(metadata, &decodedMeta)
-	assert.NilError(t, err)
-	var expected = types.AppMetadata{
-		Name:        "scarlet.devil",
-		Namespace:   "acmecorp",
-		Version:     "1.1.0-beta1",
-		Description: "new fancy webapp with microservices",
-		Maintainers: types.Maintainers{
-			{Name: "Remilia Scarlet", Email: "remilia@acmecorp.cool"},
-		},
-		Parents: types.Parents{
-			{
-				Name:      "simple",
-				Namespace: "acmecorp",
-				Version:   "1.1.0-beta1",
-				Maintainers: types.Maintainers{
-					{Name: "John Developer", Email: "john.dev@acmecorp.cool"},
-					{Name: "Jane Developer", Email: "jane.dev@acmecorp.cool"},
-				},
-			},
-		},
-	}
 
-	assert.DeepEqual(t, decodedMeta, expected)
+	assertCommand(t, dockerApp, "fork", registry+"/acmecorp/simple.dockerapp:1.1.0-beta1", "-p", tempDir, "-m", "Remilia Scarlet:remilia@acmecorp.cool")
+	metadata2, err := ioutil.ReadFile(filepath.Join(tempDir, "simple.dockerapp", "metadata.yml"))
+	assert.NilError(t, err)
+
+	golden.Assert(t, string(metadata2), "expected-fork-metadata-no-rename.golden")
 }

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -330,6 +330,8 @@ func TestForkBinary(t *testing.T) {
 	assertCommand(t, dockerApp, "fork", registry+"/acmecorp/simple.dockerapp:1.1.0-beta1", "acmecorp/scarlet.devil", "-p", tempDir, "-m", "Remilia Scarlet:remilia@acmecorp.cool")
 	metadata, err := ioutil.ReadFile(filepath.Join(tempDir, "scarlet.devil.dockerapp", "metadata.yml"))
 	assert.NilError(t, err)
+
+	golden.Assert(t, string(metadata), "expected-fork-metadata.golden")
 	var decodedMeta types.AppMetadata
 	err = yaml.Unmarshal(metadata, &decodedMeta)
 	assert.NilError(t, err)

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -341,10 +341,6 @@ func TestForkBinary(t *testing.T) {
 		Maintainers: types.Maintainers{
 			{Name: "Remilia Scarlet", Email: "remilia@acmecorp.cool"},
 		},
-		Targets: types.ApplicationTarget{
-			Swarm:      true,
-			Kubernetes: false,
-		},
 		Parents: types.Parents{
 			{
 				Name:      "simple",

--- a/e2e/fork/simple.dockerapp/docker-compose.yml
+++ b/e2e/fork/simple.dockerapp/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.6"
+services:
+  api:
+    image: python:${versions.python}
+    networks:
+      back:
+      front:
+        aliases:
+          - corp.app.api.com
+          - ${api_host}
+  web:
+    image: nginx:${versions.nginx}
+    networks:
+      - front
+    volumes:
+      - static:/opt/${static_subdir}
+    ports:
+      - ${web_port}:80
+  db:
+    image: postgres:${versions.postgres}
+    networks:
+      - back
+networks:
+  front:
+  back:
+volumes:
+  static:
+    external: true
+    name: corp/web-static-data

--- a/e2e/fork/simple.dockerapp/metadata.yml
+++ b/e2e/fork/simple.dockerapp/metadata.yml
@@ -1,0 +1,9 @@
+version: 1.1.0-beta1
+name: simple
+namespace: acmecorp
+description: "new fancy webapp with microservices"
+maintainers:
+  - name: John Developer
+    email: john.dev@acmecorp.cool
+  - name: Jane Developer
+    email: jane.dev@acmecorp.cool

--- a/e2e/fork/simple.dockerapp/settings.yml
+++ b/e2e/fork/simple.dockerapp/settings.yml
@@ -1,0 +1,7 @@
+versions:
+  python: '3.6'
+  postgres: '9.3'
+  nginx: latest
+web_port: '8082'
+api_host: coolapp.com
+static_subdir: data/static

--- a/e2e/testdata/expected-fork-metadata-no-rename.golden
+++ b/e2e/testdata/expected-fork-metadata-no-rename.golden
@@ -1,0 +1,16 @@
+version: 1.1.0-beta1
+name: simple
+description: new fancy webapp with microservices
+namespace: ""
+maintainers:
+- name: Remilia Scarlet
+  email: remilia@acmecorp.cool
+parents:
+- name: simple
+  namespace: acmecorp
+  version: 1.1.0-beta1
+  maintainers:
+  - name: John Developer
+    email: john.dev@acmecorp.cool
+  - name: Jane Developer
+    email: jane.dev@acmecorp.cool

--- a/e2e/testdata/expected-fork-metadata.golden
+++ b/e2e/testdata/expected-fork-metadata.golden
@@ -1,0 +1,16 @@
+version: 1.1.0-beta1
+name: scarlet.devil
+description: new fancy webapp with microservices
+namespace: acmecorp
+maintainers:
+- name: Remilia Scarlet
+  email: remilia@acmecorp.cool
+parents:
+- name: simple
+  namespace: acmecorp
+  version: 1.1.0-beta1
+  maintainers:
+  - name: John Developer
+    email: john.dev@acmecorp.cool
+  - name: Jane Developer
+    email: jane.dev@acmecorp.cool

--- a/internal/packager/fork.go
+++ b/internal/packager/fork.go
@@ -83,7 +83,7 @@ func updateMetadata(raw []byte, namespace, name string, maintainers []string) ([
 	var yamlMeta []byte
 	meta, err := loadMetadata(raw)
 	if err != nil {
-		return yamlMeta, err
+		return nil, err
 	}
 	// insert retrieved data in fork history section
 	log.Debug("Generating fork metadata")
@@ -97,15 +97,14 @@ func updateMetadata(raw []byte, namespace, name string, maintainers []string) ([
 	// update metadata file
 	yamlMeta, err = yaml.Marshal(newMeta)
 	if err != nil {
-		return yamlMeta, errors.Wrap(err, "failed to render metadata structure")
+		return nil, errors.Wrap(err, "failed to render metadata structure")
 	}
 	return yamlMeta, nil
 }
 
 func loadMetadata(raw []byte) (types.AppMetadata, error) {
 	var meta types.AppMetadata
-	err := yaml.Unmarshal(raw, &meta)
-	if err != nil {
+	if err := yaml.Unmarshal(raw, &meta); err != nil {
 		return meta, errors.Wrap(err, "failed to parse application metadata")
 	}
 	return meta, nil

--- a/internal/packager/fork.go
+++ b/internal/packager/fork.go
@@ -1,118 +1,118 @@
 package packager
 
 import (
-    "archive/tar"
-    "io"
-    "io/ioutil"
-    "os"
-    "path/filepath"
-    "strings"
+	"archive/tar"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 
-    "github.com/docker/app/internal"
-    "github.com/docker/app/internal/types"
+	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/types"
 
-    "github.com/pkg/errors"
-    log "github.com/sirupsen/logrus"
-    yaml "gopkg.in/yaml.v2"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Fork pulls an application and creates a local fork for the user to modify
 func Fork(originName, forkName, outputDir string, maintainers []string) error {
-    imgRef, err := splitImageName(originName)
-    if err != nil {
-        return errors.Wrapf(err, "origin %q is not a valid image name", originName)
-    }
-    log.Debugf("Pulling latest version of package %s", originName)
-    if err := pullImage(originName); err != nil {
-        return err
-    }
-    tmpdir, err := ioutil.TempDir("", "dockerappfork_")
-    if err != nil {
-        return err
-    }
-    defer os.RemoveAll(tmpdir)
-    log.Debugf("Extracting original app data to %s", tmpdir)
-    if err = Load(originName, tmpdir); err != nil {
-        return err
-    }
+	imgRef, err := splitImageName(originName)
+	if err != nil {
+		return errors.Wrapf(err, "origin %q is not a valid image name", originName)
+	}
+	log.Debugf("Pulling latest version of package %s", originName)
+	if err := pullImage(originName); err != nil {
+		return err
+	}
+	tmpdir, err := ioutil.TempDir("", "dockerappfork_")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpdir)
+	log.Debugf("Extracting original app data to %s", tmpdir)
+	if err = Load(originName, tmpdir); err != nil {
+		return err
+	}
 
-    // create app dir in output-dir
-    namespace, name := splitPackageName(forkName)
-    appPath := filepath.Join(outputDir, internal.DirNameFromAppName(name))
-    os.MkdirAll(appPath, 0755)
+	// create app dir in output-dir
+	namespace, name := splitPackageName(forkName)
+	appPath := filepath.Join(outputDir, internal.DirNameFromAppName(name))
+	os.MkdirAll(appPath, 0755)
 
-    // iterate tar contents
-    tarfile, err := os.Open(filepath.Join(tmpdir, internal.DirNameFromAppName(imgRef.Name)))
-    if err != nil {
-        return errors.Wrap(err, "failed to open package archive")
-    }
-    tarReader := tar.NewReader(tarfile)
-    for {
-        header, err := tarReader.Next()
-        if err == io.EOF {
-            break
-        }
-        data := make([]byte, header.Size)
-        if _, err = tarReader.Read(data); err != nil && err != io.EOF {
-            return errors.Wrap(err, "error reading tar data")
-        }
+	// iterate tar contents
+	tarfile, err := os.Open(filepath.Join(tmpdir, internal.DirNameFromAppName(imgRef.Name)))
+	if err != nil {
+		return errors.Wrap(err, "failed to open package archive")
+	}
+	tarReader := tar.NewReader(tarfile)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		data := make([]byte, header.Size)
+		if _, err = tarReader.Read(data); err != nil && err != io.EOF {
+			return errors.Wrap(err, "error reading tar data")
+		}
 
-        if header.Name == internal.MetadataFileName {
-            log.Debug("Loading app metadata")
-            data, err = updateMetadata(data, namespace, name, maintainers)
-            if err != nil {
-                return err
-            }
-        }
+		if header.Name == internal.MetadataFileName {
+			log.Debug("Loading app metadata")
+			data, err = updateMetadata(data, namespace, name, maintainers)
+			if err != nil {
+				return err
+			}
+		}
 
-        dest := filepath.Join(appPath, header.Name)
-        log.Debugf("Writing file at %s", dest)
-        if err = ioutil.WriteFile(dest, data, 0644); err != nil {
-            return errors.Wrap(err, "error writing output file")
-        }
-    }
+		dest := filepath.Join(appPath, header.Name)
+		log.Debugf("Writing file at %s", dest)
+		if err = ioutil.WriteFile(dest, data, 0644); err != nil {
+			return errors.Wrap(err, "error writing output file")
+		}
+	}
 
-    return nil
+	return nil
 }
 
 func updateMetadata(raw []byte, namespace, name string, maintainers []string) ([]byte, error) {
-    // retrieve original metadata (maintainer/app name/app tag)
-    var yamlMeta []byte
-    meta, err := loadMetadata(raw)
-    if err != nil {
-        return yamlMeta, err
-    }
-    // insert retrieved data in fork history section
-    log.Debug("Generating fork metadata")
-    newmeta := types.MetadataFrom(
-        meta,
-        types.WithName(name),
-        types.WithNamespace(namespace),
-        types.WithMaintainers(parseMaintainersData(maintainers)),
-    )
+	// retrieve original metadata (maintainer/app name/app tag)
+	var yamlMeta []byte
+	meta, err := loadMetadata(raw)
+	if err != nil {
+		return yamlMeta, err
+	}
+	// insert retrieved data in fork history section
+	log.Debug("Generating fork metadata")
+	newmeta := types.MetadataFrom(
+		meta,
+		types.WithName(name),
+		types.WithNamespace(namespace),
+		types.WithMaintainers(parseMaintainersData(maintainers)),
+	)
 
-    // update metadata file
-    yamlMeta, err = yaml.Marshal(newmeta)
-    if err != nil {
-        return yamlMeta, errors.Wrap(err, "failed to render metadata structure")
-    }
-    return yamlMeta, nil
+	// update metadata file
+	yamlMeta, err = yaml.Marshal(newmeta)
+	if err != nil {
+		return yamlMeta, errors.Wrap(err, "failed to render metadata structure")
+	}
+	return yamlMeta, nil
 }
 
 func loadMetadata(raw []byte) (types.AppMetadata, error) {
-    var meta types.AppMetadata
-    err := yaml.Unmarshal(raw, &meta)
-    if err != nil {
-        return meta, errors.Wrap(err, "failed to parse application metadata")
-    }
-    return meta, nil
+	var meta types.AppMetadata
+	err := yaml.Unmarshal(raw, &meta)
+	if err != nil {
+		return meta, errors.Wrap(err, "failed to parse application metadata")
+	}
+	return meta, nil
 }
 
 func splitPackageName(name string) (string, string) {
-    ls := strings.LastIndexByte(name, '/')
-    if ls == -1 {
-        return "", name
-    }
+	ls := strings.LastIndexByte(name, '/')
+	if ls == -1 {
+		return "", name
+	}
 
-    return name[:ls], name[ls+1:]
+	return name[:ls], name[ls+1:]
 }

--- a/internal/packager/fork.go
+++ b/internal/packager/fork.go
@@ -22,6 +22,9 @@ func Fork(originName, forkName, outputDir string, maintainers []string) error {
 	if err != nil {
 		return errors.Wrapf(err, "origin %q is not a valid image name", originName)
 	}
+	if forkName == "" {
+		forkName = internal.AppNameFromDir(imgRef.Name)
+	}
 	log.Debugf("Pulling latest version of package %s", originName)
 	if err := pullImage(originName); err != nil {
 		return err

--- a/internal/packager/fork.go
+++ b/internal/packager/fork.go
@@ -32,7 +32,7 @@ func Fork(originName, forkName, outputDir string, maintainers []string) error {
 	}
 	defer os.RemoveAll(tmpdir)
 	log.Debugf("Extracting original app data to %s", tmpdir)
-	if err = Load(originName, tmpdir); err != nil {
+	if err := Load(originName, tmpdir); err != nil {
 		return err
 	}
 
@@ -53,7 +53,7 @@ func Fork(originName, forkName, outputDir string, maintainers []string) error {
 			break
 		}
 		data := make([]byte, header.Size)
-		if _, err = tarReader.Read(data); err != nil && err != io.EOF {
+		if _, err := tarReader.Read(data); err != nil && err != io.EOF {
 			return errors.Wrap(err, "error reading tar data")
 		}
 
@@ -67,7 +67,7 @@ func Fork(originName, forkName, outputDir string, maintainers []string) error {
 
 		dest := filepath.Join(appPath, header.Name)
 		log.Debugf("Writing file at %s", dest)
-		if err = ioutil.WriteFile(dest, data, 0644); err != nil {
+		if err := ioutil.WriteFile(dest, data, 0644); err != nil {
 			return errors.Wrap(err, "error writing output file")
 		}
 	}
@@ -84,7 +84,7 @@ func updateMetadata(raw []byte, namespace, name string, maintainers []string) ([
 	}
 	// insert retrieved data in fork history section
 	log.Debug("Generating fork metadata")
-	newmeta := types.MetadataFrom(
+	newMeta := types.MetadataFrom(
 		meta,
 		types.WithName(name),
 		types.WithNamespace(namespace),
@@ -92,7 +92,7 @@ func updateMetadata(raw []byte, namespace, name string, maintainers []string) ([
 	)
 
 	// update metadata file
-	yamlMeta, err = yaml.Marshal(newmeta)
+	yamlMeta, err = yaml.Marshal(newMeta)
 	if err != nil {
 		return yamlMeta, errors.Wrap(err, "failed to render metadata structure")
 	}

--- a/internal/packager/fork.go
+++ b/internal/packager/fork.go
@@ -1,0 +1,122 @@
+package packager
+
+import (
+    "archive/tar"
+    "io"
+    "io/ioutil"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "github.com/docker/app/internal"
+    "github.com/docker/app/internal/types"
+
+    "github.com/pkg/errors"
+    log "github.com/sirupsen/logrus"
+    yaml "gopkg.in/yaml.v2"
+)
+
+// Fork pulls an application and creates a local fork for the user to modify
+func Fork(originName, forkName, outputDir string, maintainers []string) error {
+    log.Debugf("Pulling latest version of package %s", originName)
+    if err := pullImage(originName); err != nil {
+        return err
+    }
+    tmpdir, err := ioutil.TempDir("", "dockerappfork_")
+    if err != nil {
+        return err
+    }
+    defer os.RemoveAll(tmpdir)
+    log.Debugf("Extracting original app data to %s", tmpdir)
+    if err = Load(originName, tmpdir); err != nil {
+        return err
+    }
+
+    // create app dir in output-dir
+    namespace, name := splitPackageName(forkName)
+    appPath := filepath.Join(outputDir, internal.DirNameFromAppName(name))
+    os.MkdirAll(appPath, 0755)
+
+    // iterate tar contents
+    imgRef, err := splitImageName(originName)
+    tarfile, err := os.Open(filepath.Join(tmpdir, internal.DirNameFromAppName(imgRef.Name)))
+    if err != nil {
+        return errors.Wrap(err, "failed to open package archive")
+    }
+    tarReader := tar.NewReader(tarfile)
+    for {
+        header, err := tarReader.Next()
+        if err == io.EOF {
+            break
+        }
+        data := make([]byte, header.Size)
+        if _, err = tarReader.Read(data); err != nil && err != io.EOF {
+            return errors.Wrap(err, "error reading tar data")
+        }
+
+        if header.Name == "metadata.yml" {
+            log.Debug("Loading app metadata")
+            data, err = updateMetadata(data, namespace, name, maintainers)
+            if err != nil {
+                return err
+            }
+        }
+
+        dest := filepath.Join(appPath, header.Name)
+        log.Debugf("Writing file at %s", dest)
+        if err = ioutil.WriteFile(dest, data, 0644); err != nil {
+            return errors.Wrap(err, "error writing output file")
+        }
+    }
+
+    return nil
+}
+
+func updateMetadata(raw []byte, namespace, name string, maintainers []string) ([]byte, error) {
+    // retrieve original metadata (maintainer/app name/app tag)
+    var yamlMeta []byte
+    meta, err := loadMetadata(raw)
+    if err != nil {
+        return yamlMeta, err
+    }
+    // insert retrieved data in fork history section
+    log.Debug("Generating fork data")
+    forkData := types.ParentMetadata{
+        Name:        meta.Name,
+        Namespace:   meta.Namespace,
+        Version:     meta.Version,
+        Maintainers: meta.Maintainers,
+    }
+    log.Debug("Updating package history")
+    meta.Parents = append(meta.Parents, forkData)
+
+    // overwrite maintainer and app name info
+    meta.Name = name
+    meta.Namespace = namespace
+    meta.Maintainers = parseMaintainersData(maintainers)
+
+    // update metadata file
+    yamlMeta, err = yaml.Marshal(meta)
+    if err != nil {
+        return yamlMeta, errors.Wrap(err, "failed to render metadata structure")
+    }
+    return yamlMeta, nil
+}
+
+func loadMetadata(raw []byte) (types.AppMetadata, error) {
+    var meta types.AppMetadata
+    err := yaml.Unmarshal(raw, &meta)
+    if err != nil {
+        return meta, errors.Wrap(err, "failed to parse application metadata")
+    }
+    return meta, nil
+}
+
+func splitPackageName(name string) (string, string) {
+    ls := strings.LastIndexByte(name, '/')
+    if ls == -1 {
+        return "", name
+    }
+
+    return name[:ls], name[ls+1:]
+}

--- a/internal/packager/fork_test.go
+++ b/internal/packager/fork_test.go
@@ -3,6 +3,8 @@ package packager
 import (
     "testing"
 
+    "github.com/docker/app/internal/types"
+
     "gotest.tools/assert"
 )
 
@@ -18,4 +20,78 @@ func TestSplitPackageName(t *testing.T) {
     ns, name = splitPackageName("some.repo.tk/v3/foo/bar")
     assert.Equal(t, ns, "some.repo.tk/v3/foo")
     assert.Equal(t, name, "bar")
+}
+
+var sampleMetadata = `
+name: machine
+namespace: heavy.metal
+version: "2000"
+maintainers:
+  - name: Billy Corgan
+    email: billy@pumpkins.net
+`
+
+var decodedSampleMetadata = types.AppMetadata{
+    Name:      "machine",
+    Namespace: "heavy.metal",
+    Version:   "2000",
+    Maintainers: []types.Maintainer{
+        {Name: "Billy Corgan", Email: "billy@pumpkins.net"},
+    },
+}
+
+func TestLoadMetadata(t *testing.T) {
+    appmeta, err := loadMetadata([]byte(sampleMetadata))
+    assert.NilError(t, err)
+    assert.DeepEqual(t, appmeta, types.AppMetadata{
+        Name:      "machine",
+        Namespace: "heavy.metal",
+        Version:   "2000",
+        Maintainers: []types.Maintainer{
+            {Name: "Billy Corgan", Email: "billy@pumpkins.net"},
+        },
+    })
+}
+
+func TestLoadEmptyMetadata(t *testing.T) {
+    appmeta, err := loadMetadata([]byte(""))
+    assert.NilError(t, err)
+    assert.DeepEqual(t, appmeta, types.AppMetadata{})
+}
+
+func TestLoadInvalidMetadata(t *testing.T) {
+    _, err := loadMetadata([]byte("'rootstring'"))
+    assert.ErrorContains(t, err, "failed to parse application metadata")
+}
+
+func TestUpdateMetadata(t *testing.T) {
+    newNamespace := "frog"
+    newName := "machine"
+    maintainers := []string{"infected mushroom:im@psy.net"}
+
+    output, err := updateMetadata([]byte(sampleMetadata), newNamespace, newName, maintainers)
+    assert.NilError(t, err)
+    decodedOutput, err := loadMetadata(output)
+    assert.NilError(t, err)
+    assert.DeepEqual(t, decodedOutput, types.AppMetadata{
+        Name:      "machine",
+        Namespace: "frog",
+        Version:   decodedSampleMetadata.Version,
+        Maintainers: []types.Maintainer{
+            {Name: "infected mushroom", Email: "im@psy.net"},
+        },
+        Parents: types.Parents{
+            {
+                Name:        decodedSampleMetadata.Name,
+                Namespace:   decodedSampleMetadata.Namespace,
+                Version:     decodedSampleMetadata.Version,
+                Maintainers: decodedSampleMetadata.Maintainers,
+            },
+        },
+    })
+}
+
+func TestUpdateMetadataInvalidOrigin(t *testing.T) {
+    _, err := updateMetadata([]byte("'rootstring'"), "", "", []string{})
+    assert.ErrorContains(t, err, "failed to parse application metadata")
 }

--- a/internal/packager/fork_test.go
+++ b/internal/packager/fork_test.go
@@ -1,25 +1,25 @@
 package packager
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/docker/app/internal/types"
+	"github.com/docker/app/internal/types"
 
-    "gotest.tools/assert"
+	"gotest.tools/assert"
 )
 
 func TestSplitPackageName(t *testing.T) {
-    ns, name := splitPackageName("foo/bar")
-    assert.Equal(t, ns, "foo")
-    assert.Equal(t, name, "bar")
+	ns, name := splitPackageName("foo/bar")
+	assert.Equal(t, ns, "foo")
+	assert.Equal(t, name, "bar")
 
-    ns, name = splitPackageName("nonamespace")
-    assert.Equal(t, ns, "")
-    assert.Equal(t, name, "nonamespace")
+	ns, name = splitPackageName("nonamespace")
+	assert.Equal(t, ns, "")
+	assert.Equal(t, name, "nonamespace")
 
-    ns, name = splitPackageName("some.repo.tk/v3/foo/bar")
-    assert.Equal(t, ns, "some.repo.tk/v3/foo")
-    assert.Equal(t, name, "bar")
+	ns, name = splitPackageName("some.repo.tk/v3/foo/bar")
+	assert.Equal(t, ns, "some.repo.tk/v3/foo")
+	assert.Equal(t, name, "bar")
 }
 
 var sampleMetadata = `
@@ -32,66 +32,66 @@ maintainers:
 `
 
 var decodedSampleMetadata = types.AppMetadata{
-    Name:      "machine",
-    Namespace: "heavy.metal",
-    Version:   "2000",
-    Maintainers: []types.Maintainer{
-        {Name: "Billy Corgan", Email: "billy@pumpkins.net"},
-    },
+	Name:      "machine",
+	Namespace: "heavy.metal",
+	Version:   "2000",
+	Maintainers: []types.Maintainer{
+		{Name: "Billy Corgan", Email: "billy@pumpkins.net"},
+	},
 }
 
 func TestLoadMetadata(t *testing.T) {
-    appmeta, err := loadMetadata([]byte(sampleMetadata))
-    assert.NilError(t, err)
-    assert.DeepEqual(t, appmeta, types.AppMetadata{
-        Name:      "machine",
-        Namespace: "heavy.metal",
-        Version:   "2000",
-        Maintainers: []types.Maintainer{
-            {Name: "Billy Corgan", Email: "billy@pumpkins.net"},
-        },
-    })
+	appmeta, err := loadMetadata([]byte(sampleMetadata))
+	assert.NilError(t, err)
+	assert.DeepEqual(t, appmeta, types.AppMetadata{
+		Name:      "machine",
+		Namespace: "heavy.metal",
+		Version:   "2000",
+		Maintainers: []types.Maintainer{
+			{Name: "Billy Corgan", Email: "billy@pumpkins.net"},
+		},
+	})
 }
 
 func TestLoadEmptyMetadata(t *testing.T) {
-    appmeta, err := loadMetadata([]byte(""))
-    assert.NilError(t, err)
-    assert.DeepEqual(t, appmeta, types.AppMetadata{})
+	appmeta, err := loadMetadata([]byte(""))
+	assert.NilError(t, err)
+	assert.DeepEqual(t, appmeta, types.AppMetadata{})
 }
 
 func TestLoadInvalidMetadata(t *testing.T) {
-    _, err := loadMetadata([]byte("'rootstring'"))
-    assert.ErrorContains(t, err, "failed to parse application metadata")
+	_, err := loadMetadata([]byte("'rootstring'"))
+	assert.ErrorContains(t, err, "failed to parse application metadata")
 }
 
 func TestUpdateMetadata(t *testing.T) {
-    newNamespace := "frog"
-    newName := "machine"
-    maintainers := []string{"infected mushroom:im@psy.net"}
+	newNamespace := "frog"
+	newName := "machine"
+	maintainers := []string{"infected mushroom:im@psy.net"}
 
-    output, err := updateMetadata([]byte(sampleMetadata), newNamespace, newName, maintainers)
-    assert.NilError(t, err)
-    decodedOutput, err := loadMetadata(output)
-    assert.NilError(t, err)
-    assert.DeepEqual(t, decodedOutput, types.AppMetadata{
-        Name:      "machine",
-        Namespace: "frog",
-        Version:   decodedSampleMetadata.Version,
-        Maintainers: []types.Maintainer{
-            {Name: "infected mushroom", Email: "im@psy.net"},
-        },
-        Parents: types.Parents{
-            {
-                Name:        decodedSampleMetadata.Name,
-                Namespace:   decodedSampleMetadata.Namespace,
-                Version:     decodedSampleMetadata.Version,
-                Maintainers: decodedSampleMetadata.Maintainers,
-            },
-        },
-    })
+	output, err := updateMetadata([]byte(sampleMetadata), newNamespace, newName, maintainers)
+	assert.NilError(t, err)
+	decodedOutput, err := loadMetadata(output)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, decodedOutput, types.AppMetadata{
+		Name:      "machine",
+		Namespace: "frog",
+		Version:   decodedSampleMetadata.Version,
+		Maintainers: []types.Maintainer{
+			{Name: "infected mushroom", Email: "im@psy.net"},
+		},
+		Parents: types.Parents{
+			{
+				Name:        decodedSampleMetadata.Name,
+				Namespace:   decodedSampleMetadata.Namespace,
+				Version:     decodedSampleMetadata.Version,
+				Maintainers: decodedSampleMetadata.Maintainers,
+			},
+		},
+	})
 }
 
 func TestUpdateMetadataInvalidOrigin(t *testing.T) {
-    _, err := updateMetadata([]byte("'rootstring'"), "", "", []string{})
-    assert.ErrorContains(t, err, "failed to parse application metadata")
+	_, err := updateMetadata([]byte("'rootstring'"), "", "", []string{})
+	assert.ErrorContains(t, err, "failed to parse application metadata")
 }

--- a/internal/packager/fork_test.go
+++ b/internal/packager/fork_test.go
@@ -1,0 +1,21 @@
+package packager
+
+import (
+    "testing"
+
+    "gotest.tools/assert"
+)
+
+func TestSplitPackageName(t *testing.T) {
+    ns, name := splitPackageName("foo/bar")
+    assert.Equal(t, ns, "foo")
+    assert.Equal(t, name, "bar")
+
+    ns, name = splitPackageName("nonamespace")
+    assert.Equal(t, ns, "")
+    assert.Equal(t, name, "nonamespace")
+
+    ns, name = splitPackageName("some.repo.tk/v3/foo/bar")
+    assert.Equal(t, ns, "some.repo.tk/v3/foo")
+    assert.Equal(t, name, "bar")
+}

--- a/internal/packager/init.go
+++ b/internal/packager/init.go
@@ -212,7 +212,7 @@ func parseMaintainersData(maintainers []string) []types.Maintainer {
 	var res []types.Maintainer
 	for _, m := range maintainers {
 		ne := strings.SplitN(m, ":", 2)
-		email := ""
+		var email string
 		if len(ne) > 1 {
 			email = ne[1]
 		}

--- a/internal/packager/init.go
+++ b/internal/packager/init.go
@@ -206,6 +206,21 @@ func writeMetadataFile(name, dirName string, description string, maintainers []s
 	return ioutil.WriteFile(filepath.Join(dirName, internal.MetadataFileName), resBuf.Bytes(), 0644)
 }
 
+// parseMaintainersData parses user-provided data through the maintainers flag and returns
+// a slice of Maintainer instances
+func parseMaintainersData(maintainers []string) []types.Maintainer {
+	var res []types.Maintainer
+	for _, m := range maintainers {
+		ne := strings.Split(m, ":")
+		email := ""
+		if len(ne) > 1 {
+			email = ne[1]
+		}
+		res = append(res, types.Maintainer{Name: ne[0], Email: email})
+	}
+	return res
+}
+
 func newMetadata(name string, description string, maintainers []string) types.AppMetadata {
 	res := types.AppMetadata{
 		Version:     "0.1.0",
@@ -220,14 +235,7 @@ func newMetadata(name string, description string, maintainers []string) types.Ap
 		}
 		res.Maintainers = []types.Maintainer{{Name: userName}}
 	} else {
-		for _, m := range maintainers {
-			ne := strings.Split(m, ":")
-			email := ""
-			if len(ne) > 1 {
-				email = ne[1]
-			}
-			res.Maintainers = append(res.Maintainers, types.Maintainer{Name: ne[0], Email: email})
-		}
+		res.Maintainers = parseMaintainersData(maintainers)
 	}
 	return res
 }

--- a/internal/packager/init.go
+++ b/internal/packager/init.go
@@ -211,7 +211,7 @@ func writeMetadataFile(name, dirName string, description string, maintainers []s
 func parseMaintainersData(maintainers []string) []types.Maintainer {
 	var res []types.Maintainer
 	for _, m := range maintainers {
-		ne := strings.Split(m, ":")
+		ne := strings.SplitN(m, ":", 2)
 		email := ""
 		if len(ne) > 1 {
 			email = ne[1]

--- a/internal/packager/init_test.go
+++ b/internal/packager/init_test.go
@@ -141,7 +141,7 @@ maintainers:
 }
 
 func TestParseMaintainersData(t *testing.T) {
-	var input = []string{
+	input := []string{
 		"sakuya:sakuya.izayoi@touhou.jp",
 		"marisa.kirisame",
 		"Reimu Hakurei",
@@ -150,7 +150,7 @@ func TestParseMaintainersData(t *testing.T) {
 		"perfect:cherry:blossom",
 	}
 
-	var expectedOutput = []types.Maintainer{
+	expectedOutput := []types.Maintainer{
 		{Name: "sakuya", Email: "sakuya.izayoi@touhou.jp"},
 		{Name: "marisa.kirisame", Email: ""},
 		{Name: "Reimu Hakurei", Email: ""},
@@ -158,7 +158,7 @@ func TestParseMaintainersData(t *testing.T) {
 		{Name: "    ", Email: "    "},
 		{Name: "perfect", Email: "cherry:blossom"},
 	}
-	var output = parseMaintainersData(input)
+	output := parseMaintainersData(input)
 
 	assert.DeepEqual(t, output, expectedOutput)
 }

--- a/internal/packager/init_test.go
+++ b/internal/packager/init_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/types"
 	"gotest.tools/assert"
 	"gotest.tools/fs"
 )
@@ -137,4 +138,27 @@ maintainers:
 		fs.WithFile(internal.MetadataFileName, data, fs.WithMode(0644)),
 	)
 	assert.Assert(t, fs.Equal(tmpdir.Path(), manifest))
+}
+
+func TestParseMaintainersData(t *testing.T) {
+	var input = []string{
+		"sakuya:sakuya.izayoi@touhou.jp",
+		"marisa.kirisame",
+		"Reimu Hakurei",
+		"Hong Meiling:kurenai.misuzu@touhou.jp",
+		"    :    ",
+		"perfect:cherry:blossom",
+	}
+
+	var expectedOutput = []types.Maintainer{
+		{Name: "sakuya", Email: "sakuya.izayoi@touhou.jp"},
+		{Name: "marisa.kirisame", Email: ""},
+		{Name: "Reimu Hakurei", Email: ""},
+		{Name: "Hong Meiling", Email: "kurenai.misuzu@touhou.jp"},
+		{Name: "    ", Email: "    "},
+		{Name: "perfect", Email: "cherry:blossom"},
+	}
+	var output = parseMaintainersData(input)
+
+	assert.DeepEqual(t, output, expectedOutput)
 }

--- a/internal/packager/registry.go
+++ b/internal/packager/registry.go
@@ -147,7 +147,6 @@ func pullImage(repotag string) error {
 
 type imageComponents struct {
 	Name       string
-	Namespace  string
 	Repository string
 	Tag        string
 }
@@ -161,7 +160,6 @@ func splitImageName(repotag string) (*imageComponents, error) {
 		Repository: named.Name(),
 	}
 	res.Name = res.Repository[strings.LastIndex(res.Repository, "/")+1:]
-	res.Namespace = strings.TrimSuffix(res.Repository, res.Name)
 	if tagged, ok := named.(reference.Tagged); ok {
 		res.Tag = tagged.Tag()
 	}

--- a/internal/packager/registry_test.go
+++ b/internal/packager/registry_test.go
@@ -1,0 +1,42 @@
+package packager
+
+import (
+    "testing"
+
+    "gotest.tools/assert"
+)
+
+func TestSplitImageName(t *testing.T) {
+    var input = []string{
+        "official.dockerapp",
+        "touhou/reimu.dockerapp",
+        "tagged.dockerapp:1.2.25",
+        "touhou/sakuya.dockerapp:4.23",
+        "private.registry.co.uk/docker/anne.boleyn/annulment.dockerapp:15.28",
+    }
+
+    var output = []imageComponents{
+        {Name: "official.dockerapp", Repository: "docker.io/library/official.dockerapp"},
+        {Name: "reimu.dockerapp", Repository: "docker.io/touhou/reimu.dockerapp"},
+        {Name: "tagged.dockerapp", Repository: "docker.io/library/tagged.dockerapp", Tag: "1.2.25"},
+        {Name: "sakuya.dockerapp", Repository: "docker.io/touhou/sakuya.dockerapp", Tag: "4.23"},
+        {Name: "annulment.dockerapp", Repository: "private.registry.co.uk/docker/anne.boleyn/annulment.dockerapp", Tag: "15.28"},
+    }
+
+    for i, item := range input {
+        out, err := splitImageName(item)
+        assert.NilError(t, err, item)
+        assert.DeepEqual(t, out, &output[i])
+    }
+
+    var invalids = []string{
+        "__.dockerapp",
+        "colon:colon:colon.dockerapp:colon",
+        "nametag.dockerapp:",
+    }
+
+    for _, item := range invalids {
+        _, err := splitImageName(item)
+        assert.ErrorContains(t, err, "failed to parse image name", item)
+    }
+}

--- a/internal/packager/registry_test.go
+++ b/internal/packager/registry_test.go
@@ -1,42 +1,42 @@
 package packager
 
 import (
-    "testing"
+	"testing"
 
-    "gotest.tools/assert"
+	"gotest.tools/assert"
 )
 
 func TestSplitImageName(t *testing.T) {
-    var input = []string{
-        "official.dockerapp",
-        "touhou/reimu.dockerapp",
-        "tagged.dockerapp:1.2.25",
-        "touhou/sakuya.dockerapp:4.23",
-        "private.registry.co.uk/docker/anne.boleyn/annulment.dockerapp:15.28",
-    }
+	var input = []string{
+		"official.dockerapp",
+		"touhou/reimu.dockerapp",
+		"tagged.dockerapp:1.2.25",
+		"touhou/sakuya.dockerapp:4.23",
+		"private.registry.co.uk/docker/anne.boleyn/annulment.dockerapp:15.28",
+	}
 
-    var output = []imageComponents{
-        {Name: "official.dockerapp", Repository: "docker.io/library/official.dockerapp"},
-        {Name: "reimu.dockerapp", Repository: "docker.io/touhou/reimu.dockerapp"},
-        {Name: "tagged.dockerapp", Repository: "docker.io/library/tagged.dockerapp", Tag: "1.2.25"},
-        {Name: "sakuya.dockerapp", Repository: "docker.io/touhou/sakuya.dockerapp", Tag: "4.23"},
-        {Name: "annulment.dockerapp", Repository: "private.registry.co.uk/docker/anne.boleyn/annulment.dockerapp", Tag: "15.28"},
-    }
+	var output = []imageComponents{
+		{Name: "official.dockerapp", Repository: "docker.io/library/official.dockerapp"},
+		{Name: "reimu.dockerapp", Repository: "docker.io/touhou/reimu.dockerapp"},
+		{Name: "tagged.dockerapp", Repository: "docker.io/library/tagged.dockerapp", Tag: "1.2.25"},
+		{Name: "sakuya.dockerapp", Repository: "docker.io/touhou/sakuya.dockerapp", Tag: "4.23"},
+		{Name: "annulment.dockerapp", Repository: "private.registry.co.uk/docker/anne.boleyn/annulment.dockerapp", Tag: "15.28"},
+	}
 
-    for i, item := range input {
-        out, err := splitImageName(item)
-        assert.NilError(t, err, item)
-        assert.DeepEqual(t, out, &output[i])
-    }
+	for i, item := range input {
+		out, err := splitImageName(item)
+		assert.NilError(t, err, item)
+		assert.DeepEqual(t, out, &output[i])
+	}
 
-    var invalids = []string{
-        "__.dockerapp",
-        "colon:colon:colon.dockerapp:colon",
-        "nametag.dockerapp:",
-    }
+	var invalids = []string{
+		"__.dockerapp",
+		"colon:colon:colon.dockerapp:colon",
+		"nametag.dockerapp:",
+	}
 
-    for _, item := range invalids {
-        _, err := splitImageName(item)
-        assert.ErrorContains(t, err, "failed to parse image name", item)
-    }
+	for _, item := range invalids {
+		_, err := splitImageName(item)
+		assert.ErrorContains(t, err, "failed to parse image name", item)
+	}
 }

--- a/internal/packager/registry_test.go
+++ b/internal/packager/registry_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSplitImageName(t *testing.T) {
-	var input = []string{
+	input := []string{
 		"official.dockerapp",
 		"touhou/reimu.dockerapp",
 		"tagged.dockerapp:1.2.25",
@@ -15,7 +15,7 @@ func TestSplitImageName(t *testing.T) {
 		"private.registry.co.uk/docker/anne.boleyn/annulment.dockerapp:15.28",
 	}
 
-	var output = []imageComponents{
+	output := []imageComponents{
 		{Name: "official.dockerapp", Repository: "docker.io/library/official.dockerapp"},
 		{Name: "reimu.dockerapp", Repository: "docker.io/touhou/reimu.dockerapp"},
 		{Name: "tagged.dockerapp", Repository: "docker.io/library/tagged.dockerapp", Tag: "1.2.25"},
@@ -29,7 +29,7 @@ func TestSplitImageName(t *testing.T) {
 		assert.DeepEqual(t, out, &output[i])
 	}
 
-	var invalids = []string{
+	invalids := []string{
 		"__.dockerapp",
 		"colon:colon:colon.dockerapp:colon",
 		"nametag.dockerapp:",

--- a/internal/packager/registry_test.go
+++ b/internal/packager/registry_test.go
@@ -33,6 +33,7 @@ func TestSplitImageName(t *testing.T) {
 		"__.dockerapp",
 		"colon:colon:colon.dockerapp:colon",
 		"nametag.dockerapp:",
+		"ends/with/slash/",
 	}
 
 	for _, item := range invalids {

--- a/internal/types/metadata.go
+++ b/internal/types/metadata.go
@@ -51,3 +51,54 @@ type ParentMetadata struct {
 	Version     string
 	Maintainers Maintainers
 }
+
+// MetadataModifier is a function signature that takes and returns an AppMetadata object
+type MetadataModifier func(AppMetadata) AppMetadata
+
+// MetadataFrom returns an AppMetadata instance based on the provided AppMetadata
+// and applicable modifier functions
+func MetadataFrom(orig AppMetadata, modifiers ...MetadataModifier) AppMetadata {
+	parent := ParentMetadata{
+		Name:        orig.Name,
+		Namespace:   orig.Namespace,
+		Version:     orig.Version,
+		Maintainers: orig.Maintainers,
+	}
+
+	result := AppMetadata{
+		Version:     orig.Version,
+		Name:        orig.Name,
+		Namespace:   orig.Namespace,
+		Description: orig.Description,
+		Maintainers: orig.Maintainers,
+		Parents:     append(orig.Parents, parent),
+	}
+	for _, f := range modifiers {
+		result = f(result)
+	}
+	return result
+}
+
+// WithMaintainers returns a modified AppMetadata with updated maintainers field
+func WithMaintainers(maintainers Maintainers) MetadataModifier {
+	return func(parent AppMetadata) AppMetadata {
+		parent.Maintainers = maintainers
+		return parent
+	}
+}
+
+// WithName returns a modified AppMetadata with updated name field
+func WithName(name string) MetadataModifier {
+	return func(parent AppMetadata) AppMetadata {
+		parent.Name = name
+		return parent
+	}
+}
+
+// WithNamespace returns a modified AppMetadata with updated namespace field
+func WithNamespace(namespace string) MetadataModifier {
+	return func(parent AppMetadata) AppMetadata {
+		parent.Namespace = namespace
+		return parent
+	}
+}

--- a/internal/types/metadata.go
+++ b/internal/types/metadata.go
@@ -38,4 +38,16 @@ type AppMetadata struct {
 	Description string
 	Namespace   string
 	Maintainers Maintainers
+	Parents     Parents
+}
+
+// Parents is a list of ParentMetadata items
+type Parents []ParentMetadata
+
+// ParentMetadata contains historical data of forked packages
+type ParentMetadata struct {
+	Name        string
+	Namespace   string
+	Version     string
+	Maintainers Maintainers
 }

--- a/specification/schemas/metadata_schema_v0.1.json
+++ b/specification/schemas/metadata_schema_v0.1.json
@@ -22,23 +22,56 @@
         "maintainers": {
             "type": "array",
             "items": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "email": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "format": "email"
-                    }
-                }
+                "$ref": "#/definitions/maintainer"
+            }
+        },
+        "parents": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/parent"
             }
         }
     },
     "required": [
         "name",
         "version"
-    ]
+    ],
+    "definitions": {
+        "maintainer": {
+            "id": "#/definitions/maintainer",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "email"
+                }
+            }
+        },
+        "parent": {
+            "id": "#/definitions/parent",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "format": "hostname"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "maintainers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/maintainer"
+                    }
+                }
+            }
+        }
 }


### PR DESCRIPTION
**- What I did**

Implemented a new `docker-app fork` command with the following signature:
```
Create a fork of an existing application to be modified

Usage:
  docker-app fork <origin-name> <fork-name> [-p outputdir] [-m name:email ...] [flags]

Flags:
  -h, --help                     help for fork
  -m, --maintainer stringArray   Maintainer (name:email) (optional)
  -p, --path string              Directory where the application will be extracted (default ".")
```

https://asciinema.org/a/QyR6xAcBDZwN8GaJNErEz7shA

**- How I did it**

- Added `fork.go` inside the `packager` package, which does most of the work:
  - Pull "origin" image and saves it locally
  - Modify the contents of the metadata file to reflect the new package status
  - Copy the updated contents to the specified location
- Small modifications to `registry.go` and `init.go` extracting code snippets for reuse
- Modified the `AppMetadata` type to include a `Parents` field that tracks the package's ancestry.

**- How to verify it**

Tests are WIP. Manual testing can be performed by building from source and using the `docker-app fork` command.

**- Description for the changelog**

- Added the `fork` command, allowing the user to create a fork of an existing application to be modified locally.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1086876/42790306-34fd5ea0-891f-11e8-9d46-1de7a6f4154e.png)
