### PR TITLE
Bump wget command in README to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ More examples are available in the [examples](examples) directory.
 Pre-built binaries are available on [GitHub releases](https://github.com/docker/app/releases) for Windows, Linux and macOS.
 
 ```bash
-wget https://github.com/docker/app/releases/download/v0.4.1/docker-app-linux.tar.gz
+wget https://github.com/docker/app/releases/download/v0.5.0/docker-app-linux.tar.gz
 tar xf docker-app-linux.tar.gz
 cp docker-app-linux /usr/local/bin/docker-app
 ```


### PR DESCRIPTION
**- What I did**
Updated the `wget` command in the README to point to v0.5.0.

**- How to verify it**
1. Run `wget` command in README
1. Extract binary
1. Verify that it is v0.5.0 using `docker-app-linux version`

**- Description for the changelog**
N/A
