### PR TITLE
Add missing 'TraverseChildren: true' in the cobra.Command

### DIFF
--- a/cmd/docker-app/root.go
+++ b/cmd/docker-app/root.go
@@ -20,10 +20,11 @@ func newRootCmd(dockerCli *command.DockerCli) *cobra.Command {
 	var flags *pflag.FlagSet
 
 	cmd := &cobra.Command{
-		Use:          "docker-app",
-		Short:        "Docker Application Packages",
-		Long:         `Build and deploy Docker Application Packages.`,
-		SilenceUsage: true,
+		Use:              "docker-app",
+		Short:            "Docker Application Packages",
+		Long:             `Build and deploy Docker Application Packages.`,
+		SilenceUsage:     true,
+		TraverseChildren: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.Common.SetDefaultOptions(flags)
 			dockerPreRun(opts)


### PR DESCRIPTION
Closes #448

**- What I did**
Added missing 'TraverseChildren: true' in the cobra.Command

**- How I did it**
See above

**- How to verify it**
`./bin/docker-app --log-level=debug completion`

**- Description for the changelog**
Add missing 'TraverseChildren: true' in the cobra.Command