### PR TITLE
split/merge: Fix loading from image/URL with an empty target.

### DIFF
--- a/cmd/docker-app/split.go
+++ b/cmd/docker-app/split.go
@@ -3,7 +3,9 @@ package main
 import (
 	"os"
 
+	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/packager"
+	"github.com/docker/app/types"
 	"github.com/docker/cli/cli"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -22,9 +24,14 @@ func splitCmd() *cobra.Command {
 				return err
 			}
 			defer extractedApp.Cleanup()
-			inPlace := splitOutputDir == ""
-			if inPlace {
-				splitOutputDir = extractedApp.Path + ".tmp"
+			inPlace := false
+			if splitOutputDir == "" {
+				if extractedApp.Source == types.AppSourceURL || extractedApp.Source == types.AppSourceImage {
+					splitOutputDir = internal.DirNameFromAppName(extractedApp.Name)
+				} else {
+					inPlace = true
+					splitOutputDir = extractedApp.Path + ".tmp"
+				}
 			}
 			if err := packager.Split(extractedApp, splitOutputDir); err != nil {
 				return err

--- a/internal/packager/extract.go
+++ b/internal/packager/extract.go
@@ -113,15 +113,18 @@ func Extract(name string, ops ...func(*types.App) error) (*types.App, error) {
 		// URL or docker image
 		u, err := url.Parse(name)
 		if err == nil && (u.Scheme == "http" || u.Scheme == "https") {
+			ops = append(ops, types.WithSource(types.AppSourceURL))
 			return loader.LoadFromURL(name, ops...)
 		}
 		// look for a docker image
+		ops = append(ops, types.WithSource(types.AppSourceImage))
 		return extractImage(name, ops...)
 	}
 	if s.IsDir() {
 		// directory: already decompressed
 		appOpts := append(ops,
 			types.WithPath(appname),
+			types.WithSource(types.AppSourceSplit),
 		)
 		return loader.LoadFromDirectory(appname, appOpts...)
 	}
@@ -133,7 +136,9 @@ func Extract(name string, ops ...func(*types.App) error) (*types.App, error) {
 			return nil, err
 		}
 		defer f.Close()
+		ops = append(ops, types.WithSource(types.AppSourceMerged))
 		return loader.LoadFromSingleFile(appname, f, ops...)
 	}
+	app.Source = types.AppSourceArchive
 	return app, nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -15,11 +15,28 @@ import (
 // SingleFileSeparator is the separator used in single-file app
 const SingleFileSeparator = "\n---\n"
 
+// AppSourceKind represents what format the app was in when read
+type AppSourceKind int
+
+const (
+	// AppSourceSplit represents an Application in multiple file format
+	AppSourceSplit AppSourceKind = iota
+	// AppSourceMerged represents an Application in single file format
+	AppSourceMerged
+	// AppSourceImage represents an Application pulled from an image
+	AppSourceImage
+	// AppSourceURL represents an Application fetched from an URL
+	AppSourceURL
+	// AppSourceArchive represents an Application in an archive format
+	AppSourceArchive
+)
+
 // App represents an app
 type App struct {
 	Name    string
 	Path    string
 	Cleanup func()
+	Source  AppSourceKind
 
 	composesContent [][]byte
 	settingsContent [][]byte
@@ -121,6 +138,14 @@ func WithPath(path string) func(*App) error {
 func WithCleanup(f func()) func(*App) error {
 	return func(app *App) error {
 		app.Cleanup = f
+		return nil
+	}
+}
+
+// WithSource sets the source of the app
+func WithSource(source AppSourceKind) func(*App) error {
+	return func(app *App) error {
+		app.Source = source
 		return nil
 	}
 }


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add a Source field to App to track the kind of the source data was extracted from.
Use it to handle URL and Image cases in split/merge when no explicit target is given.

**- How to verify it**

`docker-app split bearclaw/coolapp.dockerapp:0.1.0` works

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- `split and merge` called from an image without an explicit target dir/file now works as expected.

**- A picture of a cute animal (not mandatory but encouraged)**


![catfetch](https://user-images.githubusercontent.com/3638847/45877767-3a474880-bd9f-11e8-8a1a-4f2734ce71f2.jpg)

