### PR TITLE
DirNameFromAppName: Accept a trailing '/'.

### DIFF
--- a/internal/names.go
+++ b/internal/names.go
@@ -36,7 +36,7 @@ func AppNameFromDir(dirName string) string {
 // DirNameFromAppName takes an application name and returns the
 // corresponding directory name
 func DirNameFromAppName(appName string) string {
-	if strings.HasSuffix(appName, AppExtension) {
+	if strings.HasSuffix(strings.TrimSuffix(appName, "/"), AppExtension) {
 		return appName
 	}
 	return appName + AppExtension


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Accept a trailing slash in fully qualified app name. bash completion adds a trailing slash when completing a directory.

**- How to verify it**

`docker-app render myapp.dockerapp/` now works

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- The command line now accepts an application directory name with a trailing slash.

