### PR TITLE
Some Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,29 @@
 include vars.mk
 
+ifeq ($(BUILDTIME),)
+  BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
+endif
+ifeq ($(BUILDTIME),)
+  BUILDTIME := unknown
+  $(warning unable to set BUILDTIME. Set the value manually)
+endif
+
+BUILDTAGS=""
+ifeq ($(EXPERIMENTAL),on)
+  BUILDTAGS="experimental"
+endif
+
+LDFLAGS := "-s -w \
+  -X $(PKG_NAME)/internal.GitCommit=$(COMMIT) \
+  -X $(PKG_NAME)/internal.Version=$(TAG)      \
+  -X $(PKG_NAME)/internal.Experimental=$(EXPERIMENTAL) \
+  -X $(PKG_NAME)/internal.BuildTime=$(BUILDTIME)"
+
+EXEC_EXT :=
+ifeq ($(OS),Windows_NT)
+  EXEC_EXT := .exe
+endif
+
 GO_BUILD := CGO_ENABLED=0 go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 GO_TEST := CGO_ENABLED=0 go test -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 

--- a/vars.mk
+++ b/vars.mk
@@ -30,27 +30,3 @@ endif
 ifeq ($(COMMIT),)
   COMMIT := $(shell git rev-parse --short HEAD 2> $(NULL))
 endif
-
-ifeq ($(BUILDTIME),)
-  BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
-endif
-ifeq ($(BUILDTIME),)
-  BUILDTIME := unknown
-  $(warning unable to set BUILDTIME. Set the value manually)
-endif
-
-BUILDTAGS=""
-ifeq ($(EXPERIMENTAL),on)
-  BUILDTAGS="experimental"
-endif
-
-LDFLAGS := "-s -w \
-  -X $(PKG_NAME)/internal.GitCommit=$(COMMIT) \
-  -X $(PKG_NAME)/internal.Version=$(TAG)      \
-  -X $(PKG_NAME)/internal.Experimental=$(EXPERIMENTAL) \
-  -X $(PKG_NAME)/internal.BuildTime=$(BUILDTIME)"
-
-EXEC_EXT :=
-ifeq ($(OS),Windows_NT)
-  EXEC_EXT := .exe
-endif

--- a/vars.mk
+++ b/vars.mk
@@ -32,16 +32,11 @@ ifeq ($(COMMIT),)
 endif
 
 ifeq ($(BUILDTIME),)
-  BUILDTIME := $(shell date --utc --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
-endif
-ifeq ($(BUILDTIME),)
-  BUILDTIME := $(shell gdate --utc --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
-endif
-ifeq ($(BUILDTIME),)
   BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
 endif
 ifeq ($(BUILDTIME),)
-  $(error unable to set BUILDTIME. Set the value manually)
+  BUILDTIME := unknown
+  $(warning unable to set BUILDTIME. Set the value manually)
 endif
 
 BUILDTAGS=""

--- a/vars.mk
+++ b/vars.mk
@@ -38,7 +38,10 @@ ifeq ($(BUILDTIME),)
   BUILDTIME := $(shell gdate --utc --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
 endif
 ifeq ($(BUILDTIME),)
-  $(error unable to set BUILDTIME, ensure that you have GNU date installed or set manually)
+  BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
+endif
+ifeq ($(BUILDTIME),)
+  $(error unable to set BUILDTIME. Set the value manually)
 endif
 
 BUILDTAGS=""


### PR DESCRIPTION
See individual commit messages for full description;

- Don't require nanosecond precision for BUILDTIME (requiring GNU date)
- Don't set variables twice when using `docker.Makefile`