### PR TITLE
Fix typo in `maitainers`.

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -111,7 +111,7 @@ name: app-test
 description: my cool app
 # Namespace to use when pushing to a registry. This is typically your Hub username.
 #namespace: myHubUsername
-# List of application maitainers with name and email for each
+# List of application maintainers with name and email for each
 maintainers:
   - name: bob
     email: 

--- a/e2e/testdata/init-singlefile.dockerapp
+++ b/e2e/testdata/init-singlefile.dockerapp
@@ -7,7 +7,7 @@ name: tac
 description: my cool app
 # Namespace to use when pushing to a registry. This is typically your Hub username.
 #namespace: myHubUsername
-# List of application maitainers with name and email for each
+# List of application maintainers with name and email for each
 maintainers:
   - name: bob
     email: 

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -23,7 +23,7 @@ name: hello-world
 description:
 # Namespace to use when pushing to a registry. This is typically your Hub username.
 #namespace: myHubUsername
-# List of application maitainers with name and email for each
+# List of application maintainers with name and email for each
 maintainers:
   - name: user
     email:

--- a/examples/hello-world/hello-world.dockerapp
+++ b/examples/hello-world/hello-world.dockerapp
@@ -7,7 +7,7 @@ name: hello-world
 description: "Hello, World!"
 # Namespace to use when pushing to a registry. This is typically your Hub username.
 namespace: myHubUsername
-# List of application maitainers with name and email for each
+# List of application maintainers with name and email for each
 maintainers:
   - name: user
     email: "user@email.com"

--- a/examples/voting-app/voting-app.dockerapp/metadata.yml
+++ b/examples/voting-app/voting-app.dockerapp/metadata.yml
@@ -6,7 +6,7 @@ name: voting-app
 description: "Dogs or cats?"
 # Namespace to use when pushing to a registry. This is typically your Hub username.
 namespace: myHubUsername
-# List of application maitainers with name and email for each
+# List of application maintainers with name and email for each
 maintainers:
   - name: user
     email: user@email.com

--- a/internal/packager/init.go
+++ b/internal/packager/init.go
@@ -247,7 +247,7 @@ name: {{ .Name }}
 description: {{ .Description }}
 # Namespace to use when pushing to a registry. This is typically your Hub username.
 {{ if len .Namespace}}namespace: {{ .Namespace }} {{ else }}#namespace: myHubUsername{{ end }}
-# List of application maitainers with name and email for each
+# List of application maintainers with name and email for each
 {{ if len .Maintainers }}maintainers:
 {{ range .Maintainers }}  - name: {{ .Name  }}
     email: {{ .Email }}

--- a/internal/packager/init_test.go
+++ b/internal/packager/init_test.go
@@ -82,7 +82,7 @@ name: writemetadata_test
 description: 
 # Namespace to use when pushing to a registry. This is typically your Hub username.
 #namespace: myHubUsername
-# List of application maitainers with name and email for each
+# List of application maintainers with name and email for each
 maintainers:
   - name: bearclaw
     email: bearclaw


### PR DESCRIPTION
This one only fixes a little typo in the sources and examples.

Thanks for that nice little tool!
