### PR TITLE
Create generic reusable tar handling functions

### DIFF
--- a/internal/packager/extract.go
+++ b/internal/packager/extract.go
@@ -195,16 +195,10 @@ func extract(appname, outputDir string) error {
 		return errors.Wrap(err, "failed to open application package")
 	}
 	defer f.Close()
-	tarReader := tar.NewReader(f)
+
 	outputDir = outputDir + "/"
-	for {
-		header, err := tarReader.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return errors.Wrap(err, "error reading from tar header")
-		}
+
+	err = handleTar(f, func(tarReader *tar.Reader, header *tar.Header) error {
 		switch header.Typeflag {
 		case tar.TypeDir: // = directory
 			if err := os.Mkdir(outputDir+header.Name, 0755); err != nil {
@@ -221,6 +215,7 @@ func extract(appname, outputDir string) error {
 				return errors.Wrap(err, "error writing output file")
 			}
 		}
-	}
-	return nil
+		return nil
+	})
+	return err
 }

--- a/internal/packager/tar.go
+++ b/internal/packager/tar.go
@@ -1,0 +1,49 @@
+package packager
+
+import (
+	"archive/tar"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+type tarOperation func(*tar.Reader, *tar.Header) error
+type tarStatusOperation func(*tar.Reader, *tar.Header) (bool, error)
+
+func handleTar(file io.Reader, handler tarOperation) error {
+	tarReader := tar.NewReader(file)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return errors.Wrap(err, "error reading from tar header")
+		}
+		err = handler(tarReader, header)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func handleTarWithStatus(file io.Reader, handler tarStatusOperation) (bool, error) {
+	status := false
+	tarReader := tar.NewReader(file)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return status, errors.Wrap(err, "error reading from tar header")
+		}
+		tmpStatus, err := handler(tarReader, header)
+		if err != nil {
+			return status, err
+		}
+		status = status || tmpStatus
+	}
+	return status, nil
+}


### PR DESCRIPTION
Depends on #292 (spurred by https://github.com/docker/app/pull/292#discussion_r205094387)

**- What I did**

Create 2 generic reusable tar handling functions in internal/packager and updated code to use them where applicable

**- How I did it**

```golang
type tarOperation func(*tar.Reader, *tar.Header) error
type tarStatusOperation func(*tar.Reader, *tar.Header) (bool, error)

func handleTar(file io.Reader, handler tarOperation) error {
  // ...
}

func handleTarWithStatus(file io.Reader, handler tarStatusOperation) (bool, error) {
  // ...
}
```

**- How to verify it**

e2e tests should validate that the dependent functions' behavior is unchanged.

**- Description for the changelog**

Improved tar handling code reuse

**- A picture of a cute animal (not mandatory but encouraged)**

```
|￣￣￣￣￣￣￣￣|
|  IS THIS    | 
|   CUTE      | 
|  ENOUGH?    | 
| ＿＿＿＿＿＿__| 
(\__/) || 
(•ㅅ•) || 
/ 　 づ
```