### PR TITLE
Fix attachments on deploy by switching the working directory

### DIFF
--- a/cmd/docker-app/deploy.go
+++ b/cmd/docker-app/deploy.go
@@ -77,8 +77,10 @@ func runDeploy(dockerCli command.Cli, flags *pflag.FlagSet, appname string, opts
 	if stackName == "" {
 		stackName = internal.AppNameFromDir(app.Name)
 	}
-	if err := os.Chdir(app.Path); err != nil {
-		return err
+	if app.Source.ShouldRunInsideDirectory() {
+		if err := os.Chdir(app.Path); err != nil {
+			return err
+		}
 	}
 	return stack.RunDeploy(dockerCli, flags, rendered, deployOrchestrator, options.Deploy{
 		Namespace:        stackName,

--- a/cmd/docker-app/deploy.go
+++ b/cmd/docker-app/deploy.go
@@ -18,15 +18,14 @@ import (
 )
 
 type deployOptions struct {
-	deployComposeFiles         []string
-	deploySettingsFiles        []string
-	deployEnv                  []string
-	deployOrchestrator         string
-	deployKubeConfig           string
-	deployNamespace            string
-	deployStackName            string
-	deploySendRegistryAuth     bool
-	deployKeepWorkingDirectory bool
+	deployComposeFiles     []string
+	deploySettingsFiles    []string
+	deployEnv              []string
+	deployOrchestrator     string
+	deployKubeConfig       string
+	deployNamespace        string
+	deployStackName        string
+	deploySendRegistryAuth bool
 }
 
 // deployCmd represents the deploy command
@@ -50,7 +49,6 @@ func deployCmd(dockerCli command.Cli) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.deployNamespace, "namespace", "n", "default", "Kubernetes namespace to deploy into")
 	cmd.Flags().StringVarP(&opts.deployStackName, "name", "d", "", "Stack name (default: app name)")
 	cmd.Flags().BoolVarP(&opts.deploySendRegistryAuth, "with-registry-auth", "", false, "Sends registry auth")
-	cmd.Flags().BoolVarP(&opts.deployKeepWorkingDirectory, "keep-workdir", "", false, "Keeps the working directory from where you ran the deploy command (rather than inside the dockerapp directory)")
 	if internal.Experimental == "on" {
 		cmd.Flags().StringArrayVarP(&opts.deployComposeFiles, "compose-files", "c", []string{}, "Override Compose files")
 	}
@@ -79,8 +77,8 @@ func runDeploy(dockerCli command.Cli, flags *pflag.FlagSet, appname string, opts
 	if stackName == "" {
 		stackName = internal.AppNameFromDir(app.Name)
 	}
-	if !opts.deployKeepWorkingDirectory {
-		os.Chdir(app.Path)
+	if err := os.Chdir(app.Path); err != nil {
+		return err
 	}
 	return stack.RunDeploy(dockerCli, flags, rendered, deployOrchestrator, options.Deploy{
 		Namespace:        stackName,

--- a/types/types.go
+++ b/types/types.go
@@ -32,6 +32,11 @@ const (
 	AppSourceArchive
 )
 
+// ShouldRunInsideDirectory returns whether the package is run from a directory on disk
+func (a AppSourceKind) ShouldRunInsideDirectory() bool {
+	return a == AppSourceSplit || a == AppSourceImage || a == AppSourceArchive
+}
+
 // App represents an app
 type App struct {
 	Name    string


### PR DESCRIPTION
**- What I did**
Added code to switch the working directory to the app directory when deploying a docker-app from the registry, a tarball, or from an existing directory on disk.

This is important for the usage of the Attachments work when the docker-compose file refers to files that it expects in a relative path to the working directory.

**- How I did it**
Added a chdir command and grouped the AppSourceKind into a helper method.

**- How to verify it**
Manually tested; there are no automated deploy tests.

**- Description for the changelog**
`docker-app deploy` will now change the working directory to the app directory when deploying a docker-app from the registry, a tarball, or from an existing directory on disk. There was a workaround for this bug beforehand which will no longer work: if the image relies on files on disk, the recommended workflow is to now bundle those files inside the app package as attachments.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1557887/46542718-0566e580-c8b7-11e8-9841-65bca543c8c5.png)

