### PR TITLE
Fix unit tests on windows running autocrlf=true

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,9 @@
 * text=auto
 *.sh text eol=lf
 *.go text eol=lf
+*.golden text eol=lf
+*.dockerapp text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
 *.exe binary
 vendor/** -text


### PR DESCRIPTION
**- What I did**
With Silvin; Change text files to eol=lf for .dockerapp .golden .yaml .yml to fix unit tests on windows with gitsettings autocrlf=true

This ensures these file types will be checked out with `lf` end of line chars instead of the global `CRLF` setting from gitsettings.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1557887/45555501-db2e8480-b830-11e8-90d3-9f06286fcaa3.png)

