### PR TITLE
Add a JSON format option to docker-app render

### DIFF
--- a/cmd/docker-app/render.go
+++ b/cmd/docker-app/render.go
@@ -48,13 +48,13 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 				return err
 			}
 			if renderOutput == "-" {
-				fmt.Fprint(dockerCli.Out(), string(res))
+				fmt.Fprint(dockerCli.Out(), res)
 			} else {
 				f, err := os.Create(renderOutput)
 				if err != nil {
 					return err
 				}
-				fmt.Fprint(f, string(res))
+				fmt.Fprint(f, res)
 			}
 			return nil
 		},
@@ -69,6 +69,6 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&renderSettingsFile, "settings-files", "f", []string{}, "Override settings files")
 	cmd.Flags().StringArrayVarP(&renderEnv, "set", "s", []string{}, "Override settings values")
 	cmd.Flags().StringVarP(&renderOutput, "output", "o", "-", "Output file")
-	cmd.Flags().StringVarP(&formatDriver, "presenter", "p", "yaml", "Configure the output format")
+	cmd.Flags().StringVarP(&formatDriver, "presenter", "p", "yaml", "Configure the output format (yaml|json)")
 	return cmd
 }

--- a/cmd/docker-app/render.go
+++ b/cmd/docker-app/render.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/formatter"
 	"github.com/docker/app/internal/packager"
-	"github.com/docker/app/internal/yaml"
 	"github.com/docker/app/render"
 	"github.com/docker/app/types"
 	"github.com/docker/cli/cli"
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	formatDriver       string
 	renderComposeFiles []string
 	renderSettingsFile []string
 	renderEnv          []string
@@ -42,7 +43,7 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			res, err := yaml.Marshal(rendered)
+			res, err := formatter.Format(rendered, formatDriver)
 			if err != nil {
 				return err
 			}
@@ -68,5 +69,6 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&renderSettingsFile, "settings-files", "f", []string{}, "Override settings files")
 	cmd.Flags().StringArrayVarP(&renderEnv, "set", "s", []string{}, "Override settings values")
 	cmd.Flags().StringVarP(&renderOutput, "output", "o", "-", "Output file")
+	cmd.Flags().StringVarP(&formatDriver, "presenter", "p", "yaml", "Configure the output format")
 	return cmd
 }

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -76,6 +76,15 @@ func testRenderApp(appPath string, env ...string) func(*testing.T) {
 	}
 }
 
+func TestRenderFormatters(t *testing.T) {
+	appPath := filepath.Join("testdata", "fork", "simple.dockerapp")
+	result := icmd.RunCommand(dockerApp, "render", "-p", "json", appPath).Assert(t, icmd.Success)
+	assert.Assert(t, golden.String(result.Stdout(), "expected-json-render.golden"))
+
+	result = icmd.RunCommand(dockerApp, "render", "-p", "yaml", appPath).Assert(t, icmd.Success)
+	assert.Assert(t, golden.String(result.Stdout(), "expected-yaml-render.golden"))
+}
+
 func TestInit(t *testing.T) {
 	composeData := `version: "3.2"
 services:

--- a/e2e/testdata/expected-json-render.golden
+++ b/e2e/testdata/expected-json-render.golden
@@ -1,0 +1,78 @@
+{
+  "networks": {
+    "back": {
+      "ipam": {},
+      "external": false
+    },
+    "front": {
+      "ipam": {},
+      "external": false
+    }
+  },
+  "services": {
+    "api": {
+      "build": {},
+      "credential_spec": {},
+      "deploy": {
+        "resources": {},
+        "placement": {}
+      },
+      "image": "python:3.6",
+      "networks": {
+        "back": null,
+        "front": {
+          "aliases": [
+            "corp.app.api.com",
+            "coolapp.com"
+          ]
+        }
+      }
+    },
+    "db": {
+      "build": {},
+      "credential_spec": {},
+      "deploy": {
+        "resources": {},
+        "placement": {}
+      },
+      "image": "postgres:9.3",
+      "networks": {
+        "back": null
+      }
+    },
+    "web": {
+      "build": {},
+      "credential_spec": {},
+      "deploy": {
+        "resources": {},
+        "placement": {}
+      },
+      "image": "nginx:latest",
+      "networks": {
+        "front": null
+      },
+      "ports": [
+        {
+          "mode": "ingress",
+          "target": 80,
+          "published": 8082,
+          "protocol": "tcp"
+        }
+      ],
+      "volumes": [
+        {
+          "type": "volume",
+          "source": "static",
+          "target": "/opt/data/static"
+        }
+      ]
+    }
+  },
+  "version": "3.6",
+  "volumes": {
+    "static": {
+      "name": "corp/web-static-data",
+      "external": true
+    }
+  }
+}

--- a/e2e/testdata/expected-yaml-render.golden
+++ b/e2e/testdata/expected-yaml-render.golden
@@ -1,0 +1,34 @@
+version: "3.6"
+services:
+  api:
+    image: python:3.6
+    networks:
+      back: null
+      front:
+        aliases:
+        - corp.app.api.com
+        - coolapp.com
+  db:
+    image: postgres:9.3
+    networks:
+      back: null
+  web:
+    image: nginx:latest
+    networks:
+      front: null
+    ports:
+    - mode: ingress
+      target: 80
+      published: 8082
+      protocol: tcp
+    volumes:
+    - type: volume
+      source: static
+      target: /opt/data/static
+networks:
+  back: {}
+  front: {}
+volumes:
+  static:
+    name: corp/web-static-data
+    external: true

--- a/internal/formatter/driver/driver.go
+++ b/internal/formatter/driver/driver.go
@@ -1,11 +1,11 @@
 package driver
 
 import (
-    composetypes "github.com/docker/cli/cli/compose/types"
+	composetypes "github.com/docker/cli/cli/compose/types"
 )
 
 // Driver is the interface that must be implemented by a formatter driver.
 type Driver interface {
-    // Format executes the formatter on the source config
-    Format(config *composetypes.Config) (string, error)
+	// Format executes the formatter on the source config
+	Format(config *composetypes.Config) (string, error)
 }

--- a/internal/formatter/driver/driver.go
+++ b/internal/formatter/driver/driver.go
@@ -1,0 +1,11 @@
+package driver
+
+import (
+    composetypes "github.com/docker/cli/cli/compose/types"
+)
+
+// Driver is the interface that must be implemented by a formatter driver.
+type Driver interface {
+    // Format executes the formatter on the source config
+    Format(config *composetypes.Config) (string, error)
+}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -1,0 +1,58 @@
+package formatter
+
+import (
+    "sort"
+    "sync"
+
+    "github.com/docker/app/internal/formatter/driver"
+    composetypes "github.com/docker/cli/cli/compose/types"
+    "github.com/pkg/errors"
+)
+
+var (
+    driversMu sync.RWMutex
+    drivers   = map[string]driver.Driver{}
+)
+
+// Register makes a formatter available by the provided name.
+// If Register is called twice with the same name or if driver is nil,
+// it panics.
+func Register(name string, driver driver.Driver) {
+    driversMu.Lock()
+    defer driversMu.Unlock()
+    if driver == nil {
+        panic("formatter: Register driver is nil")
+    }
+    if _, dup := drivers[name]; dup {
+        panic("formatter: Register called twice for driver " + name)
+    }
+    drivers[name] = driver
+}
+
+// Format uses the specified formatter to create a printable output.
+// If the formatter is not registered, this errors out.
+func Format(config *composetypes.Config, formatter string) (string, error) {
+    driversMu.RLock()
+    d, present := drivers[formatter]
+    driversMu.RUnlock()
+    if !present {
+        return "", errors.Errorf("unknown formatter %s", formatter)
+    }
+    s, err := d.Format(config)
+    if err != nil {
+        return "", err
+    }
+    return s, nil
+}
+
+// Drivers returns a sorted list of the names of the registered drivers.
+func Drivers() []string {
+    list := []string{}
+    driversMu.RLock()
+    for name := range drivers {
+        list = append(list, name)
+    }
+    driversMu.RUnlock()
+    sort.Strings(list)
+    return list
+}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -1,58 +1,58 @@
 package formatter
 
 import (
-    "sort"
-    "sync"
+	"sort"
+	"sync"
 
-    "github.com/docker/app/internal/formatter/driver"
-    composetypes "github.com/docker/cli/cli/compose/types"
-    "github.com/pkg/errors"
+	"github.com/docker/app/internal/formatter/driver"
+	composetypes "github.com/docker/cli/cli/compose/types"
+	"github.com/pkg/errors"
 )
 
 var (
-    driversMu sync.RWMutex
-    drivers   = map[string]driver.Driver{}
+	driversMu sync.RWMutex
+	drivers   = map[string]driver.Driver{}
 )
 
 // Register makes a formatter available by the provided name.
 // If Register is called twice with the same name or if driver is nil,
 // it panics.
 func Register(name string, driver driver.Driver) {
-    driversMu.Lock()
-    defer driversMu.Unlock()
-    if driver == nil {
-        panic("formatter: Register driver is nil")
-    }
-    if _, dup := drivers[name]; dup {
-        panic("formatter: Register called twice for driver " + name)
-    }
-    drivers[name] = driver
+	driversMu.Lock()
+	defer driversMu.Unlock()
+	if driver == nil {
+		panic("formatter: Register driver is nil")
+	}
+	if _, dup := drivers[name]; dup {
+		panic("formatter: Register called twice for driver " + name)
+	}
+	drivers[name] = driver
 }
 
 // Format uses the specified formatter to create a printable output.
 // If the formatter is not registered, this errors out.
 func Format(config *composetypes.Config, formatter string) (string, error) {
-    driversMu.RLock()
-    d, present := drivers[formatter]
-    driversMu.RUnlock()
-    if !present {
-        return "", errors.Errorf("unknown formatter %s", formatter)
-    }
-    s, err := d.Format(config)
-    if err != nil {
-        return "", err
-    }
-    return s, nil
+	driversMu.RLock()
+	d, present := drivers[formatter]
+	driversMu.RUnlock()
+	if !present {
+		return "", errors.Errorf("unknown presenter %q", formatter)
+	}
+	s, err := d.Format(config)
+	if err != nil {
+		return "", err
+	}
+	return s, nil
 }
 
 // Drivers returns a sorted list of the names of the registered drivers.
 func Drivers() []string {
-    list := []string{}
-    driversMu.RLock()
-    for name := range drivers {
-        list = append(list, name)
-    }
-    driversMu.RUnlock()
-    sort.Strings(list)
-    return list
+	list := []string{}
+	driversMu.RLock()
+	for name := range drivers {
+		list = append(list, name)
+	}
+	driversMu.RUnlock()
+	sort.Strings(list)
+	return list
 }

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -1,0 +1,96 @@
+package formatter
+
+import (
+    "testing"
+
+    "github.com/docker/app/internal/formatter/driver"
+    composetypes "github.com/docker/cli/cli/compose/types"
+    "github.com/pkg/errors"
+    "gotest.tools/assert"
+    is "gotest.tools/assert/cmp"
+)
+
+type fakeDriver struct{}
+
+func (d *fakeDriver) Format(config *composetypes.Config) (string, error) {
+    return "fake", nil
+}
+
+type fakeErrorDriver struct{}
+
+func (d *fakeErrorDriver) Format(config *composetypes.Config) (string, error) {
+    return "", errors.New("error in driver")
+}
+
+func TestRegisterNilPanics(t *testing.T) {
+    defer func() {
+        if recover() == nil {
+            t.Errorf("The code did not panic")
+        }
+        resetDrivers()
+    }()
+    Register("foo", nil)
+}
+
+func TestRegisterDuplicatePanics(t *testing.T) {
+    defer func() {
+        if recover() == nil {
+            t.Errorf("The code did not panic")
+        }
+        resetDrivers()
+    }()
+    Register("bar", &fakeDriver{})
+    Register("bar", &fakeDriver{})
+}
+
+func TestRegister(t *testing.T) {
+    d := &fakeDriver{}
+    Register("baz", d)
+    defer resetDrivers()
+    assert.Check(t, is.DeepEqual(drivers, map[string]driver.Driver{"baz": d}))
+}
+
+func TestNoDrivers(t *testing.T) {
+    assert.Check(t, is.DeepEqual(Drivers(), []string{}))
+}
+
+func TestRegisteredDrivers(t *testing.T) {
+    Register("foo", &fakeDriver{})
+    Register("bar", &fakeDriver{})
+    defer resetDrivers()
+    assert.Check(t, is.DeepEqual(Drivers(), []string{"bar", "foo"}))
+}
+
+func TestFormatNonExistentDriver(t *testing.T) {
+    _, err := Format(&composetypes.Config{}, "toto")
+    assert.Check(t, err != nil)
+    assert.Check(t, is.ErrorContains(err, "unknown formatter toto"))
+}
+
+func TestFormatErrorDriver(t *testing.T) {
+    Register("err", &fakeErrorDriver{})
+    defer resetDrivers()
+    _, err := Format(&composetypes.Config{}, "err")
+    assert.Check(t, err != nil)
+    assert.Check(t, is.ErrorContains(err, "error in driver"))
+}
+
+func TestFormatNone(t *testing.T) {
+    Register("fake", &fakeDriver{})
+    defer resetDrivers()
+    _, err := Format(&composetypes.Config{}, "none")
+    assert.Check(t, err != nil)
+    assert.Check(t, is.ErrorContains(err, "unknown formatter none"))
+}
+
+func TestFormat(t *testing.T) {
+    Register("fake", &fakeDriver{})
+    defer resetDrivers()
+    s, err := Format(&composetypes.Config{}, "fake")
+    assert.NilError(t, err)
+    assert.Check(t, is.Equal(s, "fake"))
+}
+
+func resetDrivers() {
+    drivers = map[string]driver.Driver{}
+}

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -1,96 +1,96 @@
 package formatter
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/docker/app/internal/formatter/driver"
-    composetypes "github.com/docker/cli/cli/compose/types"
-    "github.com/pkg/errors"
-    "gotest.tools/assert"
-    is "gotest.tools/assert/cmp"
+	"github.com/docker/app/internal/formatter/driver"
+	composetypes "github.com/docker/cli/cli/compose/types"
+	"github.com/pkg/errors"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 )
 
 type fakeDriver struct{}
 
 func (d *fakeDriver) Format(config *composetypes.Config) (string, error) {
-    return "fake", nil
+	return "fake", nil
 }
 
 type fakeErrorDriver struct{}
 
 func (d *fakeErrorDriver) Format(config *composetypes.Config) (string, error) {
-    return "", errors.New("error in driver")
+	return "", errors.New("error in driver")
 }
 
 func TestRegisterNilPanics(t *testing.T) {
-    defer func() {
-        if recover() == nil {
-            t.Errorf("The code did not panic")
-        }
-        resetDrivers()
-    }()
-    Register("foo", nil)
+	defer func() {
+		if recover() == nil {
+			t.Errorf("The code did not panic")
+		}
+		resetDrivers()
+	}()
+	Register("foo", nil)
 }
 
 func TestRegisterDuplicatePanics(t *testing.T) {
-    defer func() {
-        if recover() == nil {
-            t.Errorf("The code did not panic")
-        }
-        resetDrivers()
-    }()
-    Register("bar", &fakeDriver{})
-    Register("bar", &fakeDriver{})
+	defer func() {
+		if recover() == nil {
+			t.Errorf("The code did not panic")
+		}
+		resetDrivers()
+	}()
+	Register("bar", &fakeDriver{})
+	Register("bar", &fakeDriver{})
 }
 
 func TestRegister(t *testing.T) {
-    d := &fakeDriver{}
-    Register("baz", d)
-    defer resetDrivers()
-    assert.Check(t, is.DeepEqual(drivers, map[string]driver.Driver{"baz": d}))
+	d := &fakeDriver{}
+	Register("baz", d)
+	defer resetDrivers()
+	assert.Check(t, is.DeepEqual(drivers, map[string]driver.Driver{"baz": d}))
 }
 
 func TestNoDrivers(t *testing.T) {
-    assert.Check(t, is.DeepEqual(Drivers(), []string{}))
+	assert.Check(t, is.DeepEqual(Drivers(), []string{}))
 }
 
 func TestRegisteredDrivers(t *testing.T) {
-    Register("foo", &fakeDriver{})
-    Register("bar", &fakeDriver{})
-    defer resetDrivers()
-    assert.Check(t, is.DeepEqual(Drivers(), []string{"bar", "foo"}))
+	Register("foo", &fakeDriver{})
+	Register("bar", &fakeDriver{})
+	defer resetDrivers()
+	assert.Check(t, is.DeepEqual(Drivers(), []string{"bar", "foo"}))
 }
 
 func TestFormatNonExistentDriver(t *testing.T) {
-    _, err := Format(&composetypes.Config{}, "toto")
-    assert.Check(t, err != nil)
-    assert.Check(t, is.ErrorContains(err, "unknown formatter toto"))
+	_, err := Format(&composetypes.Config{}, "toto")
+	assert.Check(t, err != nil)
+	assert.Check(t, is.ErrorContains(err, `unknown presenter "toto"`))
 }
 
 func TestFormatErrorDriver(t *testing.T) {
-    Register("err", &fakeErrorDriver{})
-    defer resetDrivers()
-    _, err := Format(&composetypes.Config{}, "err")
-    assert.Check(t, err != nil)
-    assert.Check(t, is.ErrorContains(err, "error in driver"))
+	Register("err", &fakeErrorDriver{})
+	defer resetDrivers()
+	_, err := Format(&composetypes.Config{}, "err")
+	assert.Check(t, err != nil)
+	assert.Check(t, is.ErrorContains(err, "error in driver"))
 }
 
 func TestFormatNone(t *testing.T) {
-    Register("fake", &fakeDriver{})
-    defer resetDrivers()
-    _, err := Format(&composetypes.Config{}, "none")
-    assert.Check(t, err != nil)
-    assert.Check(t, is.ErrorContains(err, "unknown formatter none"))
+	Register("fake", &fakeDriver{})
+	defer resetDrivers()
+	_, err := Format(&composetypes.Config{}, "none")
+	assert.Check(t, err != nil)
+	assert.Check(t, is.ErrorContains(err, `unknown presenter "none"`))
 }
 
 func TestFormat(t *testing.T) {
-    Register("fake", &fakeDriver{})
-    defer resetDrivers()
-    s, err := Format(&composetypes.Config{}, "fake")
-    assert.NilError(t, err)
-    assert.Check(t, is.Equal(s, "fake"))
+	Register("fake", &fakeDriver{})
+	defer resetDrivers()
+	s, err := Format(&composetypes.Config{}, "fake")
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(s, "fake"))
 }
 
 func resetDrivers() {
-    drivers = map[string]driver.Driver{}
+	drivers = map[string]driver.Driver{}
 }

--- a/internal/formatter/json/doc.go
+++ b/internal/formatter/json/doc.go
@@ -1,0 +1,1 @@
+package json

--- a/internal/formatter/json/driver.go
+++ b/internal/formatter/json/driver.go
@@ -1,15 +1,15 @@
 package json
 
 import (
-    "encoding/json"
+	"encoding/json"
 
-    "github.com/docker/app/internal/formatter"
-    composetypes "github.com/docker/cli/cli/compose/types"
-    "github.com/pkg/errors"
+	"github.com/docker/app/internal/formatter"
+	composetypes "github.com/docker/cli/cli/compose/types"
+	"github.com/pkg/errors"
 )
 
 func init() {
-    formatter.Register("json", &Driver{})
+	formatter.Register("json", &Driver{})
 }
 
 // Driver is the json implementation of formatter drivers.
@@ -17,9 +17,9 @@ type Driver struct{}
 
 // Format creates a JSON document from the source config.
 func (d *Driver) Format(config *composetypes.Config) (string, error) {
-    result, err := json.MarshalIndent(config, "", "  ")
-    if err != nil {
-        return "", errors.Wrap(err, "failed to produce json structure")
-    }
-    return string(result) + "\n", nil
+	result, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to produce json structure")
+	}
+	return string(result) + "\n", nil
 }

--- a/internal/formatter/json/driver.go
+++ b/internal/formatter/json/driver.go
@@ -1,0 +1,25 @@
+package json
+
+import (
+    "encoding/json"
+
+    "github.com/docker/app/internal/formatter"
+    composetypes "github.com/docker/cli/cli/compose/types"
+    "github.com/pkg/errors"
+)
+
+func init() {
+    formatter.Register("json", &Driver{})
+}
+
+// Driver is the json implementation of formatter drivers.
+type Driver struct{}
+
+// Format creates a JSON document from the source config.
+func (d *Driver) Format(config *composetypes.Config) (string, error) {
+    result, err := json.MarshalIndent(config, "", "  ")
+    if err != nil {
+        return "", errors.Wrap(err, "failed to produce json structure")
+    }
+    return string(result) + "\n", nil
+}

--- a/internal/formatter/yaml/doc.go
+++ b/internal/formatter/yaml/doc.go
@@ -1,0 +1,1 @@
+package yaml

--- a/internal/formatter/yaml/driver.go
+++ b/internal/formatter/yaml/driver.go
@@ -1,14 +1,14 @@
 package yaml
 
 import (
-    "github.com/docker/app/internal/formatter"
-    "github.com/docker/app/internal/yaml"
-    composetypes "github.com/docker/cli/cli/compose/types"
-    "github.com/pkg/errors"
+	"github.com/docker/app/internal/formatter"
+	"github.com/docker/app/internal/yaml"
+	composetypes "github.com/docker/cli/cli/compose/types"
+	"github.com/pkg/errors"
 )
 
 func init() {
-    formatter.Register("yaml", &Driver{})
+	formatter.Register("yaml", &Driver{})
 }
 
 // Driver is the yaml implementation of formatter drivers.
@@ -16,9 +16,9 @@ type Driver struct{}
 
 // Format creates a YAML document from the source config.
 func (d *Driver) Format(config *composetypes.Config) (string, error) {
-    result, err := yaml.Marshal(config)
-    if err != nil {
-        return "", errors.Wrap(err, "failed to produce yaml structure")
-    }
-    return string(result), nil
+	result, err := yaml.Marshal(config)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to produce yaml structure")
+	}
+	return string(result), nil
 }

--- a/internal/formatter/yaml/driver.go
+++ b/internal/formatter/yaml/driver.go
@@ -1,0 +1,24 @@
+package yaml
+
+import (
+    "github.com/docker/app/internal/formatter"
+    "github.com/docker/app/internal/yaml"
+    composetypes "github.com/docker/cli/cli/compose/types"
+    "github.com/pkg/errors"
+)
+
+func init() {
+    formatter.Register("yaml", &Driver{})
+}
+
+// Driver is the yaml implementation of formatter drivers.
+type Driver struct{}
+
+// Format creates a YAML document from the source config.
+func (d *Driver) Format(config *composetypes.Config) (string, error) {
+    result, err := yaml.Marshal(config)
+    if err != nil {
+        return "", errors.Wrap(err, "failed to produce yaml structure")
+    }
+    return string(result), nil
+}

--- a/render/render.go
+++ b/render/render.go
@@ -22,6 +22,11 @@ import (
 	_ "github.com/docker/app/internal/renderer/mustache"
 	// Register yatee renderer
 	_ "github.com/docker/app/internal/renderer/yatee"
+
+	// Register json formatter
+	_ "github.com/docker/app/internal/formatter/json"
+	// Register yaml formatter
+	_ "github.com/docker/app/internal/formatter/yaml"
 )
 
 var (


### PR DESCRIPTION
**- What I did**

Added a JSON format option to docker-app render, with extensible design for possible additional output formats in the future.
```sh
$ docker-app render --formatter json appname
```

**- How I did it**

- Added `internal/formatter` package that mimics the behavior of the `internal/renderer` package, allowing modular plugins to be added in the future
- The formatter driver interface declares the `Apply()` method that takes a structured Compose config as input and outputs a formatted string.
- Formatter for JSON and YAML have been implemented

**- How to verify it**

e2e tests and unit tests have been added to verify behavior.

**- Description for the changelog**

- Added a `--formatter` flag to `docker-app render`, which supports the YAML (default) and JSON formats.

**- A picture of a cute animal (not mandatory but encouraged)**

![kitty](https://i.redd.it/cr1levi89ng11.jpg)
