### PR TITLE
Build invocation image locally

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -105,9 +105,9 @@ go test -v -run "<TEST_NAME>" .
 ```
 
 **NOTE** if the tests fail with an error message like `"Error: manifest
- for docker/cnab-app-base:v0.6.0-68-g3ae57efdb6-dirty not found"`, it means
- you forgot to rebuild the base invocation image, simply run
+for docker/cnab-app-base:v0.6.0-68-g3ae57efdb6-dirty not found"`, it means
+you forgot to rebuild the base invocation image, simply run
 
 ```sh
-$ make invocation-image
+$ make -f docker.Makefile invocation-image
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -108,6 +108,6 @@ go test -v -run "<TEST_NAME>" .
  for docker/cnab-app-base:v0.6.0-68-g3ae57efdb6-dirty not found"`, it means
  you forgot to rebuild the base invocation image, simply run
 
- ```sh
- $ make -f docker.Makefile invocation-image
- ```
+```sh
+$ make invocation-image
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
-ARG ALPINE_VERSION=3.8
-ARG GO_VERSION=1.11.0
-
 FROM dockercore/golang-cross:1.11.5@sha256:17a7e0f158521c50316a0d0c1ab1f6a75350b4d82e7ef03c98bcfbdf04feb4f3 AS build
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 
@@ -41,16 +38,3 @@ ARG EXPERIMENTAL="off"
 ARG TAG="unknown"
 # Run e2e tests
 RUN make EXPERIMENTAL=${EXPERIMENTAL} TAG=${TAG} e2e-cross
-
-# builder of invocation image entrypoint
-FROM build AS invocation-build
-COPY . .
-ARG EXPERIMENTAL="off"
-RUN make EXPERIMENTAL=${EXPERIMENTAL} bin/cnab-run
-
-# cnab invocation image
-FROM alpine:${ALPINE_VERSION} AS invocation
-RUN apk add --no-cache ca-certificates
-COPY --from=invocation-build /go/src/github.com/docker/app/bin/cnab-run /cnab/app/run
-WORKDIR /cnab/app
-CMD /cnab/app/run

--- a/Dockerfile.invocation-image
+++ b/Dockerfile.invocation-image
@@ -1,0 +1,23 @@
+ARG ALPINE_VERSION=3.8
+ARG GO_VERSION=1.11.0
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
+ARG DOCKERCLI_VERSION=18.03.1-ce
+ARG DOCKERCLI_CHANNEL=edge
+RUN apk add --no-cache \
+  make
+
+WORKDIR /go/src/github.com/docker/app/
+
+# builder of invocation image entrypoint
+FROM build AS invocation-build
+COPY . .
+ARG EXPERIMENTAL="off"
+RUN make EXPERIMENTAL=${EXPERIMENTAL} bin/cnab-run
+
+ # local cnab invocation image
+FROM alpine:${ALPINE_VERSION} as invocation
+RUN apk add --no-cache ca-certificates
+COPY --from=invocation-build /go/src/github.com/docker/app/bin/cnab-run /cnab/app/run
+WORKDIR /cnab/app
+CMD /cnab/app/run

--- a/Dockerfile.invocation-image
+++ b/Dockerfile.invocation-image
@@ -1,16 +1,14 @@
 ARG ALPINE_VERSION=3.8
-ARG GO_VERSION=1.11.0
 
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
-ARG DOCKERCLI_VERSION=18.03.1-ce
-ARG DOCKERCLI_CHANNEL=edge
-RUN apk add --no-cache \
-  make
+FROM dockercore/golang-cross:1.11.5@sha256:17a7e0f158521c50316a0d0c1ab1f6a75350b4d82e7ef03c98bcfbdf04feb4f3 AS build
+
+RUN apt-get install -y -q --no-install-recommends \
+    coreutils \
+    util-linux \
+    uuid-runtime
 
 WORKDIR /go/src/github.com/docker/app/
 
-# builder of invocation image entrypoint
-FROM build AS invocation-build
 COPY . .
 ARG EXPERIMENTAL="off"
 RUN make EXPERIMENTAL=${EXPERIMENTAL} bin/cnab-run
@@ -18,6 +16,6 @@ RUN make EXPERIMENTAL=${EXPERIMENTAL} bin/cnab-run
  # local cnab invocation image
 FROM alpine:${ALPINE_VERSION} as invocation
 RUN apk add --no-cache ca-certificates
-COPY --from=invocation-build /go/src/github.com/docker/app/bin/cnab-run /cnab/app/run
+COPY --from=build /go/src/github.com/docker/app/bin/cnab-run /cnab/app/run
 WORKDIR /cnab/app
 CMD /cnab/app/run

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ endif
 GO_BUILD := CGO_ENABLED=0 go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 GO_TEST := CGO_ENABLED=0 go test -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 
+CNAB_BASE_INVOCATION_IMAGE_NAME := docker/cnab-app-base:$(BUILD_TAG)
+
 all: bin/$(BIN_NAME) test
 
 check_go_env:
@@ -96,6 +98,9 @@ specification/bindata.go: specification/schemas/*.json
 	go generate github.com/docker/app/specification
 
 schemas: specification/bindata.go ## generate specification/bindata.go from json schemas
+
+invocation-image:
+	docker build -f Dockerfile.invocation-image $(BUILD_ARGS) --target=invocation -t $(CNAB_BASE_INVOCATION_IMAGE_NAME) .
 
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ endif
 GO_BUILD := CGO_ENABLED=0 go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 GO_TEST := CGO_ENABLED=0 go test -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 
-CNAB_BASE_INVOCATION_IMAGE_NAME := docker/cnab-app-base:$(BUILD_TAG)
-
 all: bin/$(BIN_NAME) test
 
 check_go_env:
@@ -98,9 +96,6 @@ specification/bindata.go: specification/schemas/*.json
 	go generate github.com/docker/app/specification
 
 schemas: specification/bindata.go ## generate specification/bindata.go from json schemas
-
-invocation-image:
-	docker build -f Dockerfile.invocation-image $(BUILD_ARGS) --target=invocation -t $(CNAB_BASE_INVOCATION_IMAGE_NAME) .
 
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -15,11 +15,10 @@ E2E_CROSS_CTNR_NAME := $(BIN_NAME)-e2e-cross-$(TAG)
 COV_CTNR_NAME := $(BIN_NAME)-cov-$(TAG)
 SCHEMAS_CTNR_NAME := $(BIN_NAME)-schemas-$(TAG)
 
-BUILD_ARGS=--build-arg=EXPERIMENTAL=$(EXPERIMENTAL) --build-arg=TAG=$(TAG) --build-arg=COMMIT=$(COMMIT)
+BUILD_ARGS=--build-arg=EXPERIMENTAL=$(EXPERIMENTAL) --build-arg=TAG=$(TAG) --build-arg=COMMIT=$(COMMIT) --build-arg=ALPINE_VERSION=$(ALPINE_VERSION)
 
 PKG_PATH := /go/src/$(PKG_NAME)
 
-CNAB_BASE_INVOCATION_IMAGE_NAME := docker/cnab-app-base:$(BUILD_TAG)
 PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME := docker/cnab-app-base:$(TAG)
 CNAB_BASE_INVOCATION_IMAGE_PATH := _build/invocation-image.tar
 
@@ -113,7 +112,7 @@ specification/bindata.go: specification/schemas/*.json build_dev_image
 schemas: specification/bindata.go ## generate specification/bindata.go from json schemas
 
 invocation-image:
-	docker build $(BUILD_ARGS) --target=invocation -t $(CNAB_BASE_INVOCATION_IMAGE_NAME) .
+	docker build -f Dockerfile.invocation-image $(BUILD_ARGS) --target=invocation -t $(CNAB_BASE_INVOCATION_IMAGE_NAME) .
 
 save-invocation-image: invocation-image
 	@$(call mkdir,_build)
@@ -126,4 +125,4 @@ push-invocation-image:
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-.PHONY: lint test-e2e test-unit test cli-cross cross e2e-cross coverage gradle-test shell build_dev_image tars vendor schemas help invocation-image save-invocation-image push-invocation-image
+.PHONY: lint test-e2e test-unit test cli-cross cross e2e-cross coverage gradle-test shell build_dev_image tars vendor schemas help save-invocation-image push-invocation-image

--- a/vars.mk
+++ b/vars.mk
@@ -5,6 +5,8 @@ E2E_NAME := $(BIN_NAME)-e2e
 # Enable experimental features. "on" or "off"
 EXPERIMENTAL := off
 
+ALPINE_VERSION=3.8
+
 # Failing to resolve sh.exe to a full path denotes a windows vanilla shell.
 # Although 'simple' commands are still exec'ed, 'complex' ones are batch'ed instead of sh'ed.
 ifeq ($(SHELL),sh.exe)
@@ -33,3 +35,5 @@ endif
 ifeq ($(TAG),)
   TAG := $(BUILD_TAG)
 endif
+
+CNAB_BASE_INVOCATION_IMAGE_NAME := docker/cnab-app-base:$(BUILD_TAG)


### PR DESCRIPTION
**- What I did**
Made a new Dockerfile for building the invocation image locally

**- How I did it**
Took the Dockerfile that existed and removed all the unnecessary targets and changed the first target to be the same as before we were cross-compiling the docker cli.

**- How to verify it**
Run `make invocation-image`

**- A picture of a cute animal (not mandatory but encouraged)**
github has problems uploading the image, here is an ASCII sloth, it's cute, promise
```
      `""==,,__  
        `"==..__"=..__ _    _..-==""_
             .-,`"=/ /\ \""/_)==""``
            ( (    | | | \/ |
             \ '.  |  \;  \ /
              |  \ |   |   ||
         ,-._.'  |_|   |   ||
        .\_/\     -'   ;   Y
       |  `  |        /    |-.
       '. __/_    _.-'     /'
   jgs        `'-.._____.-'
```
