### PR TITLE
Send reg auth

### DIFF
--- a/cmd/docker-app/deploy.go
+++ b/cmd/docker-app/deploy.go
@@ -16,13 +16,14 @@ import (
 )
 
 type deployOptions struct {
-	deployComposeFiles  []string
-	deploySettingsFiles []string
-	deployEnv           []string
-	deployOrchestrator  string
-	deployKubeConfig    string
-	deployNamespace     string
-	deployStackName     string
+	deployComposeFiles      []string
+	deploySettingsFiles     []string
+	deployEnv               []string
+	deployOrchestrator      string
+	deployKubeConfig        string
+	deployNamespace         string
+	deployStackName         string
+	deploySendRegistryAuth  bool
 }
 
 // deployCmd represents the deploy command
@@ -45,6 +46,7 @@ func deployCmd(dockerCli command.Cli) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.deployKubeConfig, "kubeconfig", "k", "", "kubeconfig file to use")
 	cmd.Flags().StringVarP(&opts.deployNamespace, "namespace", "n", "default", "namespace to deploy into")
 	cmd.Flags().StringVarP(&opts.deployStackName, "name", "d", "", "stack name (default: app name)")
+	cmd.Flags().BoolVarP(&opts.deploySendRegistryAuth, "with-registry-auth", "", false, "sends registry auth")
 	if internal.Experimental == "on" {
 		cmd.Flags().StringArrayVarP(&opts.deployComposeFiles, "compose-files", "c", []string{}, "Override Compose files")
 	}
@@ -76,5 +78,6 @@ func runDeploy(dockerCli command.Cli, flags *pflag.FlagSet, appname string, opts
 	return stack.RunDeploy(dockerCli, flags, rendered, deployOrchestrator, options.Deploy{
 		Namespace:    stackName,
 		ResolveImage: swarm.ResolveImageAlways,
+    SendRegistryAuth: opts.deploySendRegistryAuth,
 	})
 }

--- a/cmd/docker-app/deploy.go
+++ b/cmd/docker-app/deploy.go
@@ -78,6 +78,6 @@ func runDeploy(dockerCli command.Cli, flags *pflag.FlagSet, appname string, opts
 	return stack.RunDeploy(dockerCli, flags, rendered, deployOrchestrator, options.Deploy{
 		Namespace:    stackName,
 		ResolveImage: swarm.ResolveImageAlways,
-    SendRegistryAuth: opts.deploySendRegistryAuth,
+		SendRegistryAuth: opts.deploySendRegistryAuth,
 	})
 }

--- a/cmd/docker-app/deploy.go
+++ b/cmd/docker-app/deploy.go
@@ -16,14 +16,14 @@ import (
 )
 
 type deployOptions struct {
-	deployComposeFiles      []string
-	deploySettingsFiles     []string
-	deployEnv               []string
-	deployOrchestrator      string
-	deployKubeConfig        string
-	deployNamespace         string
-	deployStackName         string
-	deploySendRegistryAuth  bool
+	deployComposeFiles     []string
+	deploySettingsFiles    []string
+	deployEnv              []string
+	deployOrchestrator     string
+	deployKubeConfig       string
+	deployNamespace        string
+	deployStackName        string
+	deploySendRegistryAuth bool
 }
 
 // deployCmd represents the deploy command
@@ -76,8 +76,8 @@ func runDeploy(dockerCli command.Cli, flags *pflag.FlagSet, appname string, opts
 		stackName = internal.AppNameFromDir(app.Name)
 	}
 	return stack.RunDeploy(dockerCli, flags, rendered, deployOrchestrator, options.Deploy{
-		Namespace:    stackName,
-		ResolveImage: swarm.ResolveImageAlways,
+		Namespace:        stackName,
+		ResolveImage:     swarm.ResolveImageAlways,
 		SendRegistryAuth: opts.deploySendRegistryAuth,
 	})
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added an option to `deploy` `--with-registry-auth` that passes the registry auth option down to the `stack.RunDeploy` function.

fixes #339 

**- How I did it**
Self Explanatory
**- How to verify it**
Run the `docker-app deploy --with-registry-auth` command
**- Description for the changelog**
Adds `--with-registry-auth` boolean flag to `deploy` command.


**- A picture of a cute animal (not mandatory but encouraged)**

<img src="https://i.dailymail.co.uk/i/pix/2012/10/25/article-0-15A7FF78000005DC-949_634x419.jpg" />