### PR TITLE
deploy: New experimental option --render-config. New experimental command render-file.

### DIFF
--- a/cmd/docker-app/renderfile.go
+++ b/cmd/docker-app/renderfile.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/docker/app/internal/packager"
+	"github.com/docker/app/render"
+	"github.com/docker/app/types"
+	"github.com/docker/cli/cli"
+	cliopts "github.com/docker/cli/opts"
+	"github.com/spf13/cobra"
+)
+
+type renderFileOptions struct {
+	renderSettingsFile []string
+	renderEnv          []string
+}
+
+func renderFileCmd() *cobra.Command {
+	var opts renderFileOptions
+	cmd := &cobra.Command{
+		Use:   "render-attachment [<app-path>] <file-path>",
+		Short: "render specified file",
+		Args:  cli.RequiresRangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var appname, filename string
+			if len(args) == 1 {
+				filename = args[0]
+			} else {
+				appname = args[0]
+				filename = args[1]
+			}
+			app, err := packager.Extract(appname,
+				types.WithSettingsFiles(opts.renderSettingsFile...))
+			if err != nil {
+				return err
+			}
+			data, err := ioutil.ReadFile(filepath.Join(app.Path, filename))
+			if err != nil {
+				return err
+			}
+			d := cliopts.ConvertKVStringsToMap(opts.renderEnv)
+			result, err := render.RenderConfig(app, d, string(data))
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s", result)
+			return nil
+		},
+	}
+	cmd.Flags().StringArrayVarP(&opts.renderSettingsFile, "settings-files", "f", []string{}, "Override settings files")
+	cmd.Flags().StringArrayVarP(&opts.renderEnv, "set", "s", []string{}, "Override settings values")
+	return cmd
+}

--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -62,6 +62,7 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 			imageLoadCmd(),
 			packCmd(dockerCli),
 			pullCmd(),
+			renderFileCmd(),
 			unpackCmd(),
 		)
 	}

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -47,6 +47,15 @@ func TestRenderTemplates(t *testing.T) {
 	}
 }
 
+func TestRenderAttachment(t *testing.T) {
+	skip.If(t, !hasExperimental, "experimental mode needed for this test")
+	result := icmd.RunCommand(dockerApp, "render-attachment",
+		"testdata/helm.dockerapp",
+		"attachment.yml",
+		"-s", "setting=bam").Assert(t, icmd.Success)
+	assert.Assert(t, golden.String(result.Stdout(), "attachment-rendered.yml"))
+}
+
 func TestRender(t *testing.T) {
 	appsPath := filepath.Join("testdata", "render")
 	apps, err := ioutil.ReadDir(appsPath)

--- a/e2e/testdata/attachment-rendered.yml
+++ b/e2e/testdata/attachment-rendered.yml
@@ -1,0 +1,2 @@
+configuration:
+  setting: bam

--- a/e2e/testdata/helm.dockerapp/attachment.yml
+++ b/e2e/testdata/helm.dockerapp/attachment.yml
@@ -1,0 +1,2 @@
+configuration:
+  setting: {{ .setting}}


### PR DESCRIPTION
**What I did**
* All the attachments are now going by default through the rendering phase and the template engines.
* Added an **experimental** `--skip-rendering-pattern` flag to the `deploy` command, which takes a list of glob patterns, to define which attachments to skip 
* Add an **experimental** `render-attachment` command to print the result of an attachment rendering, for debug purpose.

**How to test it**
```sh
# build docker-app with experimental features
$ make EXPERIMENTAL=on bin/docker-app

# create an attachment with a go-template variable to fill
$ echo 'some text with {{.debug}}' > examples/wordpress/wordpress.dockerapp/mysettings.ini

# render the attachment with default settings
$ DOCKERAPP_RENDERERS=gotemplate ./bin/docker-app render-attachment examples/wordpress/wordpress.dockerapp mysettings.ini
some text with true

# render the attachment and override the setting
$ DOCKERAPP_RENDERERS=gotemplate ./bin/docker-app render-attachment examples/wordpress/wordpress.dockerapp mysettings.ini --set debug=false
some text with false
```