### PR TITLE
Remove `ExtractWithOrigin` and refactor `Extract`

### DIFF
--- a/cmd/docker-app/deploy.go
+++ b/cmd/docker-app/deploy.go
@@ -50,23 +50,23 @@ func deployCmd(dockerCli command.Cli) *cobra.Command {
 }
 
 func runDeploy(dockerCli command.Cli, flags *pflag.FlagSet, appname string, opts deployOptions) error {
-	appname, cleanup, err := packager.Extract(appname)
+	app, err := packager.Extract(appname)
 	if err != nil {
 		return err
 	}
-	defer cleanup()
+	defer app.Cleanup()
 	deployOrchestrator, err := command.GetStackOrchestrator(opts.deployOrchestrator, dockerCli.ConfigFile().StackOrchestrator, dockerCli.Err())
 	if err != nil {
 		return err
 	}
 	d := cliopts.ConvertKVStringsToMap(opts.deployEnv)
-	rendered, err := render.Render(appname, opts.deployComposeFiles, opts.deploySettingsFiles, d)
+	rendered, err := render.Render(app.AppName, opts.deployComposeFiles, opts.deploySettingsFiles, d)
 	if err != nil {
 		return err
 	}
 	stackName := opts.deployStackName
 	if stackName == "" {
-		stackName = internal.AppNameFromDir(appname)
+		stackName = internal.AppNameFromDir(app.AppName)
 	}
 	return stack.RunDeploy(dockerCli, flags, rendered, deployOrchestrator, options.Deploy{
 		Namespace: stackName,

--- a/cmd/docker-app/helm.go
+++ b/cmd/docker-app/helm.go
@@ -26,16 +26,16 @@ func helmCmd() *cobra.Command {
 		Long:  `Generate a Helm chart for the application.`,
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			appname, cleanup, err := packager.Extract(firstOrEmpty(args))
+			app, err := packager.Extract(firstOrEmpty(args))
 			if err != nil {
 				return err
 			}
-			defer cleanup()
+			defer app.Cleanup()
 			d := cliopts.ConvertKVStringsToMap(helmEnv)
 			if stackVersion != render.V1Beta1 && stackVersion != render.V1Beta2 {
 				return fmt.Errorf("invalid stack version %q (accepted values: %s, %s)", stackVersion, render.V1Beta1, render.V1Beta2)
 			}
-			return render.Helm(appname, helmComposeFiles, helmSettingsFile, d, helmRender, stackVersion)
+			return render.Helm(app.AppName, helmComposeFiles, helmSettingsFile, d, helmRender, stackVersion)
 		},
 	}
 	if internal.Experimental == "on" {

--- a/cmd/docker-app/image-add.go
+++ b/cmd/docker-app/image-add.go
@@ -27,17 +27,17 @@ subdirectory.`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oappname := args[0]
-			appname, cleanup, err := packager.Extract(oappname)
+			app, err := packager.Extract(oappname)
 			if err != nil {
 				return err
 			}
-			defer cleanup()
+			defer app.Cleanup()
 			d := cliopts.ConvertKVStringsToMap(imageAddEnv)
-			config, err := render.Render(appname, imageAddComposeFiles, imageAddSettingsFile, d)
+			config, err := render.Render(app.AppName, imageAddComposeFiles, imageAddSettingsFile, d)
 			if err != nil {
 				return err
 			}
-			if err := image.Add(appname, args[1:], config); err != nil {
+			if err := image.Add(app.AppName, args[1:], config); err != nil {
 				return err
 			}
 			// check if source was a tarball
@@ -56,7 +56,7 @@ subdirectory.`,
 					return err
 				}
 				// source was a tarball, rebuild it
-				return packager.Pack(appname, target)
+				return packager.Pack(app.AppName, target)
 			}
 			return nil
 		},

--- a/cmd/docker-app/image-load.go
+++ b/cmd/docker-app/image-load.go
@@ -12,12 +12,12 @@ func imageLoadCmd() *cobra.Command {
 		Short: "Load stored images for given services (default: all) to the local docker daemon",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			appname, cleanup, err := packager.Extract(args[0])
+			app, err := packager.Extract(args[0])
 			if err != nil {
 				return err
 			}
-			defer cleanup()
-			return image.Load(appname, args[1:])
+			defer app.Cleanup()
+			return image.Load(app.AppName, args[1:])
 		},
 	}
 }

--- a/cmd/docker-app/inspect.go
+++ b/cmd/docker-app/inspect.go
@@ -15,12 +15,12 @@ func inspectCmd(dockerCli command.Cli) *cobra.Command {
 		Short: "Shows metadata and settings for a given application",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			appname, cleanup, err := packager.Extract(firstOrEmpty(args))
+			app, err := packager.Extract(firstOrEmpty(args))
 			if err != nil {
 				return err
 			}
-			defer cleanup()
-			return render.Inspect(dockerCli.Out(), appname)
+			defer app.Cleanup()
+			return render.Inspect(dockerCli.Out(), app.AppName)
 		},
 	}
 }

--- a/cmd/docker-app/merge.go
+++ b/cmd/docker-app/merge.go
@@ -45,7 +45,7 @@ func mergeCmd(dockerCli command.Cli) *cobra.Command {
 		Short: "Merge a multi-file application into a single file",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			extractedApp, err := packager.ExtractWithOrigin(firstOrEmpty(args))
+			extractedApp, err := packager.Extract(firstOrEmpty(args))
 			if err != nil {
 				return err
 			}

--- a/cmd/docker-app/pack.go
+++ b/cmd/docker-app/pack.go
@@ -20,12 +20,11 @@ func packCmd(dockerCli command.Cli) *cobra.Command {
 		Short: "Pack the application as a single file",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			appname := firstOrEmpty(args)
-			appname, cleanup, err := packager.Extract(appname)
+			app, err := packager.Extract(firstOrEmpty(args))
 			if err != nil {
 				return err
 			}
-			defer cleanup()
+			defer app.Cleanup()
 			var target io.Writer
 			if packOutputFile == "-" {
 				if terminal.IsTerminal(int(dockerCli.Out().FD())) {
@@ -37,7 +36,7 @@ func packCmd(dockerCli command.Cli) *cobra.Command {
 					return err
 				}
 			}
-			return packager.Pack(appname, target)
+			return packager.Pack(app.AppName, target)
 		},
 	}
 	cmd.Flags().StringVarP(&packOutputFile, "output", "o", "-", "Output file (- for stdout)")

--- a/cmd/docker-app/render.go
+++ b/cmd/docker-app/render.go
@@ -28,13 +28,13 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 		Long:  `Render the Compose file for the application.`,
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			appname, cleanup, err := packager.Extract(firstOrEmpty(args))
+			app, err := packager.Extract(firstOrEmpty(args))
 			if err != nil {
 				return err
 			}
-			defer cleanup()
+			defer app.Cleanup()
 			d := cliopts.ConvertKVStringsToMap(renderEnv)
-			rendered, err := render.Render(appname, renderComposeFiles, renderSettingsFile, d)
+			rendered, err := render.Render(app.AppName, renderComposeFiles, renderSettingsFile, d)
 			if err != nil {
 				return err
 			}

--- a/cmd/docker-app/split.go
+++ b/cmd/docker-app/split.go
@@ -17,7 +17,7 @@ func splitCmd() *cobra.Command {
 		Short: "Split a single-file application into multiple files",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			extractedApp, err := packager.ExtractWithOrigin(firstOrEmpty(args))
+			extractedApp, err := packager.Extract(firstOrEmpty(args))
 			if err != nil {
 				return err
 			}

--- a/internal/packager/extract.go
+++ b/internal/packager/extract.go
@@ -90,21 +90,15 @@ func extractImage(appname string) (ExtractedApp, error) {
 		}
 	}
 	// this gave us a compressed app, run through extract again
-	appname, cleanup, err := Extract(filepath.Join(tempDir, appname))
-	return ExtractedApp{"", appname, cleanup}, err
+	app, err := Extract(filepath.Join(tempDir, appname))
+	return ExtractedApp{"", app.AppName, app.Cleanup}, err
 }
 
-// Extract extracts the app content if it's an archive or single-file
-func Extract(appname string) (string, func(), error) {
-	extracted, err := ExtractWithOrigin(appname)
-	return extracted.AppName, extracted.Cleanup, err
-}
-
-// ExtractWithOrigin extracts the app content if argument is an archive, or does nothing if a dir.
+// Extract extracts the app content if argument is an archive, or does nothing if a dir.
 // It returns source file, effective app name, and cleanup function
 // If appname is empty, it looks into cwd, and all subdirs for a single matching .dockerapp
 // If nothing is found, it looks for an image and loads it
-func ExtractWithOrigin(appname string) (ExtractedApp, error) {
+func Extract(appname string) (ExtractedApp, error) {
 	if appname == "" {
 		var err error
 		if appname, err = findApp(); err != nil {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -180,7 +180,6 @@ func Render(appname string, composeFiles []string, settingsFiles []string, env m
 		}
 		renderers = rl
 	}
-	// go-template, then parse, then expand the compose files
 	configFiles := []composetypes.ConfigFile{}
 	for _, c := range composes {
 		data, err := ioutil.ReadFile(c)


### PR DESCRIPTION
… and update `packager` usage to use `Extract` in any case.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
