### PR TITLE
Proposal: Remove the *no .dockerapp* magic…

### DIFF
--- a/internal/packager/extract.go
+++ b/internal/packager/extract.go
@@ -121,10 +121,6 @@ func Extract(appname string) (ExtractedApp, error) {
 	appname = internal.DirNameFromAppName(appname)
 	s, err := os.Stat(appname)
 	if err != nil {
-		// try verbatim
-		s, err = os.Stat(originalAppname)
-	}
-	if err != nil {
 		// look for a docker image
 		return extractImage(originalAppname)
 	}


### PR DESCRIPTION
With this, an app *has to* end-up with `.dockerapp`, even for images.
This means, `docker-app render foo` will always look for
`foo.dockerapp`, *never* for a folder or file called `foo`.

- This behavior is currently broken
- It makes the behavior a bit weird/inconsistent.
