### PR TITLE
 Add functionality to yatee to preserve order in templated YAML files.

### DIFF
--- a/pkg/yatee/yatee_test.go
+++ b/pkg/yatee/yatee_test.go
@@ -43,7 +43,6 @@ func testProcess(t *testing.T, input, output, settings, error string) {
 	} else {
 		assert.Equal(t, err.Error(), error)
 	}
-
 }
 
 func TestProcess(t *testing.T) {
@@ -143,4 +142,39 @@ ab:
 		"",
 		settings,
 		"eval loop detected")
+}
+
+func testProcessWithOrder(t *testing.T, input, output, error string) {
+	settings := make(map[string]interface{})
+
+	res, err := ProcessWithOrder(input, settings)
+
+	assert.NilError(t, err, "Error processing input: "+input)
+	sres, err := yaml.Marshal(res)
+	assert.NilError(t, err)
+	assert.Equal(t, output, string(sres), "Input was:"+string(sres)+"\nOutput was:"+output)
+}
+
+func TestProcessWithOrder(t *testing.T) {
+	// Test ordering is preserved inside nested structures
+	testProcessWithOrder(t,
+		`parent:
+  bb: true
+  aa: false
+`, `parent:
+  bb: true
+  aa: false
+`, "")
+
+	// Test ordering is preserved at the top level
+	testProcessWithOrder(t,
+		`bbb:
+  nested: true
+aaa:
+  nested: false
+`, `bbb:
+  nested: true
+aaa:
+  nested: false
+`, "")
 }


### PR DESCRIPTION
I left the original `Process` method intact and made `ProcessOrdered` function to preserve the the order.

**- Description for the changelog**

Add functionality to yatee to preserve order in templated YAML files.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1557887/46365137-b0855e00-c66f-11e8-9879-8513adb96066.png)
