### PR TITLE
WIP - Add --disable flag to render command

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -39,10 +39,11 @@ func (a AppSourceKind) ShouldRunInsideDirectory() bool {
 
 // App represents an app
 type App struct {
-	Name    string
-	Path    string
-	Cleanup func()
-	Source  AppSourceKind
+	Name             string
+	Path             string
+	Cleanup          func()
+	Source           AppSourceKind
+	DisabledServices map[string]bool
 
 	composesContent [][]byte
 	settingsContent [][]byte
@@ -151,6 +152,14 @@ func NewAppFromDefaultFiles(path string, ops ...func(*App) error) (*App, error) 
 func WithName(name string) func(*App) error {
 	return func(app *App) error {
 		app.Name = name
+		return nil
+	}
+}
+
+// WithDisabledServices sets the disabled/ignored services
+func WithDisabledServices(disabledServices map[string]bool) func(*App) error {
+	return func(app *App) error {
+		app.DisabledServices = disabledServices
 		return nil
 	}
 }


### PR DESCRIPTION
Adds a set/map with the services to be ignored by the render command.
All other usages of render.Render() just pass 'nil'.

Note that it's a WIP PR. 
Maybe we could use a better name for the flag and use the concept of filtering for other concepts.

Closes #396 

**- What I did**
Added the capability to remove services from the render by specifying them in the command line.

**- How I did it**
Added a new flag in the "render" command called "disable"

**- How to verify it**
Given an already existing application package that contains 3 services called "service1", "service2" and "service3" run:
```
docker-app render --disable service1 --disable service2
```
Only "service3" should be rendered

**- Description for the changelog**
Add a flag to the render command and pass the service names collected through the render.Render to be filtered afterwards

![cat-ignore-deprecation-warnings](https://user-images.githubusercontent.com/373485/48421695-475c3480-e75d-11e8-820f-642911d2e2c8.jpg)