### PR TITLE
e2e: Fix exit code on failure.

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -15,5 +15,5 @@ func TestMain(m *testing.M) {
 	if err := os.Chdir(*e2ePath); err != nil {
 		panic(err)
 	}
-	m.Run()
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix e2e's main function to properly return the test's exit code.


**- A picture of a cute animal (not mandatory but encouraged)**
![vilainchat](https://user-images.githubusercontent.com/3638847/43584237-275a15d6-9662-11e8-98dc-420a1f6e9e51.gif)


