### PR TITLE
Fix coverage on Jenkins

### DIFF
--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -60,8 +60,10 @@ pipeline {
                         dir('src/github.com/docker/app') {
                             checkout scm
                             sh 'make -f docker.Makefile save-invocation-image'
+                            sh 'make -f docker.Makefile save-invocation-image-tag INVOCATION_IMAGE_TAG=$BUILD_TAG-coverage OUTPUT=coverage-invocation-image.tar'
                             dir('_build') {
                                 stash name: 'invocation-image', includes: 'invocation-image.tar'
+                                stash name: 'coverage-invocation-image', includes: 'coverage-invocation-image.tar'
                                 archiveArtifacts 'invocation-image.tar'
                             }
                         }
@@ -69,6 +71,7 @@ pipeline {
                     post {
                         always {
                             sh 'docker rmi docker/cnab-app-base:$BUILD_TAG'
+                            sh 'docker rmi docker/cnab-app-base:$BUILD_TAG-coverage'
                             deleteDir()
                         }
                     }
@@ -87,10 +90,20 @@ pipeline {
                     steps {
                         dir('src/github.com/docker/app') {
                             checkout scm
-                            sh 'make -f docker.Makefile coverage'
+                            dir('_build') {
+                                unstash "coverage-invocation-image"
+                                sh 'docker load -i coverage-invocation-image.tar'
+                            }
+                            sh 'make -f docker.Makefile BUILD_TAG=$BUILD_TAG-coverage coverage'
                             archiveArtifacts '_build/ci-cov/all.out'
                             archiveArtifacts '_build/ci-cov/coverage.html'
                             sh 'curl -s https://codecov.io/bash | bash -s - -f _build/ci-cov/all.out -K'
+                        }
+                    }
+                    post {
+                        always {
+                            sh 'docker rmi docker/cnab-app-base:$BUILD_TAG-coverage'
+                            deleteDir()
                         }
                     }
                 }

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -19,8 +19,11 @@ BUILD_ARGS=--build-arg=EXPERIMENTAL=$(EXPERIMENTAL) --build-arg=TAG=$(TAG) --bui
 
 PKG_PATH := /go/src/$(PKG_NAME)
 
-PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME := docker/cnab-app-base:$(TAG)
+
+CNAB_BASE_INVOCATION_IMAGE_NAME := docker/cnab-app-base:$(BUILD_TAG)
 CNAB_BASE_INVOCATION_IMAGE_PATH := _build/invocation-image.tar
+
+PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME := docker/cnab-app-base:$(TAG)
 
 .DEFAULT: all
 all: cross test
@@ -114,6 +117,10 @@ schemas: specification/bindata.go ## generate specification/bindata.go from json
 invocation-image:
 	docker build -f Dockerfile.invocation-image $(BUILD_ARGS) --target=invocation -t $(CNAB_BASE_INVOCATION_IMAGE_NAME) .
 
+save-invocation-image-tag:
+	docker tag $(CNAB_BASE_INVOCATION_IMAGE_NAME) docker/cnab-app-base:$(INVOCATION_IMAGE_TAG)
+	docker save docker/cnab-app-base:$(INVOCATION_IMAGE_TAG) -o _build/$(OUTPUT)
+
 save-invocation-image: invocation-image
 	@$(call mkdir,_build)
 	docker save $(CNAB_BASE_INVOCATION_IMAGE_NAME) -o $(CNAB_BASE_INVOCATION_IMAGE_PATH)
@@ -125,4 +132,4 @@ push-invocation-image:
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-.PHONY: lint test-e2e test-unit test cli-cross cross e2e-cross coverage gradle-test shell build_dev_image tars vendor schemas help save-invocation-image push-invocation-image
+.PHONY: lint test-e2e test-unit test cli-cross cross e2e-cross coverage gradle-test shell build_dev_image tars vendor schemas help invocation-image save-invocation-image save-invocation-image-tag push-invocation-image

--- a/vars.mk
+++ b/vars.mk
@@ -35,5 +35,3 @@ endif
 ifeq ($(TAG),)
   TAG := $(BUILD_TAG)
 endif
-
-CNAB_BASE_INVOCATION_IMAGE_NAME := docker/cnab-app-base:$(BUILD_TAG)


### PR DESCRIPTION
The coverage step needs the invocation image to be present, also, we
make sure that the invocation image tag is unique so that the `Coverage`
and `Test Linux` steps don't try to remove the same image.

**- What I did**
Created a new tag of the invocation image with a unique name for the coverage stage.

**- How I did it**
* Changed the `invocation-image` and `save-invocation-image` targets in the docker.Makefile, it saves the invocation image twice with different tags
* Use that coverage invocation image in the appropriate stage in the Jenkinsfile.baguette

**- How to verify it**
Jenkins should be green

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/52565625-a5092700-2e07-11e9-82c7-17ee0628199e.png)

