### PR TITLE
Tweak makefile error message to be more descriptive 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ all: bin/$(BIN_NAME) test
 
 check_go_env:
 	@test $$(go list) = "$(PKG_NAME)" || \
-		(echo "Invalid Go environment" && false)
+		(echo "Invalid Go environment - The local directory structure must match:  $(PKG_NAME)" && false)
 
 cross: bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-windows.exe ## cross-compile binaries (linux, darwin, windows)
 


### PR DESCRIPTION
**- What I did**
Tweaked the error message inside the makefile to make it clear when you have git cloned to the wrong directory (newcomers to golang may do this without understanding you can't do this).

The old error message implied your entire golang install was corrupt.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1557887/46809719-07252300-cd67-11e8-8bf3-00bd612b863d.png)

