### PR TITLE
Make docker/app not exposed to yaml bomb

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -640,8 +640,8 @@
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "c86e64ed9581b7588e736f0c3e6ecc02cc22996e"
+  source = "https://github.com/simonferquel/yaml"
 
 [[projects]]
   name = "gotest.tools"
@@ -814,6 +814,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a24b6a0ea352f169dd0430ad65922041e8a8b450a1cad31e2f42977855a5cccd"
+  inputs-digest = "d9a1011f4ba0220435ba111f32ece000026dc4123ffa9fcfbcabac9bfd29f4f8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,6 +73,13 @@ required = ["github.com/wadey/gocovmerge"]
   name = "google.golang.org/grpc"
   revision = "v1.3.0"
 
+# This is using a fork waiting for go-yaml/yaml#375 to be merged
+# This PR allows to set a max decoded value, thus not being exposed to yaml bombs
+[[override]]
+  name = "gopkg.in/yaml.v2"
+  source = "https://github.com/simonferquel/yaml"
+  revision="c86e64ed9581b7588e736f0c3e6ecc02cc22996e"
+
 [[constraint]]
   name = "github.com/spf13/pflag"
   branch = "master"

--- a/cmd/docker-app/render.go
+++ b/cmd/docker-app/render.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/packager"
+	"github.com/docker/app/internal/yaml"
 	"github.com/docker/app/render"
 	"github.com/docker/app/types"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	cliopts "github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 var (

--- a/e2e/render_test.go
+++ b/e2e/render_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/yaml.v2"
+	"github.com/docker/app/internal/yaml"
 	"gotest.tools/assert"
 )
 

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/app/internal/helm/templatev1beta2"
 	"github.com/docker/app/internal/settings"
 	"github.com/docker/app/internal/slices"
+	"github.com/docker/app/internal/yaml"
 	"github.com/docker/app/render"
 	"github.com/docker/app/types"
 	"github.com/docker/app/types/metadata"
@@ -23,7 +24,6 @@ import (
 	"github.com/docker/cli/kubernetes/compose/v1beta1"
 	"github.com/docker/cli/kubernetes/compose/v1beta2"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -7,10 +7,10 @@ import (
 	"text/tabwriter"
 
 	"github.com/docker/app/internal/settings"
+	"github.com/docker/app/internal/yaml"
 	"github.com/docker/app/types"
 	"github.com/docker/app/types/metadata"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // Inspect dumps the metadata of an app

--- a/internal/packager/fork.go
+++ b/internal/packager/fork.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/yaml"
 	"github.com/docker/app/types/metadata"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // Fork pulls an application and creates a local fork for the user to modify

--- a/internal/packager/init.go
+++ b/internal/packager/init.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/compose"
+	"github.com/docker/app/internal/yaml"
 	"github.com/docker/app/loader"
 	"github.com/docker/app/render"
 	"github.com/docker/app/types"
@@ -22,7 +23,6 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 func prependToFile(filename, text string) error {

--- a/internal/packager/registry.go
+++ b/internal/packager/registry.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 
 	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/yaml"
 	"github.com/docker/app/types"
 	"github.com/docker/app/types/metadata"
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // Save saves an app to docker and returns the image name.

--- a/internal/renderer/yatee/driver.go
+++ b/internal/renderer/yatee/driver.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/docker/app/internal/renderer"
+	"github.com/docker/app/internal/yaml"
 	"github.com/docker/app/internal/yatee"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 func init() {

--- a/internal/settings/load.go
+++ b/internal/settings/load.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/docker/app/internal/yaml"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // Load loads the given data in settings

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/app/internal/yaml"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // Settings represents a settings map

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -1,0 +1,41 @@
+package yaml
+
+import (
+	"bytes"
+	"io"
+
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	maxDecodedValues = 1000000
+)
+
+// Unmarshal decodes the first document found within the in byte slice
+// and assigns decoded values into the out value.
+//
+// See gopkg.in/yaml.v2 documentation
+func Unmarshal(in []byte, out interface{}) error {
+	d := yaml.NewDecoder(bytes.NewBuffer(in), yaml.WithLimitDecodedValuesCount(maxDecodedValues))
+	err := d.Decode(out)
+	if err == io.EOF {
+		return nil
+	}
+	return err
+}
+
+// Marshal serializes the value provided into a YAML document. The structure
+// of the generated document will reflect the structure of the value itself.
+// Maps and pointers (to struct, string, int, etc) are accepted as the in value.
+//
+// See gopkg.in/yaml.v2 documentation
+func Marshal(in interface{}) ([]byte, error) {
+	return yaml.Marshal(in)
+}
+
+// NewDecoder returns a new decoder that reads from r.
+//
+// See gopkg.in/yaml.v2 documentation
+func NewDecoder(r io.Reader) *yaml.Decoder {
+	return yaml.NewDecoder(r, yaml.WithLimitDecodedValuesCount(maxDecodedValues))
+}

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -1,0 +1,41 @@
+package yaml
+
+import (
+	"bytes"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestDecoderYamlBomb(t *testing.T) {
+	var v map[interface{}]interface{}
+	data := []byte(`version: "3"
+services: &services ["lol","lol","lol","lol","lol","lol","lol","lol","lol"]
+b: &b [*services,*services,*services,*services,*services,*services,*services,*services,*services]
+c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]
+f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]
+g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
+h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
+i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]`)
+	d := NewDecoder(bytes.NewBuffer(data))
+	err := d.Decode(&v)
+	assert.ErrorContains(t, err, "yaml: exceeded max number of decoded values (1000000)")
+}
+
+func TestUnmarshalYamlBomb(t *testing.T) {
+	var v map[interface{}]interface{}
+	data := []byte(`version: "3"
+services: &services ["lol","lol","lol","lol","lol","lol","lol","lol","lol"]
+b: &b [*services,*services,*services,*services,*services,*services,*services,*services,*services]
+c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]
+f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]
+g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
+h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
+i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]`)
+	err := Unmarshal(data, &v)
+	assert.ErrorContains(t, err, "yaml: exceeded max number of decoded values (1000000)")
+}

--- a/internal/yatee/samples/main.go
+++ b/internal/yatee/samples/main.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/docker/app/internal/yaml"
 	"github.com/docker/app/internal/yatee"
-	yaml "gopkg.in/yaml.v2"
 )
 
 func main() {

--- a/internal/yatee/yatee.go
+++ b/internal/yatee/yatee.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/docker/app/internal/yaml"
 )
 
 const (

--- a/internal/yatee/yatee_test.go
+++ b/internal/yatee/yatee_test.go
@@ -3,7 +3,7 @@ package yatee
 import (
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/docker/app/internal/yaml"
 	"gotest.tools/assert"
 )
 

--- a/vendor/gopkg.in/yaml.v2/decode.go
+++ b/vendor/gopkg.in/yaml.v2/decode.go
@@ -224,11 +224,13 @@ func (p *parser) mapping() *node {
 // Decoder, unmarshals a node into a provided value.
 
 type decoder struct {
-	doc     *node
-	aliases map[*node]bool
-	mapType reflect.Type
-	terrors []string
-	strict  bool
+	doc           *node
+	aliases       map[*node]bool
+	mapType       reflect.Type
+	terrors       []string
+	strict        bool
+	maxValues     int
+	decodedValues int
 }
 
 var (
@@ -334,6 +336,11 @@ func (d *decoder) unmarshal(n *node, out reflect.Value) (good bool) {
 		good = d.sequence(n, out)
 	default:
 		panic("internal error: unknown node kind: " + strconv.Itoa(n.kind))
+	}
+	d.decodedValues++
+	if d.maxValues != 0 && d.decodedValues > d.maxValues {
+		good = false
+		failf("exceeded max number of decoded values (%d)", d.maxValues)
 	}
 	return good
 }

--- a/vendor/gopkg.in/yaml.v2/yaml.go
+++ b/vendor/gopkg.in/yaml.v2/yaml.go
@@ -89,26 +89,45 @@ func UnmarshalStrict(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, true)
 }
 
+// DecoderOption is an option to apply to modyfy a decoder's behavior
+type DecoderOption func(d *decoder)
+
+// WithStrict is a decoder option specifying if decoding should be strict
+func WithStrict(strict bool) DecoderOption {
+	return func(d *decoder) {
+		d.strict = strict
+	}
+}
+
+// WithLimitDecodedValuesCount limits the number of values decoded
+// This is usefull when parsing potentially malicious documents
+func WithLimitDecodedValuesCount(maxValues int) DecoderOption {
+	return func(d *decoder) {
+		d.maxValues = maxValues
+	}
+}
+
 // A Decorder reads and decodes YAML values from an input stream.
 type Decoder struct {
-	strict bool
-	parser *parser
+	options []DecoderOption
+	parser  *parser
 }
 
 // NewDecoder returns a new decoder that reads from r.
 //
 // The decoder introduces its own buffering and may read
 // data from r beyond the YAML values requested.
-func NewDecoder(r io.Reader) *Decoder {
+func NewDecoder(r io.Reader, opts ...DecoderOption) *Decoder {
 	return &Decoder{
-		parser: newParserFromReader(r),
+		parser:  newParserFromReader(r),
+		options: opts,
 	}
 }
 
 // SetStrict sets whether strict decoding behaviour is enabled when
 // decoding items in the data (see UnmarshalStrict). By default, decoding is not strict.
 func (dec *Decoder) SetStrict(strict bool) {
-	dec.strict = strict
+	dec.options = append(dec.options, WithStrict(strict))
 }
 
 // Decode reads the next YAML-encoded value from its input
@@ -117,7 +136,10 @@ func (dec *Decoder) SetStrict(strict bool) {
 // See the documentation for Unmarshal for details about the
 // conversion of YAML into a Go value.
 func (dec *Decoder) Decode(v interface{}) (err error) {
-	d := newDecoder(dec.strict)
+	d := newDecoder(false)
+	for _, o := range dec.options {
+		o(d)
+	}
 	defer handleErr(&err)
 	node := dec.parser.parse()
 	if node == nil {


### PR DESCRIPTION
- uses simon's fork of yaml.v2 to be protected against fork bomb
- create a `yaml` internal package that sets the correct options

Signed-off-by: Vincent Demeester <vincent@sbr.pm>