### PR TITLE
CNAB Status action is no more a default action

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -103,3 +103,11 @@ directly against `go test` to run root-requiring tests.
 # run the test <TEST_NAME>:
 go test -v -run "<TEST_NAME>" .
 ```
+
+**NOTE** if the tests fail with an error message like `"Error: manifest
+ for docker/cnab-app-base:v0.6.0-68-g3ae57efdb6-dirty not found"`, it means
+ you forgot to rebuild the base invocation image, simply run
+
+ ```sh
+ $ make -f docker.Makefile invocation-image
+ ```

--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -24,8 +24,8 @@ pipeline {
                             script {
                                 try {
                                     checkout scm
-                                    sh 'make -f docker.Makefile BUILD_TAG=$BUILD_TAG lint'
-                                    sh 'make -f docker.Makefile BUILD_TAG=$BUILD_TAG cross e2e-cross tars'
+                                    sh 'make -f docker.Makefile lint'
+                                    sh 'make -f docker.Makefile cli-cross cross e2e-cross tars'
                                     dir('bin') {
                                         stash name: 'binaries'
                                     }
@@ -40,7 +40,7 @@ pipeline {
                                     }
                                     archiveArtifacts 'bin/*.tar.gz'
                                 } finally {
-                                    def clean_images = /docker image ls --format="{{.ID}}" '*$BUILD_TAG*' | xargs docker image rm -f/
+                                    def clean_images = /docker image ls --format="{{.Repository}}:{{.Tag}}" '*$BUILD_TAG*' | xargs docker image rm -f/
                                     sh clean_images
                                 }
                             }
@@ -59,7 +59,7 @@ pipeline {
                     steps {
                         dir('src/github.com/docker/app') {
                             checkout scm
-                            sh 'make -f docker.Makefile BUILD_TAG=$BUILD_TAG save-invocation-image'
+                            sh 'make -f docker.Makefile save-invocation-image'
                             dir('_build') {
                                 stash name: 'invocation-image', includes: 'invocation-image.tar'
                                 archiveArtifacts 'invocation-image.tar'
@@ -104,7 +104,7 @@ pipeline {
                             dir("bin") {
                                 unstash "binaries"
                             }
-                            sh 'make -f docker.Makefile BUILD_TAG=$BUILD_TAG gradle-test'
+                            sh 'make -f docker.Makefile gradle-test'
                         }
                     }
                     post {
@@ -119,6 +119,7 @@ pipeline {
                     }
                     environment {
                         DOCKERAPP_BINARY = '../docker-app-linux'
+                        DOCKERCLI_BINARY = '../docker-linux'
                     }
                     steps  {
                         dir('src/github.com/docker/app') {
@@ -150,6 +151,7 @@ pipeline {
                     }
                     environment {
                         DOCKERAPP_BINARY = '../docker-app-darwin'
+                        DOCKERCLI_BINARY = '../docker-darwin'
                     }
                     steps {
                         dir('src/github.com/docker/app') {
@@ -181,6 +183,7 @@ pipeline {
                     }
                     environment {
                         DOCKERAPP_BINARY = '../docker-app-windows.exe'
+                        DOCKERCLI_BINARY = '../docker-windows.exe'
                     }
                     steps {
                         dir('src/github.com/docker/app') {
@@ -227,7 +230,7 @@ pipeline {
                         unstash "invocation-image"
                         sh 'docker load -i invocation-image.tar'
                     }
-                    sh 'make -f docker.Makefile BUILD_TAG=$BUILD_TAG push-invocation-image'
+                    sh 'make -f docker.Makefile push-invocation-image'
                 }
                 unstash 'artifacts'
                 echo "Releasing $TAG_NAME"

--- a/README.md
+++ b/README.md
@@ -150,10 +150,9 @@ More examples are available in the [examples](examples) directory.
 ## CNAB
 
 Under the hood `docker-app` is CNAB compliant. It generates a CNAB from your application source and is able to install and manage any other CNAB too.
-CNAB specifies four actions which `docker-app` provides as commands:
+CNAB specifies three actions which `docker-app` provides as commands:
 - `install`
 - `upgrade`
-- `status`
 - `uninstall`
 
 **Note**: These commands need a Docker Context so that `docker-app` knows which endpoint and orchestrator to target.

--- a/cmd/docker-app/status.go
+++ b/cmd/docker-app/status.go
@@ -7,6 +7,7 @@ import (
 	"github.com/deislabs/duffle/pkg/utils/crud"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -48,8 +49,10 @@ func runStatus(dockerCli command.Cli, claimName string, opts credentialOptions) 
 	if err := credentials.Validate(creds, c.Bundle.Credentials); err != nil {
 		return err
 	}
-	status := &action.Status{
+	status := &action.RunCustom{
+		Action: "status",
 		Driver: driverImpl,
 	}
-	return status.Run(&c, creds, dockerCli.Out())
+	err = status.Run(&c, creds, dockerCli.Out())
+	return errors.Wrap(err, "Status failed")
 }

--- a/e2e/cnab_test.go
+++ b/e2e/cnab_test.go
@@ -1,0 +1,65 @@
+package e2e
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+	"gotest.tools/fs"
+	"gotest.tools/icmd"
+)
+
+func TestCallCustomStatusAction(t *testing.T) {
+	testCases := []struct {
+		name           string
+		exitCode       int
+		expectedOutput string
+		cnab           string
+	}{
+		{
+			name:           "validCustomStatusAction",
+			exitCode:       0,
+			expectedOutput: "Status action",
+			cnab:           "cnab-with-status",
+		},
+		{
+			name:           "missingCustomStatusAction",
+			exitCode:       1,
+			expectedOutput: "Error: Status failed: action not defined for bundle",
+			cnab:           "cnab-without-status",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tmpDir := fs.NewDir(t, t.Name())
+			defer tmpDir.Remove()
+			testDir := path.Join("testdata", testCase.cnab)
+			cmd := icmd.Cmd{
+				Env: []string{fmt.Sprintf("DUFFLE_HOME=%s", tmpDir.Path())},
+			}
+
+			// Build CNAB invocation image
+			cmd.Command = []string{"docker", "build", "-f", path.Join(testDir, "cnab", "build", "Dockerfile"), "-t", fmt.Sprintf("e2e/%s:v0.1.0", testCase.cnab), testDir}
+			icmd.RunCmd(cmd).Assert(t, icmd.Success)
+
+			// docker-app install
+			cmd.Command = []string{dockerApp, "install", path.Join(testDir, "bundle.json"), "--name", testCase.name}
+			icmd.RunCmd(cmd).Assert(t, icmd.Success)
+
+			// docker-app uninstall
+			defer func() {
+				cmd.Command = []string{dockerApp, "uninstall", testCase.name}
+				icmd.RunCmd(cmd).Assert(t, icmd.Success)
+			}()
+
+			// docker-app status
+			cmd.Command = []string{dockerApp, "status", testCase.name}
+			result := icmd.RunCmd(cmd)
+			result.Assert(t, icmd.Expected{ExitCode: testCase.exitCode})
+			assert.Assert(t, is.Contains(result.Combined(), testCase.expectedOutput))
+		})
+	}
+}

--- a/e2e/cnab_test.go
+++ b/e2e/cnab_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"path"
+	"runtime"
 	"testing"
 
 	"gotest.tools/assert"
@@ -41,6 +42,13 @@ func TestCallCustomStatusAction(t *testing.T) {
 				Env: []string{fmt.Sprintf("DUFFLE_HOME=%s", tmpDir.Path())},
 			}
 
+			// We need to explicitly set the SYSTEMROOT on windows
+			// otherwise we get the error:
+			// "panic: failed to read random bytes: CryptAcquireContext: Provider DLL failed to initialize correctly."
+			// See: https://github.com/golang/go/issues/25210
+			if runtime.GOOS == "windows" {
+				cmd.Env = append(cmd.Env, `SYSTEMROOT=C:\WINDOWS`)
+			}
 			// Build CNAB invocation image
 			cmd.Command = []string{"docker", "build", "-f", path.Join(testDir, "cnab", "build", "Dockerfile"), "-t", fmt.Sprintf("e2e/%s:v0.1.0", testCase.cnab), testDir}
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)

--- a/e2e/helper.go
+++ b/e2e/helper.go
@@ -28,7 +28,7 @@ func NewContainer(image string, privatePort int) *Container {
 
 // Start starts a new docker container on a random port
 func (c *Container) Start(t *testing.T) {
-	result := icmd.RunCommand("docker", "run", "--rm", "-d", "-P", c.image).Assert(t, icmd.Success)
+	result := icmd.RunCommand("docker", "run", "--rm", "--privileged", "-d", "-P", c.image).Assert(t, icmd.Success)
 	c.container = strings.Trim(result.Stdout(), " \r\n")
 	time.Sleep(time.Second * 3)
 }

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -13,6 +13,7 @@ import (
 var (
 	e2ePath         = flag.String("e2e-path", ".", "Set path to the e2e directory")
 	dockerApp       = os.Getenv("DOCKERAPP_BINARY")
+	dockerCli       = os.Getenv("DOCKERCLI_BINARY")
 	hasExperimental = false
 	renderers       = ""
 )
@@ -32,6 +33,9 @@ func TestMain(m *testing.M) {
 	dockerApp, err = filepath.Abs(dockerApp)
 	if err != nil {
 		panic(err)
+	}
+	if dockerCli == "" {
+		dockerCli = "docker"
 	}
 	cmd := exec.Command(dockerApp, "version")
 	output, err := cmd.CombinedOutput()

--- a/e2e/testdata/cnab-with-status/bundle.json
+++ b/e2e/testdata/cnab-with-status/bundle.json
@@ -1,0 +1,15 @@
+{
+  "name": "cnab-with-status",
+  "version": "0.1.0",
+  "invocationImages": [
+    {
+      "imageType": "docker",
+      "image": "e2e/cnab-with-status:v0.1.0"
+    }
+  ],
+  "actions": {
+    "status": {
+      "modifies": false
+    }
+  }
+}

--- a/e2e/testdata/cnab-with-status/cnab/app/run
+++ b/e2e/testdata/cnab-with-status/cnab/app/run
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+action=$CNAB_ACTION
+name=$CNAB_INSTALLATION_NAME
+
+case $action in
+    install)
+    echo "Install action"
+    ;;
+    uninstall)
+    echo "uninstall action"
+    ;;
+    upgrade)
+    echo "Upgrade action"
+    ;;
+    status)
+    echo "Status action"
+    ;;
+    *)
+    echo "No action for $action"
+    ;;
+esac
+echo "Action $action complete for $name"

--- a/e2e/testdata/cnab-with-status/cnab/build/Dockerfile
+++ b/e2e/testdata/cnab-with-status/cnab/build/Dockerfile
@@ -1,0 +1,7 @@
+ARG ALPINE_VERSION=3.8
+
+FROM alpine:${ALPINE_VERSION}
+
+COPY cnab/app/run /cnab/app/run
+
+CMD /cnab/app/run

--- a/e2e/testdata/cnab-without-status/bundle.json
+++ b/e2e/testdata/cnab-without-status/bundle.json
@@ -1,0 +1,10 @@
+{
+    "name": "cnab-without-status",
+    "version": "0.1.0",
+    "invocationImages": [
+        {
+        "imageType": "docker",
+        "image": "e2e/cnab-without-status:v0.1.0"
+        }
+    ]
+}

--- a/e2e/testdata/cnab-without-status/cnab/app/run
+++ b/e2e/testdata/cnab-without-status/cnab/app/run
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+action=$CNAB_ACTION
+name=$CNAB_INSTALLATION_NAME
+
+case $action in
+    install)
+    echo "Install action"
+    ;;
+    uninstall)
+    echo "uninstall action"
+    ;;
+    upgrade)
+    echo "Upgrade action"
+    ;;
+    *)
+    echo "No action for $action"
+    ;;
+esac
+echo "Action $action complete for $name"

--- a/e2e/testdata/cnab-without-status/cnab/build/Dockerfile
+++ b/e2e/testdata/cnab-without-status/cnab/build/Dockerfile
@@ -1,0 +1,7 @@
+ARG ALPINE_VERSION=3.8
+
+FROM alpine:${ALPINE_VERSION}
+
+COPY cnab/app/run /cnab/app/run
+
+CMD /cnab/app/run

--- a/internal/packager/cnab.go
+++ b/internal/packager/cnab.go
@@ -81,6 +81,9 @@ func ToCNAB(app *types.App, invocationImageName string) *bundle.Bundle {
 			"inspect": {
 				Modifies: false,
 			},
+			"status": {
+				Modifies: false,
+			},
 		},
 	}
 }

--- a/internal/packager/cnab_test.go
+++ b/internal/packager/cnab_test.go
@@ -71,6 +71,9 @@ func TestToCNAB(t *testing.T) {
 			"inspect": {
 				Modifies: false,
 			},
+			"status": {
+				Modifies: false,
+			},
 		},
 	}
 	assert.DeepEqual(t, actual, expected)

--- a/vars.mk
+++ b/vars.mk
@@ -24,10 +24,12 @@ else
   NULL := /dev/null
 endif
 
-ifeq ($(TAG),)
-  TAG := $(shell git describe --always --dirty --abbrev=10 2> $(NULL))
-endif
 ifeq ($(COMMIT),)
   COMMIT := $(shell git rev-parse --short HEAD 2> $(NULL))
 endif
-BUILD_TAG ?= $(TAG)
+ifeq ($(BUILD_TAG),)
+  BUILD_TAG := $(shell git describe --always --dirty --abbrev=10 2> $(NULL))
+endif
+ifeq ($(TAG),)
+  TAG := $(BUILD_TAG)
+endif


### PR DESCRIPTION
Signed-off-by: Djordje Lukic <djordje.lukic@docker.com>

**- What I did**
CNAB spec changed, the `status` action is no more a default action so we are checking if the status action exists before calling it as a custom action.

**- How to verify it**
Run `docker-app status <NAME>` on an app that doesn't have the status action

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/52129506-fa8b4a00-2637-11e9-9997-df932a45640e.png)

