### PR TITLE
Add compose file summary to the inspect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Commands:
   fork        Create a fork of an existing application to be modified
   helm        Generate a Helm chart
   init        Start building a Docker application
-  inspect     Shows metadata and settings for a given application
+  inspect     Shows metadata, settings and a summary of the compose file for a given application
   merge       Merge a multi-file application into a single file
   push        Push the application to a registry
   render      Render the Compose file for the application

--- a/cmd/docker-app/inspect.go
+++ b/cmd/docker-app/inspect.go
@@ -19,7 +19,7 @@ var (
 func inspectCmd(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inspect [<app-name>] [-s key=value...] [-f settings-file...]",
-		Short: "Shows metadata, settings and summary of compose file for a given application",
+		Short: "Shows metadata, settings and a summary of the compose file for a given application",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app, err := packager.Extract(firstOrEmpty(args),

--- a/cmd/docker-app/inspect.go
+++ b/cmd/docker-app/inspect.go
@@ -3,24 +3,37 @@ package main
 import (
 	"github.com/docker/app/internal/inspect"
 	"github.com/docker/app/internal/packager"
+	"github.com/docker/app/types"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	cliopts "github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
+)
+
+var (
+	inspectSettingsFile []string
+	inspectEnv          []string
 )
 
 // inspectCmd represents the inspect command
 func inspectCmd(dockerCli command.Cli) *cobra.Command {
-	return &cobra.Command{
-		Use:   "inspect [<app-name>]",
-		Short: "Shows metadata and settings for a given application",
+	cmd := &cobra.Command{
+		Use:   "inspect [<app-name>] [-s key=value...] [-f settings-file...]",
+		Short: "Shows metadata, settings and summary of compose file for a given application",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			app, err := packager.Extract(firstOrEmpty(args))
+			app, err := packager.Extract(firstOrEmpty(args),
+				types.WithSettingsFiles(inspectSettingsFile...),
+			)
 			if err != nil {
 				return err
 			}
 			defer app.Cleanup()
-			return inspect.Inspect(dockerCli.Out(), app)
+			argSettings := cliopts.ConvertKVStringsToMap(inspectEnv)
+			return inspect.Inspect(dockerCli.Out(), app, argSettings)
 		},
 	}
+	cmd.Flags().StringArrayVarP(&inspectSettingsFile, "settings-files", "f", []string{}, "Override settings files")
+	cmd.Flags().StringArrayVarP(&inspectEnv, "set", "s", []string{}, "Override settings values")
+	return cmd
 }

--- a/e2e/testdata/envvariables-inspect.golden
+++ b/e2e/testdata/envvariables-inspect.golden
@@ -1,8 +1,14 @@
 myapp 0.1.0
+
 Maintained by: bearclaw <bearclaw@bearclaw.bearclaw>
 
-Setting              Default
--------              -------
+Service Replicas Ports Image
+------- -------- ----- -----
+test    1              alpine:latest
+
+Setting              Value
+-------              -----
 myapp.alpine_version latest
 myapp.command1       cat
 myapp.command2       foo
+myapp.command3       bar

--- a/e2e/testdata/envvariables-inspect.golden
+++ b/e2e/testdata/envvariables-inspect.golden
@@ -6,8 +6,8 @@ Service (1) Replicas Ports Image
 ----------- -------- ----- -----
 test        1              alpine:latest
 
-Setting (4)          Value
------------          -----
+Settings (4)         Value
+------------         -----
 myapp.alpine_version latest
 myapp.command1       cat
 myapp.command2       foo

--- a/e2e/testdata/envvariables-inspect.golden
+++ b/e2e/testdata/envvariables-inspect.golden
@@ -2,12 +2,12 @@ myapp 0.1.0
 
 Maintained by: bearclaw <bearclaw@bearclaw.bearclaw>
 
-Service Replicas Ports Image
-------- -------- ----- -----
-test    1              alpine:latest
+Service (1) Replicas Ports Image
+----------- -------- ----- -----
+test        1              alpine:latest
 
-Setting              Value
--------              -----
+Setting (4)          Value
+-----------          -----
 myapp.alpine_version latest
 myapp.command1       cat
 myapp.command2       foo

--- a/e2e/testdata/helloworld-inspect.golden
+++ b/e2e/testdata/helloworld-inspect.golden
@@ -4,11 +4,11 @@ Maintained by: user <user@email.com>
 
 Hello, World!
 
-Service Replicas Ports Image
-------- -------- ----- -----
-hello   1        8080  hashicorp/http-echo
+Service (1) Replicas Ports Image
+----------- -------- ----- -----
+hello       1        8080  hashicorp/http-echo
 
-Setting Value
-------- -----
-port    8080
-text    Hello, World!
+Setting (2) Value
+----------- -----
+port        8080
+text        Hello, World!

--- a/e2e/testdata/helloworld-inspect.golden
+++ b/e2e/testdata/helloworld-inspect.golden
@@ -8,7 +8,7 @@ Service (1) Replicas Ports Image
 ----------- -------- ----- -----
 hello       1        8080  hashicorp/http-echo
 
-Setting (2) Value
------------ -----
-port        8080
-text        Hello, World!
+Settings (2) Value
+------------ -----
+port         8080
+text         Hello, World!

--- a/e2e/testdata/helloworld-inspect.golden
+++ b/e2e/testdata/helloworld-inspect.golden
@@ -1,9 +1,14 @@
 hello-world 0.1.0
+
 Maintained by: user <user@email.com>
 
 Hello, World!
 
-Setting Default
-------- -------
+Service Replicas Ports Image
+------- -------- ----- -----
+hello   1        8080  hashicorp/http-echo
+
+Setting Value
+------- -----
 port    8080
 text    Hello, World!

--- a/e2e/testdata/render/envvariables/my.dockerapp/settings.yml
+++ b/e2e/testdata/render/envvariables/my.dockerapp/settings.yml
@@ -2,3 +2,4 @@ myapp:
   alpine_version: latest
   command1: cat
   command2: foo
+  command3: bar

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -36,7 +36,7 @@ func Inspect(out io.Writer, app *types.App, argSettings map[string]string) error
 	// Add Service section
 	addSection(&sections, len(config.Services), func(w io.Writer) {
 		for _, service := range config.Services {
-			fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", service.Name, getReplicas(service), getPorts(service), service.Image)
+			fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", service.Name, getReplicas(service), getPorts(service.Ports), service.Image)
 		}
 	}, "Service", "Replicas", "Ports", "Image")
 
@@ -124,16 +124,6 @@ func getReplicas(service composetypes.ServiceConfig) int {
 		return int(*service.Deploy.Replicas)
 	}
 	return 1
-}
-
-func getPorts(service composetypes.ServiceConfig) string {
-	var ports []string
-	for _, port := range service.Ports {
-		if port.Published > 0 {
-			ports = append(ports, fmt.Sprintf("%d", port.Published))
-		}
-	}
-	return strings.Join(ports, ",")
 }
 
 func extractSettings(app *types.App, argSettings map[string]string) ([]string, map[string]string, error) {

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -1,7 +1,6 @@
 package inspect
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"sort"
@@ -28,87 +27,70 @@ func Inspect(out io.Writer, app *types.App, argSettings map[string]string) error
 		return err
 	}
 
-	var sections []*bytes.Buffer
-
 	// Add Meta data
-	addMetadata(&sections, app)
+	printMetadata(out, app)
 
 	// Add Service section
-	addSection(&sections, len(config.Services), func(w io.Writer) {
+	printSection(out, len(config.Services), func(w io.Writer) {
 		for _, service := range config.Services {
 			fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", service.Name, getReplicas(service), getPorts(service.Ports), service.Image)
 		}
 	}, "Service", "Replicas", "Ports", "Image")
 
 	// Add Network section
-	addSection(&sections, len(config.Networks), func(w io.Writer) {
+	printSection(out, len(config.Networks), func(w io.Writer) {
 		for name := range config.Networks {
 			fmt.Fprintln(w, name)
 		}
 	}, "Network")
 
 	// Add Volume section
-	addSection(&sections, len(config.Volumes), func(w io.Writer) {
+	printSection(out, len(config.Volumes), func(w io.Writer) {
 		for name := range config.Volumes {
 			fmt.Fprintln(w, name)
 		}
 	}, "Volume")
 
 	// Add Secret section
-	addSection(&sections, len(config.Secrets), func(w io.Writer) {
+	printSection(out, len(config.Secrets), func(w io.Writer) {
 		for name := range config.Secrets {
 			fmt.Fprintln(w, name)
 		}
 	}, "Secret")
 
 	// Add Setting section
-	addSection(&sections, len(settingsKeys), func(w io.Writer) {
+	printSection(out, len(settingsKeys), func(w io.Writer) {
 		for _, k := range settingsKeys {
 			fmt.Fprintf(w, "%s\t%s\n", k, allSettings[k])
 		}
 	}, "Setting", "Value")
 
-	// Print all sections
-	printSections(out, sections)
-
 	return nil
 }
 
-func addMetadata(sections *[]*bytes.Buffer, app *types.App) {
-	buf := &bytes.Buffer{}
+func printMetadata(out io.Writer, app *types.App) {
 	meta := app.Metadata()
-	fmt.Fprintln(buf, meta.Name, meta.Version)
+	fmt.Fprintln(out, meta.Name, meta.Version)
 	if maintainers := meta.Maintainers.String(); maintainers != "" {
-		fmt.Fprintln(buf)
-		fmt.Fprintln(buf, "Maintained by:", maintainers)
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Maintained by:", maintainers)
 	}
 	if meta.Description != "" {
-		fmt.Fprintln(buf)
-		fmt.Fprintln(buf, meta.Description)
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, meta.Description)
 	}
-	*sections = append(*sections, buf)
 }
 
-func addSection(sections *[]*bytes.Buffer, len int, printer func(io.Writer), headers ...string) {
+func printSection(out io.Writer, len int, printer func(io.Writer), headers ...string) {
 	if len == 0 {
 		return
 	}
-	buf := &bytes.Buffer{}
-	w := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	fmt.Fprintln(out)
+	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
 	headers[0] = fmt.Sprintf("%s (%d)", headers[0], len)
 	printHeaders(w, headers...)
 	printer(w)
 	w.Flush()
-	*sections = append(*sections, buf)
-}
-
-// printSections makes sure there isn't any extra line at the end of the command output
-func printSections(out io.Writer, sections []*bytes.Buffer) {
-	ss := make([]string, len(sections))
-	for i, section := range sections {
-		ss[i] = section.String()
-	}
-	fmt.Fprint(out, strings.Join(ss, "\n"))
 }
 
 func printHeaders(w io.Writer, headers ...string) {

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -95,6 +95,7 @@ func addSection(sections *[]*bytes.Buffer, len int, printer func(io.Writer), hea
 	}
 	buf := &bytes.Buffer{}
 	w := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	headers[0] = fmt.Sprintf("%s (%d)", headers[0], len)
 	printHeaders(w, headers...)
 	printer(w)
 	w.Flush()

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -87,7 +87,11 @@ func printSection(out io.Writer, len int, printer func(io.Writer), headers ...st
 	}
 	fmt.Fprintln(out)
 	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
-	headers[0] = fmt.Sprintf("%s (%d)", headers[0], len)
+	var plural string
+	if len > 1 {
+		plural = "s"
+	}
+	headers[0] = fmt.Sprintf("%s%s (%d)", headers[0], plural, len)
 	printHeaders(w, headers...)
 	printer(w)
 	w.Flush()

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -1,42 +1,163 @@
 package inspect
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
+	"github.com/docker/app/render"
 	"github.com/docker/app/types"
+	"github.com/docker/app/types/settings"
+	composetypes "github.com/docker/cli/cli/compose/types"
 )
 
 // Inspect dumps the metadata of an app
-func Inspect(out io.Writer, app *types.App) error {
+func Inspect(out io.Writer, app *types.App, argSettings map[string]string) error {
+	// Render the compose file
+	config, err := render.Render(app, argSettings)
+	if err != nil {
+		return err
+	}
+
+	// Extract all the settings
+	settingsKeys, allSettings, err := extractSettings(app, argSettings)
+	if err != nil {
+		return err
+	}
+
+	var sections []*bytes.Buffer
+
+	// Add Meta data
+	addMetadata(&sections, app)
+
+	// Add Service section
+	addSection(&sections, len(config.Services), func(w io.Writer) {
+		for _, service := range config.Services {
+			fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", service.Name, getReplicas(service), getPorts(service), service.Image)
+		}
+	}, "Service", "Replicas", "Ports", "Image")
+
+	// Add Network section
+	addSection(&sections, len(config.Networks), func(w io.Writer) {
+		for name := range config.Networks {
+			fmt.Fprintln(w, name)
+		}
+	}, "Network")
+
+	// Add Volume section
+	addSection(&sections, len(config.Volumes), func(w io.Writer) {
+		for name := range config.Volumes {
+			fmt.Fprintln(w, name)
+		}
+	}, "Volume")
+
+	// Add Secret section
+	addSection(&sections, len(config.Secrets), func(w io.Writer) {
+		for name := range config.Secrets {
+			fmt.Fprintln(w, name)
+		}
+	}, "Secret")
+
+	// Add Setting section
+	addSection(&sections, len(settingsKeys), func(w io.Writer) {
+		for _, k := range settingsKeys {
+			fmt.Fprintf(w, "%s\t%s\n", k, allSettings[k])
+		}
+	}, "Setting", "Value")
+
+	// Print all sections
+	printSections(out, sections)
+
+	return nil
+}
+
+func addMetadata(sections *[]*bytes.Buffer, app *types.App) {
+	buf := &bytes.Buffer{}
 	meta := app.Metadata()
-	// extract settings
-	settings := app.Settings().Flatten()
+	fmt.Fprintln(buf, meta.Name, meta.Version)
+	if maintainers := meta.Maintainers.String(); maintainers != "" {
+		fmt.Fprintln(buf)
+		fmt.Fprintln(buf, "Maintained by:", maintainers)
+	}
+	if meta.Description != "" {
+		fmt.Fprintln(buf)
+		fmt.Fprintln(buf, meta.Description)
+	}
+	*sections = append(*sections, buf)
+}
+
+func addSection(sections *[]*bytes.Buffer, len int, printer func(io.Writer), headers ...string) {
+	if len == 0 {
+		return
+	}
+	buf := &bytes.Buffer{}
+	w := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	printHeaders(w, headers...)
+	printer(w)
+	w.Flush()
+	*sections = append(*sections, buf)
+}
+
+// printSections makes sure there isn't any extra line at the end of the command output
+func printSections(out io.Writer, sections []*bytes.Buffer) {
+	ss := make([]string, len(sections))
+	for i, section := range sections {
+		ss[i] = section.String()
+	}
+	fmt.Fprint(out, strings.Join(ss, "\n"))
+}
+
+func printHeaders(w io.Writer, headers ...string) {
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	dashes := make([]string, len(headers))
+	for i, h := range headers {
+		dashes[i] = strings.Repeat("-", len(h))
+	}
+	fmt.Fprintln(w, strings.Join(dashes, "\t"))
+}
+
+func getReplicas(service composetypes.ServiceConfig) int {
+	if service.Deploy.Replicas != nil {
+		return int(*service.Deploy.Replicas)
+	}
+	return 1
+}
+
+func getPorts(service composetypes.ServiceConfig) string {
+	var ports []string
+	for _, port := range service.Ports {
+		if port.Published > 0 {
+			ports = append(ports, fmt.Sprintf("%d", port.Published))
+		}
+	}
+	return strings.Join(ports, ",")
+}
+
+func extractSettings(app *types.App, argSettings map[string]string) ([]string, map[string]string, error) {
+	allSettings, err := mergeAndFlattenSettings(app, argSettings)
+	if err != nil {
+		return nil, nil, err
+	}
 	// sort the keys to get consistent output
 	var settingsKeys []string
-	for k := range settings {
+	for k := range allSettings {
 		settingsKeys = append(settingsKeys, k)
 	}
 	sort.Slice(settingsKeys, func(i, j int) bool { return settingsKeys[i] < settingsKeys[j] })
-	// build maintainers string
-	maintainers := meta.Maintainers.String()
-	fmt.Fprintf(out, "%s %s\n", meta.Name, meta.Version)
-	if maintainers != "" {
-		fmt.Fprintf(out, "Maintained by: %s\n", maintainers)
-		fmt.Fprintln(out, "")
+	return settingsKeys, allSettings, nil
+}
+
+func mergeAndFlattenSettings(app *types.App, argSettings map[string]string) (map[string]string, error) {
+	sArgs, err := settings.FromFlatten(argSettings)
+	if err != nil {
+		return nil, err
 	}
-	if meta.Description != "" {
-		fmt.Fprintf(out, "%s\n", meta.Description)
-		fmt.Fprintln(out, "")
+	s, err := settings.Merge(app.Settings(), sArgs)
+	if err != nil {
+		return nil, err
 	}
-	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
-	fmt.Fprintln(w, "Setting\tDefault")
-	fmt.Fprintln(w, "-------\t-------")
-	for _, k := range settingsKeys {
-		fmt.Fprintf(w, "%s\t%s\n", k, settings[k])
-	}
-	w.Flush()
-	return nil
+	return s.Flatten(), nil
 }

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -70,7 +70,7 @@ services:
   web:
     image: nginx:latest
     ports:
-      - 8080:80
+      - 8080-8100:12300-12320
     deploy:
       replicas: 2
 networks:

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -13,11 +13,7 @@ import (
 )
 
 const (
-	composeYAML = `version: "3.1"
-
-services:
-  web:
-    image: nginx`
+	composeYAML = `version: "3.1"`
 )
 
 func TestInspect(t *testing.T) {
@@ -50,8 +46,41 @@ maintainers:
 description: "this is sparta !"`),
 			fs.WithFile(internal.SettingsFileName, ""),
 		),
+		fs.WithDir("overridden",
+			fs.WithFile(internal.ComposeFileName, `
+version: "3.1"
+
+services:
+  web:
+    image: nginx
+    ports:
+      - ${web.port}:80
+`),
+			fs.WithFile(internal.MetadataFileName, `
+version: 0.1.0
+name: foo
+`),
+			fs.WithFile(internal.SettingsFileName, ""),
+		),
 		fs.WithDir("full",
-			fs.WithFile(internal.ComposeFileName, composeYAML),
+			fs.WithFile(internal.ComposeFileName, `
+version: "3.1"
+
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - 8080:80
+    deploy:
+      replicas: 2
+networks:
+  my-network:
+volumes:
+  my-volume:
+secrets:
+  my-secret:
+    file: ./my_secret.txt
+`),
 			fs.WithFile(internal.MetadataFileName, `
 version: 0.1.0
 name: foo
@@ -66,14 +95,23 @@ text: hello`),
 	)
 	defer dir.Remove()
 
-	for _, appname := range []string{
-		"no-maintainers", "no-description", "no-settings", "full",
+	for _, testcase := range []struct {
+		name string
+		args map[string]string
+	}{
+		{name: "no-maintainers"},
+		{name: "no-description"},
+		{name: "no-settings"},
+		{name: "overridden", args: map[string]string{"web.port": "80"}},
+		{name: "full"},
 	} {
-		outBuffer := new(bytes.Buffer)
-		app, err := types.NewAppFromDefaultFiles(dir.Join(appname))
-		assert.NilError(t, err)
-		err = Inspect(outBuffer, app)
-		assert.NilError(t, err)
-		golden.Assert(t, outBuffer.String(), fmt.Sprintf("inspect-%s.golden", appname), appname)
+		t.Run(testcase.name, func(t *testing.T) {
+			outBuffer := new(bytes.Buffer)
+			app, err := types.NewAppFromDefaultFiles(dir.Join(testcase.name))
+			assert.NilError(t, err)
+			err = Inspect(outBuffer, app, testcase.args)
+			assert.NilError(t, err)
+			golden.Assert(t, outBuffer.String(), fmt.Sprintf("inspect-%s.golden", testcase.name), testcase.name)
+		})
 	}
 }

--- a/internal/inspect/ports.go
+++ b/internal/inspect/ports.go
@@ -1,0 +1,71 @@
+package inspect
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	composetypes "github.com/docker/cli/cli/compose/types"
+)
+
+type portRange struct {
+	start uint32
+	end   *uint32
+}
+
+func newPort(start uint32) *portRange {
+	return &portRange{start: start}
+}
+
+func (p *portRange) add(end uint32) bool {
+	if p.end == nil {
+		if p.start+1 == end {
+			p.end = &end
+			return true
+		}
+		return false
+	}
+	if *p.end+1 == end {
+		p.end = &end
+		return true
+
+	}
+	return false
+}
+
+func (p portRange) String() string {
+	res := fmt.Sprintf("%d", p.start)
+	if p.end != nil {
+		res += fmt.Sprintf("-%d", *p.end)
+	}
+	return res
+}
+
+// getPorts identifies all the published port ranges, merges them
+// if they are consecutive, and return a string with all the published
+// ports.
+func getPorts(ports []composetypes.ServicePortConfig) string {
+	var (
+		portRanges    []*portRange
+		lastPortRange *portRange
+	)
+	sort.Slice(ports, func(i int, j int) bool { return ports[i].Published < ports[j].Published })
+	for _, port := range ports {
+		if port.Published > 0 {
+			if lastPortRange == nil {
+				lastPortRange = newPort(port.Published)
+			} else if !lastPortRange.add(port.Published) {
+				portRanges = append(portRanges, lastPortRange)
+				lastPortRange = newPort(port.Published)
+			}
+		}
+	}
+	if lastPortRange != nil {
+		portRanges = append(portRanges, lastPortRange)
+	}
+	output := make([]string, len(portRanges))
+	for i, p := range portRanges {
+		output[i] = p.String()
+	}
+	return strings.Join(output, ",")
+}

--- a/internal/inspect/ports_test.go
+++ b/internal/inspect/ports_test.go
@@ -1,0 +1,76 @@
+package inspect
+
+import (
+	"testing"
+
+	composetypes "github.com/docker/cli/cli/compose/types"
+	"gotest.tools/assert"
+)
+
+func TestGetPorts(t *testing.T) {
+	for _, testcase := range []struct {
+		name     string
+		ports    []composetypes.ServicePortConfig
+		expected string
+	}{
+		{
+			name:     "no-published-ports",
+			ports:    []composetypes.ServicePortConfig{target(80)},
+			expected: "",
+		},
+		{
+			name:     "published-port",
+			ports:    []composetypes.ServicePortConfig{published(8080)},
+			expected: "8080",
+		},
+		{
+			name:     "mix-published-target-ports",
+			ports:    []composetypes.ServicePortConfig{published(8080), target(80), published(9090)},
+			expected: "8080,9090",
+		},
+		{
+			name:     "simple-range",
+			ports:    publishedRange(8080, 8085),
+			expected: "8080-8085",
+		},
+		{
+			name:     "complex-range",
+			ports:    append(append(publishedRange(8080, 8081), target(80), published(8082)), publishedRange(8083, 8090)...),
+			expected: "8080-8090",
+		},
+		{
+			name:     "multi-range",
+			ports:    append(append(publishedRange(8080, 8081), published(8083)), publishedRange(8085, 8086)...),
+			expected: "8080-8081,8083,8085-8086",
+		},
+		{
+			name:     "ports-are-sorted",
+			ports:    []composetypes.ServicePortConfig{published(8080), published(8082), published(7979), published(8081)},
+			expected: "7979,8080-8082",
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			assert.Equal(t, getPorts(testcase.ports), testcase.expected)
+		})
+	}
+}
+
+func published(port uint32) composetypes.ServicePortConfig {
+	return composetypes.ServicePortConfig{
+		Published: port,
+	}
+}
+
+func target(port uint32) composetypes.ServicePortConfig {
+	return composetypes.ServicePortConfig{
+		Target: port,
+	}
+}
+
+func publishedRange(start, end uint32) []composetypes.ServicePortConfig {
+	var ports []composetypes.ServicePortConfig
+	for i := start; i <= end; i++ {
+		ports = append(ports, published(i))
+	}
+	return ports
+}

--- a/internal/inspect/testdata/inspect-full.golden
+++ b/internal/inspect/testdata/inspect-full.golden
@@ -4,23 +4,23 @@ Maintained by: foo <foo@bar.com>
 
 this is sparta !
 
-Service Replicas Ports     Image
-------- -------- -----     -----
-web     2        8080-8100 nginx:latest
+Service (1) Replicas Ports     Image
+----------- -------- -----     -----
+web         2        8080-8100 nginx:latest
 
-Network
--------
+Network (1)
+-----------
 my-network
 
-Volume
-------
+Volume (1)
+----------
 my-volume
 
-Secret
-------
+Secret (1)
+----------
 my-secret
 
-Setting Value
-------- -----
-port    8080
-text    hello
+Setting (2) Value
+----------- -----
+port        8080
+text        hello

--- a/internal/inspect/testdata/inspect-full.golden
+++ b/internal/inspect/testdata/inspect-full.golden
@@ -1,9 +1,26 @@
 foo 0.1.0
+
 Maintained by: foo <foo@bar.com>
 
 this is sparta !
 
-Setting Default
-------- -------
+Service Replicas Ports Image
+------- -------- ----- -----
+web     2        8080  nginx:latest
+
+Network
+-------
+my-network
+
+Volume
+------
+my-volume
+
+Secret
+------
+my-secret
+
+Setting Value
+------- -----
 port    8080
 text    hello

--- a/internal/inspect/testdata/inspect-full.golden
+++ b/internal/inspect/testdata/inspect-full.golden
@@ -4,9 +4,9 @@ Maintained by: foo <foo@bar.com>
 
 this is sparta !
 
-Service Replicas Ports Image
-------- -------- ----- -----
-web     2        8080  nginx:latest
+Service Replicas Ports     Image
+------- -------- -----     -----
+web     2        8080-8100 nginx:latest
 
 Network
 -------

--- a/internal/inspect/testdata/inspect-full.golden
+++ b/internal/inspect/testdata/inspect-full.golden
@@ -20,7 +20,7 @@ Secret (1)
 ----------
 my-secret
 
-Setting (2) Value
------------ -----
-port        8080
-text        hello
+Settings (2) Value
+------------ -----
+port         8080
+text         hello

--- a/internal/inspect/testdata/inspect-no-description.golden
+++ b/internal/inspect/testdata/inspect-no-description.golden
@@ -1,5 +1,3 @@
 foo 0.1.0
-Maintained by: foo <foo@bar.com>
 
-Setting Default
-------- -------
+Maintained by: foo <foo@bar.com>

--- a/internal/inspect/testdata/inspect-no-maintainers.golden
+++ b/internal/inspect/testdata/inspect-no-maintainers.golden
@@ -1,3 +1,1 @@
 foo 0.1.0
-Setting Default
-------- -------

--- a/internal/inspect/testdata/inspect-no-settings.golden
+++ b/internal/inspect/testdata/inspect-no-settings.golden
@@ -1,7 +1,5 @@
 foo 0.1.0
+
 Maintained by: foo <foo@bar.com>
 
 this is sparta !
-
-Setting Default
-------- -------

--- a/internal/inspect/testdata/inspect-overridden.golden
+++ b/internal/inspect/testdata/inspect-overridden.golden
@@ -1,9 +1,9 @@
 foo 0.1.0
 
-Service Replicas Ports Image
-------- -------- ----- -----
-web     1        80    nginx
+Service (1) Replicas Ports Image
+----------- -------- ----- -----
+web         1        80    nginx
 
-Setting  Value
--------  -----
-web.port 80
+Setting (1) Value
+----------- -----
+web.port    80

--- a/internal/inspect/testdata/inspect-overridden.golden
+++ b/internal/inspect/testdata/inspect-overridden.golden
@@ -1,0 +1,9 @@
+foo 0.1.0
+
+Service Replicas Ports Image
+------- -------- ----- -----
+web     1        80    nginx
+
+Setting  Value
+-------  -----
+web.port 80


### PR DESCRIPTION
**- What I did**
Added services, networks, volumes and secrets sections to the `inspect` command.

**- How to verify it**
(**UPDATED**)
```sh
$ make bin/docker-app
$ ./bin/docker-app inspect examples/voting-app/voting-app.dockerapp
voting-app 0.1.0

Maintained by: user <user@email.com>

Dogs or cats?

Services (6) Replicas Ports Image
------------ -------- ----- -----
db           1              postgres:9.4
vote         1        8080  dockersamples/examplevotingapp_vote:latest
result       1        8181  dockersamples/examplevotingapp_result:latest
worker       1              dockersamples/examplevotingapp_worker:latest
visualizer   1        8282  dockersamples/visualizer:latest
redis        1              redis:alpine

Networks (2)
------------
frontend
backend

Volume (1)
----------
db-data

Settings (14)         Value
-------------         -----
result.image.name     dockersamples/examplevotingapp_result
result.image.tag      latest
result.port           8181
result.replicas       1
visualizer.image.name dockersamples/visualizer
visualizer.image.tag  latest
visualizer.port       8282
vote.image.name       dockersamples/examplevotingapp_vote
vote.image.tag        latest
vote.port             8080
vote.replicas         1
worker.image.name     dockersamples/examplevotingapp_worker
worker.image.tag      latest
worker.replicas       1
```

**- Description for the changelog**
* Add compose file summary to the inspect command

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/45038031-ad8f5180-b060-11e8-8a00-a4eea8f7f946.png)

