### PR TITLE
gradle: Pin version as current latest image is broken.

### DIFF
--- a/Dockerfile.gradle
+++ b/Dockerfile.gradle
@@ -1,3 +1,3 @@
-FROM gradle:jdk8
+FROM gradle:4.9-jdk8
 COPY bin/docker-app-linux /usr/local/bin/docker-app
 COPY --chown=gradle:gradle integrations/gradle .


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Pin gradle version to 4.9 as latest images (4.10) are currently broken (missing arch amd64).

