### PR TITLE
Allow user to configure repo name with save and push commands

### DIFF
--- a/cmd/docker-app/push.go
+++ b/cmd/docker-app/push.go
@@ -11,6 +11,7 @@ import (
 type pushOptions struct {
 	namespace string
 	tag       string
+	repo      string
 }
 
 func pushCmd() *cobra.Command {
@@ -25,7 +26,7 @@ func pushCmd() *cobra.Command {
 				return err
 			}
 			defer app.Cleanup()
-			dgst, err := packager.Push(app, opts.namespace, opts.tag)
+			dgst, err := packager.Push(app, opts.namespace, opts.tag, opts.repo)
 			if err == nil {
 				fmt.Println(dgst)
 			}
@@ -34,5 +35,6 @@ func pushCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.namespace, "namespace", "", "Namespace to use (default: namespace in metadata)")
 	cmd.Flags().StringVarP(&opts.tag, "tag", "t", "", "Tag to use (default: version in metadata)")
+	cmd.Flags().StringVar(&opts.repo, "repo", "", "Name of the remote repository (default: <app-name>.dockerapp)")
 	return cmd
 }

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -283,6 +283,12 @@ func testImage(registry string) func(*testing.T) {
 		dir := fs.NewDir(t, "save-prepare-build", fs.WithFile("my.dockerapp", singleFileApp))
 		defer dir.Remove()
 		icmd.RunCommand(dockerApp, "push", "--namespace", registry+"/myuser", dir.Join("my.dockerapp")).Assert(t, icmd.Success)
+
+		icmd.RunCommand(dockerApp, "push", "-t", "marshmallows", "--namespace", registry+"/rainbows", "--repo", "unicorns", "render/envvariables").Assert(t, icmd.Success)
+		AssertCommand(t, "docker", "image", "rm", registry+"/rainbows/unicorns:marshmallows")
+		AssertCommandOutput(t, "image-inspect-labels.golden", "docker", "inspect", "-f", "{{.Config.Labels.maintainers}}", registry+"/rainbows/unicorns:marshmallows")
+		icmd.RunCommand(dockerApp, "inspect", registry+"/rainbows/unicorns:marshmallows").Assert(t, icmd.Success)
+		AssertCommand(t, dockerApp, "inspect", registry+"/rainbows/unicorns")
 	}
 }
 

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -284,11 +284,9 @@ func testImage(registry string) func(*testing.T) {
 		defer dir.Remove()
 		icmd.RunCommand(dockerApp, "push", "--namespace", registry+"/myuser", dir.Join("my.dockerapp")).Assert(t, icmd.Success)
 
-		icmd.RunCommand(dockerApp, "push", "-t", "marshmallows", "--namespace", registry+"/rainbows", "--repo", "unicorns", "render/envvariables").Assert(t, icmd.Success)
-		AssertCommand(t, "docker", "image", "rm", registry+"/rainbows/unicorns:marshmallows")
-		AssertCommandOutput(t, "image-inspect-labels.golden", "docker", "inspect", "-f", "{{.Config.Labels.maintainers}}", registry+"/rainbows/unicorns:marshmallows")
+		// push with custom repo name
+		icmd.RunCommand(dockerApp, "push", "-t", "marshmallows", "--namespace", registry+"/rainbows", "--repo", "unicorns", "testdata/render/envvariables/my.dockerapp").Assert(t, icmd.Success)
 		icmd.RunCommand(dockerApp, "inspect", registry+"/rainbows/unicorns:marshmallows").Assert(t, icmd.Success)
-		AssertCommand(t, dockerApp, "inspect", registry+"/rainbows/unicorns")
 	}
 }
 

--- a/internal/packager/registry.go
+++ b/internal/packager/registry.go
@@ -66,7 +66,7 @@ func Pull(repotag string, outputDir string) (string, error) {
 }
 
 // Push pushes an app to a registry. Returns the image digest.
-func Push(app *types.App, namespace, tag string) (string, error) {
+func Push(app *types.App, namespace, tag, repo string) (string, error) {
 	payload := make(map[string]string)
 	payload[internal.MetadataFileName] = string(app.MetadataRaw())
 	payload[internal.ComposeFileName] = string(app.Composes()[0])
@@ -80,9 +80,12 @@ func Push(app *types.App, namespace, tag string) (string, error) {
 			tag = metadata.Version
 		}
 	}
+	if repo == "" {
+		repo = internal.AppNameFromDir(app.Name) + internal.AppExtension
+	}
 	if namespace != "" && namespace[len(namespace)-1] != '/' {
 		namespace += "/"
 	}
-	imageName := namespace + internal.AppNameFromDir(app.Name) + internal.AppExtension + ":" + tag
+	imageName := namespace + repo + ":" + tag
 	return resto.PushConfigMulti(context.Background(), payload, imageName, resto.RegistryOptions{}, nil)
 }


### PR DESCRIPTION
**- What I did**

Added a `--repo` flag to `save` and `push` subcommands.
This includes a change to `packager.extractImage` to allow app images to forgo the `.dockerapp` suffix.
Fixes #320

**- How I did it**

Added new flag definition and slightly modified relevant `internal/packager/registry` methods.

**- How to verify it**

See e2e test update

**- Description for the changelog**

Added the ability to configure target repository in `save` and `push` commands with the `--repo` flag.


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1086876/44490794-27145200-a614-11e8-9b66-f57a3fd8848a.png)
