### PR TITLE
Add render test with user settings

### DIFF
--- a/render/render_test.go
+++ b/render/render_test.go
@@ -136,8 +136,7 @@ services:
 }
 
 func TestValidateBrokenComposeFile(t *testing.T) {
-	metadata := strings.NewReader(`version: "0.1"
-name: myname`)
+	metadata := strings.NewReader(validMeta)
 	brokenComposeFile := strings.NewReader(`version: "3.6"
 unknown-property: value`)
 	app := &types.App{Path: "my-app"}
@@ -151,8 +150,7 @@ unknown-property: value`)
 }
 
 func TestValidateRenderedApplication(t *testing.T) {
-	metadata := strings.NewReader(`version: "0.1"
-name: myname`)
+	metadata := strings.NewReader(validMeta)
 	composeFile := strings.NewReader(`
 version: "3.6"
 services:


### PR DESCRIPTION
**- What I did**

Added a render test for `func Render(app *types.App, env map[string]string) (*composetypes.Config, error)` with user settings.

**- How to verify it**

Run `go test ./render`

**- Description for the changelog**

N/A
