### PR TITLE
Add support for loading URLs.

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -285,6 +285,12 @@ func TestSplitMergeBinary(t *testing.T) {
 	assertCommand(t, dockerApp, "split", "split")
 }
 
+func TestURLBinary(t *testing.T) {
+	url := "https://raw.githubusercontent.com/docker/app/v0.4.1/examples/hello-world/hello-world.dockerapp"
+	dockerApp, _ := getDockerAppBinary(t)
+	assertCommandOutput(t, "helloworld-inspect.golden", dockerApp, "inspect", url)
+}
+
 func TestImageBinary(t *testing.T) {
 	dockerApp, _ := getDockerAppBinary(t)
 	r := startRegistry(t)

--- a/e2e/testdata/helloworld-inspect.golden
+++ b/e2e/testdata/helloworld-inspect.golden
@@ -1,0 +1,9 @@
+hello-world 0.1.0
+Maintained by: user <user@email.com>
+
+Hello, World!
+
+Setting Default
+------- -------
+port    8080
+text    Hello, World!

--- a/internal/packager/extract.go
+++ b/internal/packager/extract.go
@@ -3,6 +3,7 @@ package packager
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -104,6 +105,11 @@ func Extract(name string, ops ...func(*types.App) error) (*types.App, error) {
 	appname := internal.DirNameFromAppName(name)
 	s, err := os.Stat(appname)
 	if err != nil {
+		// URL or docker image
+		u, err := url.Parse(name)
+		if err == nil && (u.Scheme == "http" || u.Scheme == "https") {
+			return loader.LoadFromURL(name, ops...)
+		}
 		// look for a docker image
 		return extractImage(name, ops...)
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,21 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/pkg/errors"
 )
+
+// LoadFromURL loads a docker app from an URL that should return a single-file app.
+func LoadFromURL(url string, ops ...func(*types.App) error) (*types.App, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to download "+url)
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if resp.StatusCode != 200 {
+		return nil, errors.Errorf("failed to download %s: %s", url, resp.Status)
+	}
+	return LoadFromSingleFile(url, resp.Body, ops...)
+}
 
 // LoadFromSingleFile loads a docker app from a single-file format (as a reader)
 func LoadFromSingleFile(path string, r io.Reader, ops ...func(*types.App) error) (*types.App, error) {


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add support from loading docker-app from an URL (http or https).

**- How I did it**

Hook Extract(), add a loader.LoadFromURL.

**- How to verify it**

`docker-app render someURL`

**- Description for the changelog**

- Applications can be loaded from an http or https URL.

