### PR TITLE
 render: err out if any setting value is nil after merge.

### DIFF
--- a/cmd/docker-app/renderfile.go
+++ b/cmd/docker-app/renderfile.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/docker/app/internal/packager"
+	"github.com/docker/app/render"
+	"github.com/docker/app/types"
+	"github.com/docker/cli/cli"
+	cliopts "github.com/docker/cli/opts"
+	"github.com/spf13/cobra"
+)
+
+type renderFileOptions struct {
+	renderSettingsFile []string
+	renderEnv          []string
+}
+
+func renderFileCmd() *cobra.Command {
+	var opts renderFileOptions
+	cmd := &cobra.Command{
+		Use:   "render-attachment [<app-path>] <file-path>",
+		Short: "render specified file",
+		Args:  cli.RequiresRangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var appname, filename string
+			if len(args) == 1 {
+				filename = args[0]
+			} else {
+				appname = args[0]
+				filename = args[1]
+			}
+			app, err := packager.Extract(appname,
+				types.WithSettingsFiles(opts.renderSettingsFile...))
+			if err != nil {
+				return err
+			}
+			data, err := ioutil.ReadFile(filepath.Join(app.Path, filename))
+			if err != nil {
+				return err
+			}
+			d := cliopts.ConvertKVStringsToMap(opts.renderEnv)
+			result, err := render.RenderConfig(app, d, string(data))
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s", result)
+			return nil
+		},
+	}
+	cmd.Flags().StringArrayVarP(&opts.renderSettingsFile, "settings-files", "f", []string{}, "Override settings files")
+	cmd.Flags().StringArrayVarP(&opts.renderEnv, "set", "s", []string{}, "Override settings values")
+	return cmd
+}

--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -62,6 +62,7 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 			imageLoadCmd(),
 			packCmd(dockerCli),
 			pullCmd(),
+			renderFileCmd(),
 			unpackCmd(),
 		)
 	}

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -47,6 +47,15 @@ func TestRenderTemplates(t *testing.T) {
 	}
 }
 
+func TestRenderAttachment(t *testing.T) {
+	skip.If(t, !hasExperimental, "experimental mode needed for this test")
+	result := icmd.RunCommand(dockerApp, "render-attachment",
+		"testdata/helm.dockerapp",
+		"attachment.yml",
+		"-s", "setting=bam").Assert(t, icmd.Success)
+	assert.Assert(t, golden.String(result.Stdout(), "attachment-rendered.yml"))
+}
+
 func TestRender(t *testing.T) {
 	appsPath := filepath.Join("testdata", "render")
 	apps, err := ioutil.ReadDir(appsPath)

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -95,6 +95,11 @@ func TestRenderFormatters(t *testing.T) {
 	assert.Assert(t, golden.String(result.Stdout(), "expected-yaml-render.golden"))
 }
 
+func TestMandatorySettings(t *testing.T) {
+	icmd.RunCommand(dockerApp, "render", "testdata/mandatory-settings").Assert(t, icmd.Expected{ExitCode: 1})
+	icmd.RunCommand(dockerApp, "render", "testdata/mandatory-settings", "-s", "mandatory=12", "-s", "mandat.ory=13").Assert(t, icmd.Success)
+}
+
 func TestInit(t *testing.T) {
 	composeData := `version: "3.2"
 services:

--- a/e2e/testdata/attachment-rendered.yml
+++ b/e2e/testdata/attachment-rendered.yml
@@ -1,0 +1,2 @@
+configuration:
+  setting: bam

--- a/e2e/testdata/helm.dockerapp/attachment.yml
+++ b/e2e/testdata/helm.dockerapp/attachment.yml
@@ -1,0 +1,2 @@
+configuration:
+  setting: {{ .setting}}

--- a/e2e/testdata/mandatory-settings.dockerapp
+++ b/e2e/testdata/mandatory-settings.dockerapp
@@ -1,0 +1,31 @@
+# This section contains your application metadata.
+# Version of the application
+version: 0.1.0
+# Name of the application
+name: hello-world
+# A short description of the application
+description: "Hello, World!"
+# Namespace to use when pushing to a registry. This is typically your Hub username.
+namespace: myHubUsername
+# List of application maintainers with name and email for each
+maintainers:
+  - name: user
+    email: "user@email.com"
+
+---
+# This section contains the Compose file that describes your application services.
+version: "3.6"
+services:
+  hello:
+    image: hashicorp/http-echo
+    command: ["-text", "${text}"]
+    ports:
+      - ${port}:5678
+
+---
+# This section contains the default values for your application settings.
+port: 8080
+text: Hello, World!
+mandatory: null
+mandat:
+  ory: null

--- a/render/render.go
+++ b/render/render.go
@@ -58,6 +58,17 @@ func makeSettings(app *types.App, env map[string]string) (settings.Settings, err
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to merge settings")
 	}
+	// check for remaining nil values and err if present
+	// metadata can contain nil values (email) so skip it
+	fileEnvSettings, err := settings.Merge(fileSettings, envSettings)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to merge settings")
+	}
+	nilKeys := settings.NilKeys(fileEnvSettings)
+	if len(nilKeys) != 0 {
+		return nil, fmt.Errorf("the following settings must be set: %s", strings.Join(nilKeys, ","))
+	}
+
 	return allSettings, nil
 }
 

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -192,3 +192,25 @@ services:
 	assert.Assert(t, c != nil)
 	assert.NilError(t, err)
 }
+
+func TestRenderWithNullSettings(t *testing.T) {
+	metadata := strings.NewReader(validMeta)
+	composeFile := strings.NewReader(`
+version: "3.6"
+services:
+    hello:
+        image: ${image}`)
+	settings := strings.NewReader(`image: null`)
+	app := &types.App{Path: "my-app"}
+	err := types.Metadata(metadata)(app)
+	assert.NilError(t, err)
+	err = types.WithComposes(composeFile)(app)
+	assert.NilError(t, err)
+	err = types.WithSettings(settings)(app)
+	assert.NilError(t, err)
+	_, err = Render(app, nil)
+	assert.ErrorContains(t, err, "the following settings must be set: image")
+	c, err := Render(app, map[string]string{"image": "myimage"})
+	assert.NilError(t, err)
+	assert.Assert(t, c != nil)
+}

--- a/types/settings/merge.go
+++ b/types/settings/merge.go
@@ -12,6 +12,14 @@ func Merge(settings ...Settings) (Settings, error) {
 		if err := mergo.Merge(&s, setting, mergo.WithOverride, mergo.WithAppendSlice); err != nil {
 			return s, errors.Wrap(err, "cannot merge settings")
 		}
+		// Workaround: mergo drops top-level nil values
+		for k, v := range setting {
+			if v == nil {
+				if _, ok := s[k]; !ok {
+					s[k] = nil
+				}
+			}
+		}
 	}
 	return s, nil
 }

--- a/types/settings/settings.go
+++ b/types/settings/settings.go
@@ -106,3 +106,39 @@ func assignKey(m map[string]interface{}, keys []string, value interface{}) error
 	}
 	return assignKey(m[key].(map[string]interface{}), ks, value)
 }
+
+func nilKeysList(l []interface{}, prefix string, res *[]string) {
+	for i, v := range l {
+		key := fmt.Sprintf("%s[%v]", prefix, i)
+		if v == nil {
+			*res = append(*res, key)
+		}
+		switch vv := v.(type) {
+		case map[string]interface{}:
+			nilKeys(vv, key+".", res)
+		case []interface{}:
+			nilKeysList(vv, key+".", res)
+		}
+	}
+}
+
+func nilKeys(s map[string]interface{}, prefix string, res *[]string) {
+	for k, v := range s {
+		if v == nil {
+			*res = append(*res, prefix+k)
+		}
+		switch vv := v.(type) {
+		case map[string]interface{}:
+			nilKeys(vv, prefix+k+".", res)
+		case []interface{}:
+			nilKeysList(vv, prefix+k+".", res)
+		}
+	}
+}
+
+// NilKeys return the list of keys with a nil value
+func NilKeys(settings Settings) []string {
+	var res []string
+	nilKeys(settings, "", &res)
+	return res
+}


### PR DESCRIPTION
This allows the application maintainer to define mandatory settings, by giving them the `null` value.

**- What I did**

Err out if any nil value is detected in settings after merge.

**- How to verify it**

e2e test was added

**- Description for the changelog**
- application rendering will now fail if any setting has the nil value. This allows maintainers to define mandatory settings that must be overridden.
