### PR TITLE
Fix more case for `x-enabled` parsing failures

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -133,8 +133,10 @@ func processEnabled(config *composetypes.Config) error {
 func isEnabled(e interface{}) (bool, error) {
 	switch v := e.(type) {
 	case string:
-		v = strings.ToLower(v)
+		v = strings.ToLower(strings.TrimSpace(v))
 		switch {
+		case v == "1", v == "true":
+			return true, nil
 		case v == "", v == "0", v == "false":
 			return false, nil
 		case strings.HasPrefix(v, "!"):

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -55,7 +55,7 @@ func TestRender(t *testing.T) {
 }
 
 func TestRenderEnabledFalse(t *testing.T) {
-	for _, tc := range []interface{}{false, "false"} {
+	for _, tc := range []interface{}{false, "false", "! ${myapp.debug}"} {
 		configs := []composetypes.ConfigFile{
 			{
 				Config: map[string]interface{}{
@@ -70,7 +70,9 @@ func TestRenderEnabledFalse(t *testing.T) {
 				},
 			},
 		}
-		c, err := render(configs, map[string]string{})
+		c, err := render(configs, map[string]string{
+			"myapp.debug": "true",
+		})
 		assert.NilError(t, err)
 		assert.Check(t, is.Len(c.Services, 0))
 	}


### PR DESCRIPTION
- support `true` value
- trim spaces in case it's a string and the value has space in there

Follow-up of #361 :sweat_smile: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
