### PR TITLE
Image map support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -159,7 +159,7 @@
   revision = "0377f7d767206f3a9e8881d0f02267b0d89c7a62"
 
 [[projects]]
-  digest = "1:a72272dfefbb22c87cda3dbefbb256741d861d2fb727210a66e0df0df6084b30"
+  digest = "1:9a4926a6de553a8f80d958a622308b86dadf199dde2602e88fe6e1943d1890e9"
   name = "github.com/containerd/cri"
   packages = ["pkg/util"]
   pruneopts = "NUT"
@@ -183,7 +183,7 @@
   revision = "461401dc8f19d80baa4b70178935e4501286c00b"
 
 [[projects]]
-  digest = "1:9e2dbc126e8e5314cba3ab654b2183376dc81cb657ca8c588f86990f5da88cbc"
+  digest = "1:76a167b7658125360bbd52626d85031c89383c0ec6f3e4e25afd776c9a27f286"
   name = "github.com/coreos/etcd"
   packages = ["raft/raftpb"]
   pruneopts = "NUT"
@@ -199,8 +199,8 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "master-docker-app"
-  digest = "1:00492a2d9a8dd69a2c1c882ccfc90b60420b014ea57adc12bcef91b4f92c9008"
+  branch = "master"
+  digest = "1:e2033d363ec4e251ae535f558c51269c78c05bcb0e1eded55ea1800ff58d86ef"
   name = "github.com/deislabs/duffle"
   packages = [
     "pkg/action",
@@ -214,8 +214,7 @@
     "pkg/utils/crud",
   ]
   pruneopts = "NUT"
-  revision = "85a7e9ff937150d0e4cae5acf36bfb2598a536cd"
-  source = "github.com/silvin-lubecki/duffle"
+  revision = "eaa7595bd231ca353ec886708405fe4deba91968"
 
 [[projects]]
   digest = "1:657236b6a87fbaf9e27e2029be1b4f49fc6367f61a4ac106c012576c414cbcc0"
@@ -315,7 +314,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b1ebf6d2021d75519a0e508774eb0df1a9f25ddcef2a3a75c4e3d662fc0cd773"
+  digest = "1:6e16b5aee97695cb06862f865a433e510622be6a03a34ddea5be12622cafb7c5"
   name = "github.com/docker/docker"
   packages = [
     "api",
@@ -1108,7 +1107,7 @@
   source = "https://github.com/simonferquel/yaml"
 
 [[projects]]
-  digest = "1:8eed93b935c1abf503719923397fce5258a94a7834f35323e41c5c61b9e7bfe6"
+  digest = "1:fba52eeb003a81a7ad2eb9c92f139c43a8b0a4e8cc51c049fd03a2eb8f6894ae"
   name = "gotest.tools"
   packages = [
     "assert",
@@ -1277,7 +1276,7 @@
   revision = "kubernetes-1.11.1"
 
 [[projects]]
-  digest = "1:18254705f2e912ec0142b7b36546c5d38d74e9d137c8d243985bff4d247eed81"
+  digest = "1:34af467590a9aa09701c1c3bea1fa6cdd5e8a8478e0baff9b8f6d4ba9518a42d"
   name = "k8s.io/kubernetes"
   packages = ["pkg/api/v1/pod"]
   pruneopts = "NUT"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,11 +31,9 @@ required = ["github.com/wadey/gocovmerge"]
   name = "github.com/docker/cli"
   revision = "f95ca8e1ba6c22c9abcdbf65e8dcc39c53958bba"
 
-# Waiting for https://github.com/deislabs/duffle/pull/617 to be merged
 [[override]]
   name = "github.com/deislabs/duffle"
-  branch = "master-docker-app"
-  source = "github.com/silvin-lubecki/duffle"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/cmd/docker-app/bundle.go
+++ b/cmd/docker-app/bundle.go
@@ -99,7 +99,7 @@ func makeBundleFromApp(dockerCli command.Cli, app *types.App, namespace, invocat
 	if err := jsonmessage.DisplayJSONMessagesStream(buildResp.Body, ioutil.Discard, 0, false, func(jsonmessage.JSONMessage) {}); err != nil {
 		return nil, err
 	}
-	return packager.ToCNAB(app, invocationImageName), nil
+	return packager.ToCNAB(app, invocationImageName)
 }
 
 func makeImageName(meta metadata.AppMetadata, namespace, name, suffix string) (string, error) {

--- a/cmd/docker-app/inspect.go
+++ b/cmd/docker-app/inspect.go
@@ -29,7 +29,7 @@ func inspectCmd(dockerCli command.Cli) *cobra.Command {
 			}
 			defer app.Cleanup()
 			argParameters := cliopts.ConvertKVStringsToMap(inspectEnv)
-			return inspect.Inspect(dockerCli.Out(), app, argParameters)
+			return inspect.Inspect(dockerCli.Out(), app, argParameters, nil)
 		},
 	}
 	cmd.Flags().StringArrayVarP(&inspectParametersFile, "parameters-files", "f", []string{}, "Override with parameters from files")

--- a/cmd/docker-app/render.go
+++ b/cmd/docker-app/render.go
@@ -39,7 +39,7 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 			}
 			defer app.Cleanup()
 			d := cliopts.ConvertKVStringsToMap(renderEnv)
-			rendered, err := render.Render(app, d)
+			rendered, err := render.Render(app, d, nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/docker-app/validate.go
+++ b/cmd/docker-app/validate.go
@@ -28,7 +28,7 @@ func validateCmd() *cobra.Command {
 			}
 			defer app.Cleanup()
 			argParameters := cliopts.ConvertKVStringsToMap(validateEnv)
-			_, err = render.Render(app, argParameters)
+			_, err = render.Render(app, argParameters, nil)
 			return err
 		},
 	}

--- a/examples_test.go
+++ b/examples_test.go
@@ -18,12 +18,12 @@ func Example() {
 	defer f.Close()
 	app, err := loader.LoadFromSingleFile("myApp", f)
 	if err != nil {
-		panic("cannot load application")
+		panic("cannot load application: " + err.Error())
 	}
 	// Render the app to a composefile format, using some user provided parameters
 	c, err := render.Render(app, map[string]string{
 		"text": "hello examples!",
-	})
+	}, nil)
 	if err != nil {
 		panic("cannot render application")
 	}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -26,29 +26,32 @@ var (
 )
 
 // Load applies the specified function when loading a slice of compose data
-func Load(composes [][]byte, apply func(string) (string, error)) ([]composetypes.ConfigFile, error) {
+func Load(composes [][]byte, apply func(string) (string, error)) ([]composetypes.ConfigFile, map[string]string, error) {
 	configFiles := []composetypes.ConfigFile{}
 	for _, data := range composes {
 		s, err := apply(string(data))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		parsed, err := loader.ParseYAML([]byte(s))
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to parse Compose file %s", data)
+			return nil, nil, errors.Wrapf(err, "failed to parse Compose file %s", data)
 		}
 		configFiles = append(configFiles, composetypes.ConfigFile{Config: parsed})
 	}
 
-	if err := validateImageInConfigFiles(configFiles); err != nil {
-		return nil, err
+	images, err := validateImagesInConfigFiles(configFiles)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return configFiles, nil
+	return configFiles, images, nil
 }
 
-func validateImageInConfigFiles(configFiles []composetypes.ConfigFile) error {
+// validateImagesInConfigFiles validates that there is no unsupported variable expensions in service images and returns a map of service name -> image
+func validateImagesInConfigFiles(configFiles []composetypes.ConfigFile) (map[string]string, error) {
 	var errors []string
+	images := map[string]string{}
 	for _, configFile := range configFiles {
 		services, ok := configFile.Config["services"].(map[string]interface{})
 		if !ok {
@@ -63,6 +66,7 @@ func validateImageInConfigFiles(configFiles []composetypes.ConfigFile) error {
 			if !ok {
 				continue
 			}
+			images[serviceName] = imageName
 
 			if ExtrapolationPattern.MatchString(imageName) {
 				errors = append(errors,
@@ -73,10 +77,10 @@ func validateImageInConfigFiles(configFiles []composetypes.ConfigFile) error {
 	}
 
 	if len(errors) > 0 {
-		return fmt.Errorf("%s", strings.Join(errors, "\n"))
+		return nil, fmt.Errorf("%s", strings.Join(errors, "\n"))
 	}
 
-	return nil
+	return images, nil
 }
 
 // ExtractVariables extracts the variables from the specified compose data

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -54,7 +54,8 @@ services:
 }
 
 func runLoad(composeFile []byte) ([]composetypes.ConfigFile, error) {
-	return Load([][]byte{composeFile}, func(data string) (string, error) {
+	files, _, err := Load([][]byte{composeFile}, func(data string) (string, error) {
 		return renderer.Apply(data, map[string]interface{}{"image": "nginx"})
 	})
+	return files, err
 }

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/deislabs/duffle/pkg/bundle"
 	"github.com/docker/app/render"
 	"github.com/docker/app/types"
 	"github.com/docker/app/types/parameters"
@@ -15,9 +16,9 @@ import (
 )
 
 // Inspect dumps the metadata of an app
-func Inspect(out io.Writer, app *types.App, argParameters map[string]string) error {
+func Inspect(out io.Writer, app *types.App, argParameters map[string]string, imageMap map[string]bundle.Image) error {
 	// Render the compose file
-	config, err := render.Render(app, argParameters)
+	config, err := render.Render(app, argParameters, imageMap)
 	if err != nil {
 		return err
 	}

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -110,7 +110,7 @@ text: hello`),
 			outBuffer := new(bytes.Buffer)
 			app, err := types.NewAppFromDefaultFiles(dir.Join(testcase.name))
 			assert.NilError(t, err)
-			err = Inspect(outBuffer, app, testcase.args)
+			err = Inspect(outBuffer, app, testcase.args, nil)
 			assert.NilError(t, err)
 			assert.Assert(t, golden.String(outBuffer.String(), fmt.Sprintf("inspect-%s.golden", testcase.name)))
 		})

--- a/internal/packager/cnab_test.go
+++ b/internal/packager/cnab_test.go
@@ -11,7 +11,8 @@ import (
 func TestToCNAB(t *testing.T) {
 	app, err := types.NewAppFromDefaultFiles("testdata/packages/packing.dockerapp")
 	assert.NilError(t, err)
-	actual := ToCNAB(app, "test-image")
+	actual, err := ToCNAB(app, "test-image")
+	assert.NilError(t, err)
 	expected := &bundle.Bundle{
 		Description: "hello",
 		Name:        "my-namespace/packing",
@@ -59,12 +60,12 @@ func TestToCNAB(t *testing.T) {
 				},
 				DefaultValue: "",
 			},
-			"watcher.image": {
+			"watcher.cmd": {
 				DataType: "string",
 				Destination: &bundle.Location{
 					EnvironmentVariable: "docker_param1",
 				},
-				DefaultValue: "watcher:latest",
+				DefaultValue: "foo",
 			},
 		},
 		Actions: map[string]bundle.Action{
@@ -73,6 +74,36 @@ func TestToCNAB(t *testing.T) {
 			},
 			"status": {
 				Modifies: false,
+			},
+		},
+		Images: map[string]bundle.Image{
+			"front": {
+				Description: "nginx",
+				BaseImage: bundle.BaseImage{
+					Image:     "nginx",
+					ImageType: "docker",
+				},
+			},
+			"debug": {
+				Description: "busybox:latest",
+				BaseImage: bundle.BaseImage{
+					Image:     "busybox:latest",
+					ImageType: "docker",
+				},
+			},
+			"monitor": {
+				Description: "busybox:latest",
+				BaseImage: bundle.BaseImage{
+					Image:     "busybox:latest",
+					ImageType: "docker",
+				},
+			},
+			"app-watcher": {
+				Description: "watcher",
+				BaseImage: bundle.BaseImage{
+					Image:     "watcher",
+					ImageType: "docker",
+				},
 			},
 		},
 	}

--- a/internal/packager/testdata/packages/packing.dockerapp/docker-compose.yml
+++ b/internal/packager/testdata/packages/packing.dockerapp/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   front:
-    image: nginx:${myapp.nginx_version}
+    image: nginx
     deploy:
       replicas: ${myapp.nginx_replicas}
   debug:
@@ -26,4 +26,4 @@ services:
     command: monitor --source ${app.name}-${app.version} $$dollar
     x-enabled: "! ${myapp.debug}"
   app-watcher:
-    image: $watcher.image
+    image: watcher

--- a/internal/packager/testdata/packages/packing.dockerapp/parameters.yml
+++ b/internal/packager/testdata/packages/packing.dockerapp/parameters.yml
@@ -1,2 +1,2 @@
 watcher:
-  image: watcher:latest
+  cmd: foo

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/deislabs/duffle/pkg/bundle"
 	"github.com/docker/app/types"
 	composetypes "github.com/docker/cli/cli/compose/types"
 	yaml "gopkg.in/yaml.v2"
@@ -32,7 +33,7 @@ func TestRenderMissingValue(t *testing.T) {
 	finalEnv := map[string]string{
 		"imageName": "foo",
 	}
-	_, err := render(configFiles, finalEnv)
+	_, err := render(configFiles, finalEnv, nil)
 	assert.Check(t, err != nil)
 	assert.Check(t, is.ErrorContains(err, "required variable"))
 }
@@ -55,7 +56,7 @@ func TestRender(t *testing.T) {
 		"version": "latest",
 		"foo.bar": "baz",
 	}
-	c, err := render(configFiles, finalEnv)
+	c, err := render(configFiles, finalEnv, nil)
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(c.Services, 1))
 	assert.Check(t, is.Equal(c.Services[0].Image, "busybox:latest"))
@@ -80,7 +81,7 @@ func TestRenderEnabledFalse(t *testing.T) {
 		}
 		c, err := render(configs, map[string]string{
 			"myapp.debug": "true",
-		})
+		}, nil)
 		assert.NilError(t, err)
 		assert.Check(t, is.Len(c.Services, 0))
 	}
@@ -119,7 +120,7 @@ back:
 		"front.port":            "4242",
 		"back.port":             "6666",
 	}
-	c, err := Render(app, userParameters)
+	c, err := Render(app, userParameters, nil)
 	assert.NilError(t, err)
 	s, err := yaml.Marshal(c)
 	assert.NilError(t, err)
@@ -162,7 +163,7 @@ services:
 	userParameters := map[string]string{
 		"nginx.replicas": "9",
 	}
-	c, err := Render(app, userParameters)
+	c, err := Render(app, userParameters, nil)
 	assert.NilError(t, err)
 	s, err := yaml.Marshal(c)
 	assert.NilError(t, err)
@@ -184,7 +185,7 @@ unknown-property: value`)
 	assert.NilError(t, err)
 	err = types.WithComposes(brokenComposeFile)(app)
 	assert.NilError(t, err)
-	c, err := Render(app, nil)
+	c, err := Render(app, nil, nil)
 	assert.Assert(t, is.Nil(c))
 	assert.Error(t, err, "failed to load Compose file: unknown-property Additional property unknown-property is not allowed")
 }
@@ -206,7 +207,28 @@ services:
 	assert.NilError(t, err)
 	err = types.WithParameters(parameters)(app)
 	assert.NilError(t, err)
-	c, err := Render(app, nil)
+	c, err := Render(app, nil, nil)
 	assert.Assert(t, c != nil)
 	assert.NilError(t, err)
+}
+
+func TestServiceImageOverride(t *testing.T) {
+	configFiles := []composetypes.ConfigFile{
+		{
+			Config: map[string]interface{}{
+				"version": "3",
+				"services": map[string]interface{}{
+					"foo": map[string]interface{}{
+						"image": "busybox",
+					},
+				},
+			},
+		},
+	}
+	c, err := render(configFiles, nil, map[string]bundle.Image{
+		"foo": {BaseImage: bundle.BaseImage{Image: "test"}},
+	})
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(c.Services, 1))
+	assert.Check(t, is.Equal(c.Services[0].Image, "test"))
 }

--- a/vendor/github.com/deislabs/duffle/pkg/action/action.go
+++ b/vendor/github.com/deislabs/duffle/pkg/action/action.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -39,8 +40,19 @@ func selectInvocationImage(d driver.Driver, c *claim.Claim) (bundle.InvocationIm
 	return bundle.InvocationImage{}, errors.New("driver is not compatible with any of the invocation images in the bundle")
 }
 
+func getImageMap(b *bundle.Bundle) ([]byte, error) {
+	imgs := b.Images
+	if imgs == nil {
+		imgs = make(map[string]bundle.Image)
+	}
+	return json.Marshal(imgs)
+}
+
 func opFromClaim(action string, c *claim.Claim, ii bundle.InvocationImage, creds credentials.Set, w io.Writer) (*driver.Operation, error) {
 	env, files, err := creds.Expand(c.Bundle)
+	if err != nil {
+		return nil, err
+	}
 
 	// Quick verification that no params were passed that are not actual legit params.
 	for key := range c.Parameters {
@@ -68,6 +80,12 @@ func opFromClaim(action string, c *claim.Claim, ii bundle.InvocationImage, creds
 		}
 	}
 
+	imgMap, err := getImageMap(c.Bundle)
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate image map: %s", err)
+	}
+	files["/cnab/app/image-map.json"] = string(imgMap)
+
 	env["CNAB_INSTALLATION_NAME"] = c.Name
 	env["CNAB_ACTION"] = action
 	env["CNAB_BUNDLE_NAME"] = c.Bundle.Name
@@ -83,5 +101,5 @@ func opFromClaim(action string, c *claim.Claim, ii bundle.InvocationImage, creds
 		Environment:  env,
 		Files:        files,
 		Out:          w,
-	}, err
+	}, nil
 }

--- a/vendor/github.com/deislabs/duffle/pkg/bundle/bundle.go
+++ b/vendor/github.com/deislabs/duffle/pkg/bundle/bundle.go
@@ -18,7 +18,7 @@ type Bundle struct {
 	Keywords         []string                       `json:"keywords,omitempty" mapstructure:"keywords,omitempty"`
 	Maintainers      []Maintainer                   `json:"maintainers,omitempty" mapstructure:"maintainers,omitempty"`
 	InvocationImages []InvocationImage              `json:"invocationImages" mapstructure:"invocationImages"`
-	Images           []Image                        `json:"images" mapstructure:"images"`
+	Images           map[string]Image               `json:"images" mapstructure:"images"`
 	Actions          map[string]Action              `json:"actions,omitempty" mapstructure:"actions,omitempty"`
 	Parameters       map[string]ParameterDefinition `json:"parameters" mapstructure:"parameters"`
 	Credentials      map[string]Location            `json:"credentials" mapstructure:"credentials"`

--- a/vendor/github.com/deislabs/duffle/pkg/driver/docker_driver.go
+++ b/vendor/github.com/deislabs/duffle/pkg/driver/docker_driver.go
@@ -83,12 +83,9 @@ func pullImage(ctx context.Context, cli command.Cli, image string) error {
 		return err
 	}
 	defer responseBody.Close()
-	return jsonmessage.DisplayJSONMessagesStream(
-		responseBody,
-		cli.Out(),
-		cli.Out().FD(),
-		cli.Out().IsTerminal(),
-		nil)
+
+	// passing isTerm = false here because of https://github.com/Nvveen/Gotty/pull/1
+	return jsonmessage.DisplayJSONMessagesStream(responseBody, cli.Out(), cli.Out().FD(), false, nil)
 }
 
 func (d *DockerDriver) initializeDockerCli() (command.Cli, error) {


### PR DESCRIPTION
~~This add support for pushing / pull from and to an OCIIndex/DockerManifestList~~ deferred to a followup PR
Adds support for creating image maps, and do image remapping on install (for scenarios like applevel promotion and airgapped scenarios with DTR).