### PR TITLE
Fix helm generation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -108,7 +108,7 @@
     "service/logs",
     "templates"
   ]
-  revision = "da544e893879e2b506165f49684afd44311d0cdb"
+  revision = "ff1a34d9a9d3bb3a7079ad1bf27d80d9a007c1ca"
 
 [[projects]]
   name = "github.com/docker/distribution"

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -240,9 +240,9 @@ func TestHelmBinary(t *testing.T) {
 	chart, _ := ioutil.ReadFile(dir.Join("helm.chart/Chart.yaml"))
 	values, _ := ioutil.ReadFile(dir.Join("helm.chart/values.yaml"))
 	stack, _ := ioutil.ReadFile(dir.Join("helm.chart/templates/stack.yaml"))
-	golden.Assert(t, string(chart), "helm-expected.chart/Chart.yaml")
-	golden.Assert(t, string(values), "helm-expected.chart/values.yaml")
-	golden.Assert(t, string(stack), "helm-expected.chart/templates/stack.yaml")
+	golden.Assert(t, string(chart), "helm-expected.chart/Chart.yaml", "chart file is wrong")
+	golden.Assert(t, string(values), "helm-expected.chart/values.yaml", "values file is wrong")
+	golden.Assert(t, string(stack), "helm-expected.chart/templates/stack.yaml", "stack file is wrong")
 }
 
 func TestHelmV1Beta1Binary(t *testing.T) {
@@ -252,9 +252,9 @@ func TestHelmV1Beta1Binary(t *testing.T) {
 	chart, _ := ioutil.ReadFile(dir.Join("helm.chart/Chart.yaml"))
 	values, _ := ioutil.ReadFile(dir.Join("helm.chart/values.yaml"))
 	stack, _ := ioutil.ReadFile(dir.Join("helm.chart/templates/stack.yaml"))
-	golden.Assert(t, string(chart), "helm-expected.chart/Chart.yaml")
-	golden.Assert(t, string(values), "helm-expected.chart/values.yaml")
-	golden.Assert(t, string(stack), "helm-expected.chart/templates/stack-v1beta1.yaml")
+	golden.Assert(t, string(chart), "helm-expected.chart/Chart.yaml", "chart file is wrong")
+	golden.Assert(t, string(values), "helm-expected.chart/values.yaml", "values file is wrong")
+	golden.Assert(t, string(stack), "helm-expected.chart/templates/stack-v1beta1.yaml", "stack file is wrong")
 }
 
 func TestHelmInvalidStackVersionBinary(t *testing.T) {

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -44,7 +44,7 @@ with the appropriate content (value or template)
 */
 
 // Helm renders an app as an Helm Chart
-func Helm(appname string, composeFiles []string, settingsFile []string, env map[string]string, render bool, stackVersion string) error {
+func Helm(appname string, composeFiles []string, settingsFile []string, env map[string]string, shouldRender bool, stackVersion string) error {
 	targetDir := internal.AppNameFromDir(appname) + ".chart"
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		return errors.Wrap(err, "failed to create Chart directory")
@@ -53,7 +53,7 @@ func Helm(appname string, composeFiles []string, settingsFile []string, env map[
 	if err != nil {
 		return err
 	}
-	if render {
+	if shouldRender {
 		return helmRender(appname, targetDir, composeFiles, settingsFile, env, stackVersion)
 	}
 	data, err := ioutil.ReadFile(filepath.Join(appname, internal.ComposeFileName))
@@ -64,7 +64,7 @@ func Helm(appname string, composeFiles []string, settingsFile []string, env map[
 	if err != nil {
 		return errors.Wrap(err, "failed to parse compose file")
 	}
-	vars := template.ExtractVariables(cfgMap)
+	vars := template.ExtractVariables(cfgMap, render.Pattern)
 	// FIXME(vdemeester): remove the need to create this slice
 	variables := []string{}
 	for k := range vars {

--- a/internal/packager/init.go
+++ b/internal/packager/init.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/render"
 	"github.com/docker/app/internal/types"
 	"github.com/docker/cli/cli/compose/loader"
 	dtemplate "github.com/docker/cli/cli/compose/template"
@@ -128,7 +129,7 @@ func initFromComposeFile(name string, composeFile string) error {
 			}
 		}
 	}
-	vars := dtemplate.ExtractVariables(cfgMap)
+	vars := dtemplate.ExtractVariables(cfgMap, render.Pattern)
 	needsFilling := false
 	for k, v := range vars {
 		if _, ok := settings[k]; !ok {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -34,7 +34,8 @@ var (
 		delimiter, delimiter, substitution, substitution,
 	)
 
-	pattern = regexp.MustCompile(patternString)
+	// Pattern is the variable regexp pattern used to interpolate or extract variables when rendering
+	Pattern = regexp.MustCompile(patternString)
 )
 
 // Render renders the Compose file for this app, merging in settings files, other compose files, and env
@@ -109,7 +110,7 @@ func render(configFiles []composetypes.ConfigFile, finalEnv map[string]string) (
 }
 
 func substitute(template string, mapping composetemplate.Mapping) (string, error) {
-	return composetemplate.SubstituteWith(template, mapping, pattern, errorIfMissing)
+	return composetemplate.SubstituteWith(template, mapping, Pattern, errorIfMissing)
 }
 
 func errorIfMissing(substitution string, mapping composetemplate.Mapping) (string, bool, error) {


### PR DESCRIPTION
This bump the docker/cli version to get the fix required on
`ExtractVariables`. It now takes a pattern other than the default,
which is something we require on `docker/app` as the pattern we
use (when interpolating) is a bit different from the default one.

It also adds a small message on the e2e test errors to see which file
was wrong.

Depends on https://github.com/docker/cli/pull/1262

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
