### PR TITLE
Jenkinsfile: constrain all jobs to nodes with the `team-local` label

### DIFF
--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -2,7 +2,7 @@ properties([buildDiscarder(logRotator(numToKeepStr: '20'))])
 
 pipeline {
     agent {
-        label 'pipeline'
+        label 'team-local && pipeline'
     }
 
     options {
@@ -12,7 +12,7 @@ pipeline {
     stages {
         stage('Build') {
             agent {
-                label 'linux'
+                label 'team-local && linux'
             }
             steps  {
                 dir('src/github.com/docker/app') {
@@ -54,7 +54,7 @@ pipeline {
                         CODECOV_TOKEN = credentials('jenkins-codecov-token')
                     }
                     agent {
-                        label 'linux'
+                        label 'team-local && linux'
                     }
                     steps {
                         dir('src/github.com/docker/app') {
@@ -68,7 +68,7 @@ pipeline {
                 }
                 stage("Gradle test") {
                     agent {
-                        label 'linux'
+                        label 'team-local && linux'
                     }
                     steps {
                         dir('src/github.com/docker/app') {
@@ -82,7 +82,7 @@ pipeline {
                 }
                 stage("Test Linux") {
                     agent {
-                        label 'linux'
+                        label 'team-local && linux'
                     }
 		    environment {
 			DOCKERAPP_BINARY = '../docker-app-linux'
@@ -107,7 +107,7 @@ pipeline {
                 }
                 stage("Test Mac") {
                     agent {
-                        label "mac"
+                        label 'team-local && mac'
                     }
 		    environment {
 			DOCKERAPP_BINARY = '../docker-app-darwin'
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stage("Test Win") {
                     agent {
-                        label "windows"
+                        label 'team-local && windows && linux-containers'
                     }
 		    environment {
 			DOCKERAPP_BINARY = '../docker-app-windows.exe'
@@ -159,7 +159,7 @@ pipeline {
         }
         stage('Release') {
             agent {
-                label "linux"
+                label 'team-local && linux'
             }
             when {
                 buildingTag()


### PR DESCRIPTION
Our Jenkins service now supports auto-scalling cloud worker nodes, however
these are not always compatible with what we need. In particular they contain
nodes labelled `windows` which are configured for Windows containers rather
than Linux containers.

To avoid this for now we have added a `team-local` label to all of the
non-cloud worker nodes (i.e. the ones which are local to the team on the
Jenkins server) and this change adds that selector to the pipeline stages.

Also add `linux-containers` to the Windows job which expects that (this label
was preexisting on the node but not used).

Finally, we were inconsistent in the types of quotes being used (double vs
single) so since we are touching every line use single quotes for them all.

Signed-off-by: Ian Campbell <ijc@docker.com>
