### PR TITLE
Rename render presenter flag to formatter

### DIFF
--- a/cmd/docker-app/render.go
+++ b/cmd/docker-app/render.go
@@ -69,6 +69,6 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&renderSettingsFile, "settings-files", "f", []string{}, "Override settings files")
 	cmd.Flags().StringArrayVarP(&renderEnv, "set", "s", []string{}, "Override settings values")
 	cmd.Flags().StringVarP(&renderOutput, "output", "o", "-", "Output file")
-	cmd.Flags().StringVarP(&formatDriver, "presenter", "p", "yaml", "Configure the output format (yaml|json)")
+	cmd.Flags().StringVar(&formatDriver, "formatter", "yaml", "Configure the output format (yaml|json)")
 	return cmd
 }

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -78,10 +78,10 @@ func testRenderApp(appPath string, env ...string) func(*testing.T) {
 
 func TestRenderFormatters(t *testing.T) {
 	appPath := filepath.Join("testdata", "fork", "simple.dockerapp")
-	result := icmd.RunCommand(dockerApp, "render", "-p", "json", appPath).Assert(t, icmd.Success)
+	result := icmd.RunCommand(dockerApp, "render", "--formatter", "json", appPath).Assert(t, icmd.Success)
 	assert.Assert(t, golden.String(result.Stdout(), "expected-json-render.golden"))
 
-	result = icmd.RunCommand(dockerApp, "render", "-p", "yaml", appPath).Assert(t, icmd.Success)
+	result = icmd.RunCommand(dockerApp, "render", "--formatter", "yaml", appPath).Assert(t, icmd.Success)
 	assert.Assert(t, golden.String(result.Stdout(), "expected-yaml-render.golden"))
 }
 

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -33,10 +33,10 @@ func Register(name string, driver driver.Driver) {
 // If the formatter is not registered, this errors out.
 func Format(config *composetypes.Config, formatter string) (string, error) {
 	driversMu.RLock()
-	d, present := drivers[formatter]
+	d, ok := drivers[formatter]
 	driversMu.RUnlock()
-	if !present {
-		return "", errors.Errorf("unknown presenter %q", formatter)
+	if !ok {
+		return "", errors.Errorf("unknown formatter %q", formatter)
 	}
 	s, err := d.Format(config)
 	if err != nil {

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -64,7 +64,7 @@ func TestRegisteredDrivers(t *testing.T) {
 func TestFormatNonExistentDriver(t *testing.T) {
 	_, err := Format(&composetypes.Config{}, "toto")
 	assert.Check(t, err != nil)
-	assert.Check(t, is.ErrorContains(err, `unknown presenter "toto"`))
+	assert.Check(t, is.ErrorContains(err, `unknown formatter "toto"`))
 }
 
 func TestFormatErrorDriver(t *testing.T) {
@@ -80,7 +80,7 @@ func TestFormatNone(t *testing.T) {
 	defer resetDrivers()
 	_, err := Format(&composetypes.Config{}, "none")
 	assert.Check(t, err != nil)
-	assert.Check(t, is.ErrorContains(err, `unknown presenter "none"`))
+	assert.Check(t, is.ErrorContains(err, `unknown formatter "none"`))
 }
 
 func TestFormat(t *testing.T) {


### PR DESCRIPTION
**- What I did**
Renamed the render `--presenter` flag to `--formatter` and removed the short flag as `-f` would conflict with settings files.

**- How I did it**
- Changed flag
- Updated tests

**- How to verify it**
```bash
$ docker-app render --help
Usage:	docker-app render <app-name> [-s key=value...] [-f settings-file...] [flags]

Render the Compose file for the application.

Options:
      --formatter string             Configure the output format (yaml|json) (default "yaml")
  -o, --output string                Output file (default "-")
  -s, --set stringArray              Override settings values
  -f, --settings-files stringArray   Override settings files
$ pwd
GOPATH/src/github.com/docker/app/examples/hello-world
$ docker-app render --formatter json
{
  "services": {
    "hello": {
      "build": {},
      "command": [
        "-text",
        "Hello, World!"
      ],
      "credential_spec": {},
      "deploy": {
        "resources": {},
        "placement": {}
      },
      "image": "hashicorp/http-echo",
      "ports": [
        {
          "mode": "ingress",
          "target": 5678,
          "published": 8080,
          "protocol": "tcp"
        }
      ]
    }
  },
  "version": "3.6"
}
```

**- Description for the changelog**
- Render now has an option to format the output in JSON or YAML
