### PR TITLE
Fix rendering an app without any default settings

### DIFF
--- a/render/render_test.go
+++ b/render/render_test.go
@@ -106,12 +106,9 @@ back:
   image: wrong
 `)
 	app := &types.App{Path: "my-app"}
-	err := types.Metadata(metadata)(app)
-	assert.NilError(t, err)
-	err = types.WithComposes(composeFile)(app)
-	assert.NilError(t, err)
-	err = types.WithSettings(settings)(app)
-	assert.NilError(t, err)
+	assert.NilError(t, types.Metadata(metadata)(app))
+	assert.NilError(t, types.WithComposes(composeFile)(app))
+	assert.NilError(t, types.WithSettings(settings)(app))
 	userSettings := map[string]string{
 		"front.image": "nginx",
 		"front.port":  "4242",
@@ -132,6 +129,33 @@ services:
       target: 80
       published: 4242
       protocol: tcp
+`)
+}
+
+func TestRenderWithoutDefaultSettings(t *testing.T) {
+	metadata := strings.NewReader(validMeta)
+	composeFile := strings.NewReader(`
+version: "3.6"
+services:
+  front:
+    image: ${front.image}
+`)
+	settings := strings.NewReader("")
+	app := &types.App{Path: "my-app"}
+	assert.NilError(t, types.Metadata(metadata)(app))
+	assert.NilError(t, types.WithComposes(composeFile)(app))
+	assert.NilError(t, types.WithSettings(settings)(app))
+	userSettings := map[string]string{
+		"front.image": "nginx",
+	}
+	c, err := Render(app, userSettings)
+	assert.NilError(t, err)
+	s, err := yaml.Marshal(c)
+	assert.NilError(t, err)
+	assert.Equal(t, string(s), `version: "3.6"
+services:
+  front:
+    image: nginx
 `)
 }
 

--- a/types/settings/settings.go
+++ b/types/settings/settings.go
@@ -100,9 +100,9 @@ func assignKey(m map[string]interface{}, keys []string, value interface{}) error
 		return nil
 	}
 	if v, present := m[key]; !present {
-		m[key] = Settings{}
-	} else if _, isMap := v.(Settings); !isMap {
+		m[key] = map[string]interface{}{}
+	} else if _, isMap := v.(map[string]interface{}); !isMap {
 		return errors.Errorf("key %s already present and not a map (%T)", key, v)
 	}
-	return assignKey(m[key].(Settings), ks, value)
+	return assignKey(m[key].(map[string]interface{}), ks, value)
 }

--- a/types/settings/settings_test.go
+++ b/types/settings/settings_test.go
@@ -47,12 +47,12 @@ func TestFromFlatten(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(s, Settings{
 		"foo": "bar",
-		"bar": Settings{
+		"bar": map[string]interface{}{
 			"baz":  "banana",
 			"port": 80,
 		},
-		"baz": Settings{
-			"biz": Settings{
+		"baz": map[string]interface{}{
+			"biz": map[string]interface{}{
 				"a": 1,
 				"b": 2,
 			},


### PR DESCRIPTION
**- How I did it**
It fixes the settings.FromFlatten function, which was returning recursive Settings, instead of map[string]interface{}. The render worked if the default settings were overridden, which are already with the good type (map[string]interface{}).

**- How to verify it**
Create an app, add some variables in the compose file, no default settings and try to render it, filling the variables using the command line. It should fail without this patch.

**- Description for the changelog**
* Fix rendering an app without any default settings

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/45036726-8b480480-b05d-11e8-87f6-12797c877025.png)
