### PR TITLE
Image: add, load, push. New --registry option to deploy and render.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,30 @@ For example, the following will create the `/opt/myapps/hello2.dockerapp` folder
 $ docker-app fork remote/hello.dockerapp:1.0.0 mine/hello2 --path /opt/myapps
 ```
 
+## Storing images in the application package
+
+Using the `docker-app image add` command, one can store all images used by the
+application into the `images` subfolder.
+
+Those images can then be pushed to another registry using `docker-app image push`. Finally the
+`render` and `deploy` commands support overriding the image names with any registry using the `--registry` argument.
+
+What follows is a complete deployment scenario of an application from the Hub into a cluster without access
+to the Internet:
+
+``` sh
+# Download myapp from the Hub locally
+opensystem$ docker-app split myuser/myapp.dockerapp
+# Store used images into the application folder.
+# The images must be available on your local docker daemon
+opensystem$ docker-app image add myapp
+# Now transport the myapp.dockerapp folder to the air-gapped cluster and login:
+# Push the application's images to a local registry
+closed$ docker-app image push myapp myregistry:5000
+# Deploy overriding image names with the local registry
+closed$ docker-app deploy --registry myregistry:5000 myapp
+```
+
 ## Next steps
 
 We have lots of ideas for making Compose-based applications easier to share and reuse, and making applications a first-class part of the Docker toolchain. Please let us know what you think about this initial release and about any of the ideas below:
@@ -231,7 +255,6 @@ We have lots of ideas for making Compose-based applications easier to share and 
 * Introducing environments to the settings file
 * Docker images which launch the application when run
 * Built-in commands for running applications
-* Saving required images into the application artifact to support offline installation
 * Signing applications with notary
 
 

--- a/cmd/docker-app/image-add.go
+++ b/cmd/docker-app/image-add.go
@@ -16,18 +16,32 @@ var (
 	imageAddComposeFiles []string
 	imageAddSettingsFile []string
 	imageAddEnv          []string
+	imageAddPull         bool
+	imageAddQuiet        bool
 )
 
 func imageAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "image-add <app-name> [services...]",
+		Use:   "add <app-name> [--pull] [services...]",
 		Short: "Add images for given services (default: all) to the app package",
 		Long: `This command renders the app's docker-compose.yml file, looks for the
 images it uses, and saves them from the local docker daemon to the images/
 subdirectory.`,
-		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oappname := args[0]
+			var (
+				oappname string
+				err      error
+				services []string
+			)
+			if len(args) == 0 {
+				oappname, err = packager.FindApp()
+				if err != nil {
+					return err
+				}
+			} else {
+				oappname = args[0]
+				services = args[1:]
+			}
 			app, err := packager.Extract(oappname,
 				types.WithSettingsFiles(imageAddSettingsFile...),
 				types.WithComposeFiles(imageAddComposeFiles...),
@@ -41,7 +55,7 @@ subdirectory.`,
 			if err != nil {
 				return err
 			}
-			if err := image.Add(app.Name, args[1:], config); err != nil {
+			if err := image.Add(app.Path, services, config, imageAddPull, imageAddQuiet); err != nil {
 				return err
 			}
 			// check if source was a tarball
@@ -67,8 +81,11 @@ subdirectory.`,
 	}
 	if internal.Experimental == "on" {
 		cmd.Flags().StringArrayVarP(&imageAddComposeFiles, "compose-files", "c", []string{}, "Override Compose files")
-		cmd.Flags().StringArrayVarP(&imageAddSettingsFile, "settings-files", "s", []string{}, "Override settings files")
-		cmd.Flags().StringArrayVarP(&imageAddEnv, "env", "e", []string{}, "Override environment values")
 	}
+	cmd.Flags().StringArrayVarP(&imageAddSettingsFile, "settings-files", "f", []string{}, "Override settings files")
+	cmd.Flags().StringArrayVarP(&imageAddEnv, "set", "s", []string{}, "Override environment values")
+	cmd.Flags().BoolVarP(&imageAddPull, "pull", "p", false, "Pull images first")
+	cmd.Flags().BoolVarP(&imageAddPull, "quiet", "q", false, "Suppress progress output")
+
 	return cmd
 }

--- a/cmd/docker-app/image-load.go
+++ b/cmd/docker-app/image-load.go
@@ -8,7 +8,7 @@ import (
 
 func imageLoadCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "image-load <app-name> [services...]",
+		Use:   "load <app-name> [services...]",
 		Short: "Load stored images for given services (default: all) to the local docker daemon",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -17,7 +17,7 @@ func imageLoadCmd() *cobra.Command {
 				return err
 			}
 			defer app.Cleanup()
-			return image.Load(app.Name, args[1:])
+			return image.Load(app.Path, args[1:])
 		},
 	}
 }

--- a/cmd/docker-app/image-push.go
+++ b/cmd/docker-app/image-push.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/image"
+	"github.com/docker/app/internal/packager"
+	"github.com/docker/app/render"
+	"github.com/docker/app/types"
+	cliopts "github.com/docker/cli/opts"
+	"github.com/spf13/cobra"
+)
+
+var (
+	imagePushComposeFiles []string
+	imagePushSettingsFile []string
+	imagePushEnv          []string
+	imagePushRegistry     string
+)
+
+func imagePushCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push <app-name> <registry> [services...]",
+		Short: "Push images for given services (default: all) to given registry",
+		Long: `This command renders the app's docker-compose.yml file, and pushes
+the images saved in the application to the given registry.`,
+		Args: cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := packager.Extract(args[0],
+				types.WithSettingsFiles(imagePushSettingsFile...),
+				types.WithComposeFiles(imagePushComposeFiles...),
+			)
+			if err != nil {
+				return err
+			}
+			defer app.Cleanup()
+			d := cliopts.ConvertKVStringsToMap(imagePushEnv)
+			config, err := render.Render(app, d)
+			if err != nil {
+				return err
+			}
+			return image.Push(app.Path, args[1], args[2:], config)
+		},
+	}
+	if internal.Experimental == "on" {
+		cmd.Flags().StringArrayVarP(&imagePushComposeFiles, "compose-files", "c", []string{}, "Override Compose files")
+	}
+	cmd.Flags().StringArrayVarP(&imagePushSettingsFile, "settings-files", "f", []string{}, "Override settings files")
+	cmd.Flags().StringArrayVarP(&imagePushEnv, "set", "s", []string{}, "Override environment values")
+	cmd.Flags().StringVarP(&imagePushRegistry, "registry", "r", "", "Registry to push to")
+	return cmd
+}

--- a/cmd/docker-app/image.go
+++ b/cmd/docker-app/image.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func imageCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "image",
+		Short: "Manipulate Docker images associated with the application",
+	}
+	cmd.AddCommand(imageAddCmd(), imageLoadCmd(), imagePushCmd())
+	return cmd
+}

--- a/cmd/docker-app/render.go
+++ b/cmd/docker-app/render.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/formatter"
+	"github.com/docker/app/internal/image"
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/render"
 	"github.com/docker/app/types"
@@ -21,6 +22,7 @@ var (
 	renderSettingsFile []string
 	renderEnv          []string
 	renderOutput       string
+	renderRegistry     string
 )
 
 func renderCmd(dockerCli command.Cli) *cobra.Command {
@@ -42,6 +44,11 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 			rendered, err := render.Render(app, d)
 			if err != nil {
 				return err
+			}
+			if renderRegistry != "" {
+				if err = image.ChangeAllImages(rendered, renderRegistry); err != nil {
+					return err
+				}
 			}
 			res, err := formatter.Format(rendered, formatDriver)
 			if err != nil {
@@ -70,5 +77,6 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&renderEnv, "set", "s", []string{}, "Override settings values")
 	cmd.Flags().StringVarP(&renderOutput, "output", "o", "-", "Output file")
 	cmd.Flags().StringVar(&formatDriver, "formatter", "yaml", "Configure the output format (yaml|json)")
+	cmd.Flags().StringVarP(&renderRegistry, "registry", "r", "", "Override registry for all images")
 	return cmd
 }

--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -46,7 +46,6 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		deployCmd(dockerCli),
 		forkCmd(),
 		helmCmd(),
-		imageCmd(),
 		initCmd(),
 		inspectCmd(dockerCli),
 		mergeCmd(dockerCli),
@@ -59,6 +58,7 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 	)
 	if internal.Experimental == "on" {
 		cmd.AddCommand(
+			imageCmd(),
 			packCmd(dockerCli),
 			pullCmd(),
 			unpackCmd(),

--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -46,6 +46,7 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		deployCmd(dockerCli),
 		forkCmd(),
 		helmCmd(),
+		imageCmd(),
 		initCmd(),
 		inspectCmd(dockerCli),
 		mergeCmd(dockerCli),
@@ -58,8 +59,6 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 	)
 	if internal.Experimental == "on" {
 		cmd.AddCommand(
-			imageAddCmd(),
-			imageLoadCmd(),
 			packCmd(dockerCli),
 			pullCmd(),
 			unpackCmd(),

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -376,4 +376,7 @@ func TestImagePush(t *testing.T) {
 	icmd.RunCommand(dockerApp, "image", "add", dir.Join("app")).Assert(t, icmd.Success)
 	icmd.RunCommand(dockerApp, "image", "push", dir.Join("app"), registry).Assert(t, icmd.Success)
 	icmd.RunCommand("docker", "pull", registry+"/library/alpine:latest").Assert(t, icmd.Success)
+	// check that attachment skips image files
+	result := icmd.RunCommand(dockerApp, "inspect", dir.Join("app")).Assert(t, icmd.Success)
+	assert.Assert(t, golden.String(result.Combined(), "images-alpine-no-attachments.golden"))
 }

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -360,6 +360,7 @@ func TestRenderWithRegistry(t *testing.T) {
 }
 
 func TestImagePush(t *testing.T) {
+	skip.If(t, !hasExperimental, "experimental mode needed for this test")
 	r := startRegistry(t)
 	defer r.Stop(t)
 	registry := r.GetAddress(t)

--- a/e2e/testdata/images-alpine-no-attachments.golden
+++ b/e2e/testdata/images-alpine-no-attachments.golden
@@ -1,0 +1,5 @@
+alpine 0.1.0
+
+Service (1) Replicas Ports Image
+----------- -------- ----- -----
+alpine      1              alpine:latest

--- a/e2e/testdata/images-render-registry.golden
+++ b/e2e/testdata/images-render-registry.golden
@@ -1,0 +1,10 @@
+version: "3.2"
+services:
+  etcd:
+    image: localhost:5000/coreos/etcd:v2.3.8
+  mysql:
+    image: localhost:5000/library/mysql:5.6
+  onhub:
+    image: localhost:5000/username/reponame:latest
+  vars:
+    image: localhost:5000/user/image:5.2

--- a/e2e/testdata/images.dockerapp
+++ b/e2e/testdata/images.dockerapp
@@ -1,0 +1,17 @@
+name: images
+version: 0.1.0
+---
+version: '3.2'
+services:
+  mysql:
+    image: mysql:5.6
+  etcd:
+    image: quay.io/coreos/etcd:v2.3.8
+  onhub:
+    image: username/reponame:latest
+  vars:
+    image: ${imagename}:${imageversion}
+---
+imagename: user/image
+imageversion: '4.2'
+

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -5,25 +5,38 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/app/internal/slices"
 	composetypes "github.com/docker/cli/cli/compose/types"
+	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 )
 
 // Add add service images to the app package
-func Add(appname string, services []string, config *composetypes.Config) error {
-	if err := os.Mkdir(filepath.Join(appname, "images"), 0755); err != nil {
-		return errors.Wrap(err, "cannot create 'images' folder")
+func Add(appname string, services []string, config *composetypes.Config, pull bool, quiet bool) error {
+	if err := os.Mkdir(filepath.Join(appname, "images"), 0755); err != nil && !os.IsExist(err) {
+		return errors.Wrap(err, "cannot create 'images' folder, this command only works with a multi-file application package")
 	}
 	for _, s := range config.Services {
 		if len(services) != 0 && !slices.ContainsString(services, s.Name) {
 			continue
 		}
+		if !quiet {
+			fmt.Printf("Adding image %s for service %s...\n", s.Image, s.Name)
+		}
+		if pull {
+			cmd := exec.Command("docker", "pull", s.Image)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error pulling %s: %s\n", s.Image, string(output))
+				return err
+			}
+		}
 		cmd := exec.Command("docker", "save", "-o", filepath.Join(appname, "images", s.Name), s.Image)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			fmt.Println(output)
+			fmt.Fprintf(os.Stderr, "error from docker when saving %s: %s\n", s.Image, string(output))
 			return err
 		}
 	}
@@ -48,7 +61,112 @@ func Load(appname string, services []string) error {
 		cmd := exec.Command("docker", "load", "-i", filepath.Join(appname, "images", i))
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			fmt.Println(output)
+			fmt.Println(string(output))
+			return err
+		}
+	}
+	return nil
+}
+
+func serviceByName(config *composetypes.Config, name string) *composetypes.ServiceConfig {
+	for _, s := range config.Services {
+		if s.Name == name {
+			return &s
+		}
+	}
+	return nil
+}
+
+// ChangeAllImages adds given registry to all images used in config
+func ChangeAllImages(config *composetypes.Config, registry string) error {
+	for i, s := range config.Services {
+		ni, err := ChangeImageRepository(s.Image, registry)
+		if err != nil {
+			return err
+		}
+		config.Services[i].Image = ni
+	}
+	return nil
+}
+
+// ChangeImageRepository changes the registry for image to given value
+func ChangeImageRepository(image, registry string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse image reference: %s", err)
+	}
+	path := reference.Path(named)
+	if tagged, ok := named.(reference.Tagged); ok {
+		path = path + ":" + tagged.Tag()
+	}
+	path = registry + "/" + path
+	return path, nil
+}
+
+func loadImage(image string) (string, error) {
+	cmd := exec.Command("docker", "load", "-q", "-i", image)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println(string(output))
+		return "", err
+	}
+	// output is one of:
+	// Loaded image ID: sha256:cf4d5c8667efcb194163da2da2f3da583602bbd9aa5894e785f51c7f5e91bffb
+	// Loaded image: REF
+	soutput := string(output)
+	var ref string
+	if strings.Contains(soutput, "Loaded image:") {
+		ref = strings.SplitN(soutput, ":", 2)[1]
+	} else {
+		outputComponents := strings.Split(string(output), ":")
+		if len(outputComponents) != 3 {
+			return "", fmt.Errorf("failed to parse 'docker load' output: %s", string(output))
+		}
+		ref = outputComponents[2]
+	}
+	ref = strings.Trim(ref, "\n ")
+	return ref, nil
+}
+
+// Push loads and pushes images found in app to given registry
+func Push(appPath string, registry string, services []string, config *composetypes.Config) error {
+	imageDir, err := os.Open(filepath.Join(appPath, "images"))
+	if err != nil {
+		return fmt.Errorf("no images found in app")
+	}
+	defer imageDir.Close()
+	images, err := imageDir.Readdirnames(0)
+	if err != nil {
+		return err
+	}
+	for _, i := range images {
+		if len(services) != 0 && !slices.ContainsString(services, i) {
+			continue
+		}
+		ref, err := loadImage(filepath.Join(appPath, "images", i))
+		if err != nil {
+			return err
+		}
+		service := serviceByName(config, i)
+		if service == nil {
+			return fmt.Errorf("failed to find service '%s' in config", i)
+		}
+		path, err := ChangeImageRepository(service.Image, registry)
+		if err != nil {
+			return err
+		}
+		// retag
+		cmd := exec.Command("docker", "tag", ref, path)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to retag '%s' to '%s': %s", ref, path, string(output))
+			return err
+		}
+		// push
+		cmd = exec.Command("docker", "push", path)
+		output, err = cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to push '%s': %s", path, string(output))
 			return err
 		}
 	}

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -1,0 +1,22 @@
+package image
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestChangeImageRepository(t *testing.T) {
+	res, err := ChangeImageRepository("foo/bar:1.2", "localhost:5000")
+	assert.NilError(t, err)
+	assert.Equal(t, res, "localhost:5000/foo/bar:1.2")
+	res, err = ChangeImageRepository("repo.io/foo/bar:1.2", "localhost:5000")
+	assert.NilError(t, err)
+	assert.Equal(t, res, "localhost:5000/foo/bar:1.2")
+	res, err = ChangeImageRepository("repo.io:3000/foo/bar:1.2", "localhost:5000")
+	assert.NilError(t, err)
+	assert.Equal(t, res, "localhost:5000/foo/bar:1.2")
+	res, err = ChangeImageRepository("foo/bar", "localhost:5000")
+	assert.NilError(t, err)
+	assert.Equal(t, res, "localhost:5000/foo/bar")
+}

--- a/internal/packager/extract.go
+++ b/internal/packager/extract.go
@@ -15,8 +15,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// findApp looks for an app in CWD or subdirs
-func findApp() (string, error) {
+// FindApp looks for an app in CWD or subdirs
+func FindApp() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", errors.Wrap(err, "cannot resolve current working directory")
@@ -96,7 +96,7 @@ func extractImage(appname string, ops ...func(*types.App) error) (*types.App, er
 func Extract(name string, ops ...func(*types.App) error) (*types.App, error) {
 	if name == "" {
 		var err error
-		if name, err = findApp(); err != nil {
+		if name, err = FindApp(); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/resto/resto.go
+++ b/pkg/resto/resto.go
@@ -8,12 +8,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"os"
+	"path"
 	"strings"
 	"time"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client"
@@ -373,4 +377,366 @@ func pushConfigLegacy(ctx context.Context, payload map[string]string, pr parsedR
 	}
 	dgst, err := manifestService.Put(ctx, dman, distribution.WithTag(pr.tag))
 	return dgst.String(), err
+}
+
+func tarPush(w *tar.Writer, path string, payload []byte) error {
+	if err := w.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     path,
+		Mode:     0600,
+		Size:     int64(len(payload)),
+	}); err != nil {
+		return err
+	}
+	if _, err := w.Write(payload); err != nil {
+		return err
+	}
+	return nil
+}
+
+func tarPushStream(w *tar.Writer, path string, size int64, data io.ReadCloser) error {
+	defer data.Close()
+	if err := w.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     path,
+		Mode:     0600,
+		Size:     size,
+	}); err != nil {
+		return err
+	}
+	length, err := io.Copy(w, data)
+	if err != nil {
+		return err
+	}
+	if length != size {
+		return fmt.Errorf("unexpected payload size, got %v, wanted %v", length, size)
+	}
+	return nil
+}
+
+type manifestItem struct {
+	Config       string
+	RepoTags     []string
+	Layers       []string
+	LayerSources map[string]distribution.Descriptor
+}
+
+// PullImage pulls given image into output tarball compatible with 'docker load'
+func PullImage(ctx context.Context, repoTag string, opts RegistryOptions, output io.Writer) error { //nolint:gocyclo
+	pr, err := parseRef(repoTag)
+	if err != nil {
+		return err
+	}
+	if opts.Username == "" {
+		opts.Username, opts.Password, err = getCredentials(pr.domain)
+		if err != nil {
+			log.Debugf("failed to get credentials for %s: %s", pr.domain, err)
+		}
+	}
+	w := tar.NewWriter(output)
+	defer w.Close()
+	repo, err := NewRepository(ctx, pr.domain, pr.path, opts)
+	if err != nil {
+		return err
+	}
+	tagService := repo.Tags(ctx)
+	dgst, err := tagService.Get(ctx, pr.tag)
+	if err != nil {
+		return err
+	}
+	manifestService, err := repo.Manifests(ctx)
+	if err != nil {
+		return err
+	}
+	manifest, err := manifestService.Get(ctx, dgst.Digest)
+	if err != nil {
+		return err
+	}
+	mediaType, payload, err := manifest.Payload()
+	if err != nil {
+		return err
+	}
+	var mi []manifestItem
+	blobsService := repo.Blobs(ctx)
+	switch mediaType {
+	case schema2.MediaTypeManifest:
+		m, err := pullOne(ctx, w, manifest, blobsService)
+		if err != nil {
+			return err
+		}
+		mi = append(mi, m)
+	case manifestlist.MediaTypeManifestList:
+		if err := tarPush(w, "manifestlist.json", payload); err != nil {
+			return err
+		}
+		refs := manifest.References()
+		for _, r := range refs {
+			subman, err := manifestService.Get(ctx, r.Digest)
+			if err != nil {
+				return err
+			}
+			m, err := pullOne(ctx, w, subman, blobsService)
+			if err != nil {
+				return err
+			}
+			mi = append(mi, m)
+		}
+	default:
+		return fmt.Errorf("unknown media type %s", mediaType)
+	}
+	payload, err = json.Marshal(mi)
+	if err != nil {
+		return err
+	}
+	return tarPush(w, "manifest.json", payload)
+}
+
+// pullOne pulls one image into the tarball w and returns a manifestItem
+func pullOne(ctx context.Context, w *tar.Writer, manifest distribution.Manifest, blobsService distribution.BlobStore) (manifestItem, error) {
+	refs := manifest.References()
+	var mi manifestItem
+	for i, r := range refs {
+		var layerStream io.ReadCloser
+		if r.MediaType == schema2.MediaTypeForeignLayer {
+			for _, u := range r.URLs {
+				resp, err := http.Get(u)
+				if err == nil && resp.StatusCode == 200 {
+					layerStream = resp.Body
+					break
+				}
+			}
+			if layerStream == nil {
+				return manifestItem{}, fmt.Errorf("failed to get foreign layer %s", r.Digest)
+			}
+			if mi.LayerSources == nil {
+				mi.LayerSources = make(map[string]distribution.Descriptor)
+			}
+			mi.LayerSources[r.Digest.String()] = r
+		} else {
+			var err error
+			layerStream, err = blobsService.Open(ctx, r.Digest)
+			if err != nil {
+				_, p, _ := manifest.Payload()
+				fmt.Println(string(p))
+				return manifestItem{}, fmt.Errorf("failed to get blob for layer %v: %s: %s", i, r.Digest, err)
+			}
+		}
+		if i == 0 { // first entry is the config
+			name := fmt.Sprintf("%s.json", r.Digest.Hex())
+			mi.Config = name
+			if err := tarPushStream(w, name, r.Size, layerStream); err != nil {
+				return manifestItem{}, err
+			}
+		} else {
+			name := path.Join(r.Digest.Hex(), "layer.tar")
+			mi.Layers = append(mi.Layers, name)
+			if err := tarPushStream(w, name, r.Size, layerStream); err != nil {
+				return manifestItem{}, err
+			}
+		}
+	}
+	return mi, nil
+}
+
+// extractManifest extracts and unmarshals the manifestItem list in 'manifest.json' in input tarball
+func extractManifest(input string) ([]manifestItem, error) {
+	f, err := os.Open(input)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	r := tar.NewReader(f)
+	for {
+		header, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if header.Name != "manifest.json" {
+			continue
+		}
+		content := bytes.NewBuffer(nil)
+		io.Copy(content, r)
+		var res []manifestItem
+		err = json.Unmarshal(content.Bytes(), &res)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
+	}
+	return nil, fmt.Errorf("manifest.json not found in tarball")
+}
+
+// isForeign returns true and fills desc if given layer digest is a foreign layer
+func isForeign(manifests []manifestItem, digest string, desc *distribution.Descriptor) bool {
+	for _, m := range manifests {
+		if m.LayerSources == nil {
+			continue
+		}
+		if d, ok := m.LayerSources[digest]; ok {
+			*desc = d
+			return true
+		}
+	}
+	return false
+}
+
+// PushImage pushes given tarball to registry
+func PushImage(ctx context.Context, repoTag string, opts RegistryOptions, input string) error { //nolint:gocyclo
+	// We need the manifest data available to detect foreign layers, but it is at the end of the tarball
+	manifestItems, err := extractManifest(input)
+	if err != nil {
+		return err
+	}
+	pr, err := parseRef(repoTag)
+	if err != nil {
+		return err
+	}
+	if opts.Username == "" {
+		opts.Username, opts.Password, err = getCredentials(pr.domain)
+		if err != nil {
+			log.Debugf("failed to get credentials for %s: %s", pr.domain, err)
+		}
+	}
+	repo, err := NewRepository(ctx, pr.domain, pr.path, opts)
+	if err != nil {
+		return err
+	}
+	manifestService, err := repo.Manifests(ctx)
+	if err != nil {
+		return err
+	}
+	blobsService := repo.Blobs(ctx)
+	f, err := os.Open(input)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	r := tar.NewReader(f)
+	// for each layer/config file name, store the resulting pushed descriptor
+	descriptorMap := make(map[string]distribution.Descriptor)
+	// extracted manifestList from manifestlist.json if present
+	var manifestList manifestlist.DeserializedManifestList
+	for {
+		header, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if header.Name == "manifestlist.json" {
+			content := bytes.NewBuffer(nil)
+			io.Copy(content, r)
+			err = json.Unmarshal(content.Bytes(), &manifestList)
+			if err != nil {
+				return err
+			}
+		}
+		if strings.HasSuffix(header.Name, "layer.tar") {
+			// foreign layer check
+			sha := "sha256:" + path.Dir(header.Name)
+			var desc distribution.Descriptor
+			if isForeign(manifestItems, sha, &desc) {
+				descriptorMap[header.Name] = desc
+				continue
+			}
+			// push layer
+			bw, err := blobsService.Create(ctx)
+			if err != nil {
+				return err
+			}
+			dgstr := digest.Canonical.Digester()
+			sz, err := io.Copy(bw, io.TeeReader(r, dgstr.Hash()))
+			if err != nil {
+				return err
+			}
+			desc = distribution.Descriptor{
+				MediaType: schema2.MediaTypeLayer,
+				Size:      header.Size,
+				Digest:    dgstr.Digest(),
+			}
+			desc, err = bw.Commit(ctx, desc)
+			if err != nil {
+				return fmt.Errorf("layer push error for %s (%s) (pushed %v(%v) of %v): %s",
+					header.Name, sha, sz, bw.Size(), header.Size, err)
+			}
+			descriptorMap[header.Name] = desc
+		}
+		if path.Base(header.Name) == header.Name && strings.HasSuffix(header.Name, ".json") && header.Name != "manifest.json" {
+			// config
+			content := bytes.NewBuffer(nil)
+			_, err := io.Copy(content, r)
+			if err != nil {
+				return err
+			}
+			desc, err := blobsService.Put(ctx, schema2.MediaTypeImageConfig, content.Bytes())
+			if err != nil {
+				return fmt.Errorf("failed to push config blob: %s", err)
+			}
+			descriptorMap[header.Name] = desc
+		}
+	}
+	// all layers and config pushed, now assemble and push manifests
+	var manifestDigests []digest.Digest
+	var manifestSizes []int
+	var putOptions []distribution.ManifestServiceOption
+	if len(manifestItems) == 1 {
+		putOptions = append(putOptions, distribution.WithTag(pr.tag))
+	}
+	for i, mi := range manifestItems {
+		man := schema2.Manifest{
+			Versioned: schema2.SchemaVersion,
+		}
+		man.Config = descriptorMap[mi.Config]
+		for _, l := range mi.Layers {
+			man.Layers = append(man.Layers, descriptorMap[l])
+		}
+		dman, err := schema2.FromStruct(man)
+		if err != nil {
+			return err
+		}
+		_, p, err := dman.Payload()
+		if err != nil {
+			return err
+		}
+		dgst, err := manifestService.Put(ctx, dman, putOptions...)
+		if err != nil {
+			return fmt.Errorf("failed to push manifest %v: %s", i, err)
+		}
+		manifestDigests = append(manifestDigests, dgst)
+		manifestSizes = append(manifestSizes, len(p))
+		if err != nil {
+			return err
+		}
+	}
+	if len(manifestItems) > 1 {
+		// assemble and push multiarch manifest list
+		if len(manifestList.Manifests) == 0 {
+			return fmt.Errorf("missing manifestlist.json in source tarball")
+		}
+		if len(manifestList.Manifests) != len(manifestItems) {
+			return fmt.Errorf("manifest list size mismatch, expected %v, got %v", len(manifestItems), len(manifestList.Manifests))
+		}
+		// update manifestList with current size and sha
+		for i := range manifestItems {
+			manifestList.Manifests[i].Digest = manifestDigests[i]
+			manifestList.Manifests[i].Size = int64(manifestSizes[i])
+		}
+		// canonical representation is cached, we need to create a new ManifestList
+		ml, err := manifestlist.FromDescriptors(manifestList.Manifests)
+		if err != nil {
+			return err
+		}
+		_, err = manifestService.Put(ctx, ml, distribution.WithTag(pr.tag))
+		if err != nil {
+			return fmt.Errorf("failed to push multiarch manifest: %s", err)
+		}
+	}
+	return nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -186,7 +186,9 @@ func WithAttachments(rootAppDir string) func(*App) error {
 			if err != nil {
 				return err
 			}
-
+			if path == filepath.Join(rootAppDir, "images") {
+				return filepath.SkipDir
+			}
 			if info.IsDir() {
 				return nil
 			}


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Move image-add and image-load to image subcommand.
- Add `image push` command.
- Add `--registry` option to render and deploy.

**- How to verify it**

e2e and unit tests.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- New `image` command with `push`, `add` and `load` subcommands.
- New `--registry` option to `deploy` and `render` to override the image names with given registry.

**- A picture of a cute animal (not mandatory but encouraged)**

![catinbox](https://user-images.githubusercontent.com/3638847/45482934-ab5b8000-b74f-11e8-98c8-e171febd6099.jpg)
