### PR TITLE
WIP (DO NOT MERGE) - Add validation just before execution of `deploy` and `push` commands. Should include `init`?

### DIFF
--- a/cmd/docker-app/cmd_utils.go
+++ b/cmd/docker-app/cmd_utils.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	cliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/debug"
+	cliflags "github.com/docker/cli/cli/flags"
+)
+
+func firstOrEmpty(list []string) string {
+	if len(list) != 0 {
+		return list[0]
+	}
+	return ""
+}
+
+func dockerPreRun(opts *cliflags.ClientOptions) {
+	cliflags.SetLogLevel(opts.Common.LogLevel)
+	if opts.ConfigDir != "" {
+		cliconfig.SetDir(opts.ConfigDir)
+	}
+	if opts.Common.Debug {
+		debug.Enable()
+	}
+}

--- a/cmd/docker-app/push.go
+++ b/cmd/docker-app/push.go
@@ -26,6 +26,10 @@ func pushCmd() *cobra.Command {
 				return err
 			}
 			defer app.Cleanup()
+			err = runValidation(app)
+			if err != nil {
+				return err
+			}
 			dgst, err := packager.Push(app, opts.namespace, opts.tag, opts.repo)
 			if err == nil {
 				fmt.Println(dgst)

--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -6,8 +6,6 @@ import (
 	"github.com/docker/app/internal"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	cliconfig "github.com/docker/cli/cli/config"
-	"github.com/docker/cli/cli/debug"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -64,24 +62,5 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 			pullCmd(),
 			unpackCmd(),
 		)
-	}
-}
-
-func firstOrEmpty(list []string) string {
-	if len(list) != 0 {
-		return list[0]
-	}
-	return ""
-}
-
-func dockerPreRun(opts *cliflags.ClientOptions) {
-	cliflags.SetLogLevel(opts.Common.LogLevel)
-
-	if opts.ConfigDir != "" {
-		cliconfig.SetDir(opts.ConfigDir)
-	}
-
-	if opts.Common.Debug {
-		debug.Enable()
 	}
 }

--- a/cmd/docker-app/validate.go
+++ b/cmd/docker-app/validate.go
@@ -20,19 +20,21 @@ func validateCmd() *cobra.Command {
 		Short: "Checks the rendered application is syntactically correct",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			app, err := packager.Extract(firstOrEmpty(args),
-				types.WithSettingsFiles(validateSettingsFile...),
-			)
+			app, err := packager.Extract(firstOrEmpty(args), types.WithSettingsFiles(validateSettingsFile...))
 			if err != nil {
 				return err
 			}
 			defer app.Cleanup()
-			argSettings := cliopts.ConvertKVStringsToMap(validateEnv)
-			_, err = render.Render(app, argSettings)
-			return err
+			return runValidation(app)
 		},
 	}
 	cmd.Flags().StringArrayVarP(&validateSettingsFile, "settings-files", "f", []string{}, "Override settings files")
 	cmd.Flags().StringArrayVarP(&validateEnv, "set", "s", []string{}, "Override settings values")
 	return cmd
+}
+
+func runValidation(app *types.App) error {
+	argSettings := cliopts.ConvertKVStringsToMap(validateEnv)
+	_, err := render.Render(app, argSettings)
+	return err
 }


### PR DESCRIPTION
**- What I did**
Added validation before `deploy` and `push`

Closes: https://github.com/docker/app/issues/424

**- How I did it**
I extracted the validation to a function, so we can call it from other commands, then it's just a question of calling it at the very beginning of the other commands and check it's return error

**- How to verify it**
Can be tested by commenting any mandatory fields, like metadata's `version` then trying to `push` or `deploy`

**- Description for the changelog**
Added validation before `deploy` and `push`
![mouse](https://user-images.githubusercontent.com/373485/49452164-ef0ad680-f7e0-11e8-888a-71bec9d659e7.jpg)

