### PR TITLE
WIP Adds docker-app image to dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,11 @@ RUN make EXPERIMENTAL=${EXPERIMENTAL} cross
 FROM cross AS e2e-cross
 ARG EXPERIMENTAL="off"
 RUN make EXPERIMENTAL=${EXPERIMENTAL} e2e-cross
+
+# Image to be pushed to DockerHub
+# To be run as:
+# docker run -v ${PWD}:/mnt -w /mnt docker/app --help
+FROM alpine AS export-image
+COPY --from=cross /go/src/github.com/docker/app/bin/docker-app-linux /usr/bin/docker-app
+ENTRYPOINT ["/usr/bin/docker-app"]
+CMD []

--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -14,6 +14,9 @@ pipeline {
             agent {
                 label 'team-local && linux'
             }
+            environment {
+                DOCKERHUB_CREDS=credentials('dockerhub-dockerdsgcibot')
+            }
             steps  {
                 dir('src/github.com/docker/app') {
                     script {
@@ -21,6 +24,12 @@ pipeline {
                             checkout scm
                             sh 'make -f docker.Makefile lint'
                             sh 'make -f docker.Makefile cross e2e-cross tars'
+
+                            // This block is just for simulating a possible push to dockerhub, but without the push
+                            sh 'docker login --username "${DOCKERHUB_CREDS_USR}" --password "${DOCKERHUB_CREDS_PSW}"'
+                            sh 'make TAG_NAME=buildtesttag -f docker.Makefile dockerhub-build'
+                            sh 'docker logout'
+
                             dir('bin') {
                                 stash name: 'binaries'
                             }
@@ -59,6 +68,7 @@ pipeline {
                     steps {
                         dir('src/github.com/docker/app') {
                             checkout scm
+                            sh 'echo $(git describe --abbrev=0 --tags)'
                             sh 'make -f docker.Makefile coverage'
                             archiveArtifacts '_build/ci-cov/all.out'
                             archiveArtifacts '_build/ci-cov/coverage.html'
@@ -170,6 +180,32 @@ pipeline {
                     echo "Releasing $TAG_NAME"
                     dir('bin') {
                         release('docker/app')
+                    }
+                }
+            }
+            post {
+                always {
+                    deleteDir()
+                }
+            }
+        }
+        stage('Publish image to DockerHub') {
+            agent {
+                label 'team-local && linux'
+            }
+            when{
+                buildingTag()
+            }
+            environment {
+                DOCKERHUB_CREDS=credentials('dockerhub-dockerdsgcibot')
+            }
+            steps {
+                dir('src/github.com/docker/app') {
+                    checkout scm
+                    script {
+                        sh 'docker login --username "${DOCKERHUB_CREDS_USR}" --password "${DOCKERHUB_CREDS_PSW}"'
+                        sh 'make TAG_NAME=${TAG_NAME} -f docker.Makefile dockerhub-publish'
+                        sh 'docker logout'
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ cp docker-app-linux /usr/local/bin/docker-app
 
 **Note:** To use Application Packages as images (i.e.: `save`, `push`, or `deploy` when package is not present locally) on Windows, one must be in Linux container mode.
 
+### Pulling docker image
+`docker-app` also has Docker images. To pull the latest one, run:
+```bash
+$ docker pull docker/app
+```
+
+For more about the usage of the docker image, please refer to [Docker image usage](#docker-image-usage) for more information.
+
 ## Integrating with Helm
 
 `docker-app` comes with a few other helpful commands as well, in particular the ability to create Helm Charts from your Docker Applications. This can be useful if you're adopting Kubernetes, and standardising on Helm to manage the lifecycle of your application components, but want to maintain the simplicity of Compose when writing you applications. This also makes it easy to run the same applications locally just using Docker, if you don't want to be running a full Kubernetes cluster.
@@ -271,6 +279,19 @@ Commands:
 
 Run 'docker-app COMMAND --help' for more information on a command.
 ```
+
+### Docker image usage
+`docker-app` can also run as a Docker image, for example:
+```sh
+$ docker run -v ${PWD}:/mnt -w /mnt docker/app version
+Version:      <Version>
+Git commit:   <Commit id>
+Built:        <Date of the build>
+OS/Arch:      linux/amd64
+Experimental: off
+Renderers:    none
+```
+**Note**: the `-v` stands for volume that has to be mapped so the container can reach the host's file system in case of running any command that has files as input or output
 
 ## Shell completion
 

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -6,6 +6,7 @@ BIN_IMAGE_NAME := $(BIN_NAME)-bin:$(TAG)
 CROSS_IMAGE_NAME := $(BIN_NAME)-cross:$(TAG)
 E2E_CROSS_IMAGE_NAME := $(BIN_NAME)-e2e-cross:$(TAG)
 GRADLE_IMAGE_NAME := $(BIN_NAME)-gradle:$(TAG)
+DOCKERHUB_IMAGE_NAME := docker/app
 
 BIN_CTNR_NAME := $(BIN_NAME)-bin-$(TAG)
 CROSS_CTNR_NAME := $(BIN_NAME)-cross-$(TAG)
@@ -50,6 +51,14 @@ e2e-cross: create_bin
 	@$(call chmod,+x,bin/$(BIN_NAME)-e2e-linux)
 	@$(call chmod,+x,bin/$(BIN_NAME)-e2e-darwin)
 	@$(call chmod,+x,bin/$(BIN_NAME)-e2e-windows.exe)
+
+dockerhub-build:
+	if [ -z "$(TAG_NAME)" ] ; then echo "No TAG_NAME specified"; exit 1; fi
+	docker build $(BUILD_ARGS) --target export-image -t $(DOCKERHUB_IMAGE_NAME):$(TAG_NAME) -t $(DOCKERHUB_IMAGE_NAME):latest .
+
+dockerhub-publish: dockerhub-build
+	docker push $(DOCKERHUB_IMAGE_NAME):$(TAG_NAME)
+	docker push $(DOCKERHUB_IMAGE_NAME):latest
 
 tars:
 	tar czf bin/$(BIN_NAME)-linux.tar.gz -C bin $(BIN_NAME)-linux
@@ -98,4 +107,4 @@ schemas: specification/bindata.go ## generate specification/bindata.go from json
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-.PHONY: lint test-e2e test-unit test cross e2e-cross coverage gradle-test shell build_dev_image tars vendor schemas help
+.PHONY: lint test-e2e test-unit test cross e2e-cross coverage gradle-test shell build_dev_image tars vendor schemas help dockerhub-publish dockerhub-build


### PR DESCRIPTION
**- What I did**
Add a docker-app image to dockerhub so that people can run it in a container or use it as a base image.  
Ex: `docker run -v ${PWD}:/mnt -w /mnt docker/app --help`

The intent is to implement #367

**- How I did it**
Adding a new docker image of docker-app in the Dockerfile to be exported to dockerhub.
Also, a new stage in the Jenkinsfile is available so that it can push a new docker image to Dockerhub when a tag is built.

**- How to verify it**
When pushing a new tag to git, a new docker image should be pushed to dockerhub just after passing the tests.

**- Description for the changelog**
New images are now pushed to dockerhub as soon as a Tag is pushed to github and it passes the tests stages.

**- A picture of a cute animal (not mandatory but encouraged)**
![cao-deliver](https://user-images.githubusercontent.com/373485/48719250-52133f80-ec1d-11e8-82d8-4d382e6755ba.jpg)