### PR TITLE
Introduce namespaced custom actions for inspect and status.

### DIFF
--- a/cmd/cnab-run/main.go
+++ b/cmd/cnab-run/main.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
+	"github.com/docker/app/internal"
 )
 
 type cnabAction string
@@ -12,8 +14,8 @@ const (
 	cnabActionInstall   = cnabAction("install")
 	cnabActionUninstall = cnabAction("uninstall")
 	cnabActionUpgrade   = cnabAction("upgrade")
-	cnabActionStatus    = cnabAction("status")
-	cnabActionInspect   = cnabAction("inspect")
+	cnabActionStatus    = cnabAction(internal.Namespace + "status")
+	cnabActionInspect   = cnabAction(internal.Namespace + "inspect")
 )
 
 type cnabOperation struct {

--- a/cmd/docker-app/inspect.go
+++ b/cmd/docker-app/inspect.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/deislabs/duffle/pkg/action"
 	"github.com/deislabs/duffle/pkg/claim"
+	"github.com/docker/app/internal"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
@@ -43,7 +44,7 @@ func inspectCmd(dockerCli command.Cli) *cobra.Command {
 			c.Parameters = parameters
 
 			a := &action.RunCustom{
-				Action: "inspect",
+				Action: internal.Namespace + "inspect",
 				Driver: driverImpl,
 			}
 			err = a.Run(c, map[string]string{"docker.context": ""}, dockerCli.Out())

--- a/cmd/docker-app/status.go
+++ b/cmd/docker-app/status.go
@@ -5,6 +5,7 @@ import (
 	"github.com/deislabs/duffle/pkg/claim"
 	"github.com/deislabs/duffle/pkg/credentials"
 	"github.com/deislabs/duffle/pkg/utils/crud"
+	"github.com/docker/app/internal"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
@@ -50,7 +51,7 @@ func runStatus(dockerCli command.Cli, claimName string, opts credentialOptions) 
 		return err
 	}
 	status := &action.RunCustom{
-		Action: "status",
+		Action: internal.Namespace + "status",
 		Driver: driverImpl,
 	}
 	err = status.Run(&c, creds, dockerCli.Out())

--- a/e2e/testdata/cnab-with-status/bundle.json
+++ b/e2e/testdata/cnab-with-status/bundle.json
@@ -8,7 +8,7 @@
     }
   ],
   "actions": {
-    "status": {
+    "com.docker.app.status": {
       "modifies": false
     }
   }

--- a/e2e/testdata/cnab-with-status/cnab/app/run
+++ b/e2e/testdata/cnab-with-status/cnab/app/run
@@ -13,7 +13,7 @@ case $action in
     upgrade)
     echo "Upgrade action"
     ;;
-    status)
+    com.docker.app.status)
     echo "Status action"
     ;;
     *)

--- a/e2e/testdata/simple-bundle.json.golden
+++ b/e2e/testdata/simple-bundle.json.golden
@@ -41,10 +41,10 @@
 		}
 	},
 	"actions": {
-		"inspect": {
+		"com.docker.app.inspect": {
 			"Modifies": false
 		},
-		"status": {
+		"com.docker.app.status": {
 			"Modifies": false
 		}
 	},

--- a/internal/names.go
+++ b/internal/names.go
@@ -21,6 +21,9 @@ const (
 
 	// DeprecatedSettingsFileName is the deprecated settings file name (replaced by ParametersFileName)
 	DeprecatedSettingsFileName = "settings.yml"
+
+	// Namespace is the reverse DNS namespace used with labels and CNAB custom actions.
+	Namespace = "com.docker.app."
 )
 
 var (

--- a/internal/packager/cnab.go
+++ b/internal/packager/cnab.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/deislabs/duffle/pkg/bundle"
+	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/compose"
 	"github.com/docker/app/types"
 )
@@ -85,10 +86,10 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 		Version:     app.Metadata().Version,
 		Parameters:  parameters,
 		Actions: map[string]bundle.Action{
-			"inspect": {
+			internal.Namespace + "inspect": {
 				Modifies: false,
 			},
-			"status": {
+			internal.Namespace + "status": {
 				Modifies: false,
 			},
 		},

--- a/internal/packager/cnab_test.go
+++ b/internal/packager/cnab_test.go
@@ -3,6 +3,8 @@ package packager
 import (
 	"testing"
 
+	"github.com/docker/app/internal"
+
 	"github.com/deislabs/duffle/pkg/bundle"
 	"github.com/docker/app/types"
 	"gotest.tools/assert"
@@ -69,10 +71,10 @@ func TestToCNAB(t *testing.T) {
 			},
 		},
 		Actions: map[string]bundle.Action{
-			"inspect": {
+			internal.Namespace + "inspect": {
 				Modifies: false,
 			},
-			"status": {
+			internal.Namespace + "status": {
 				Modifies: false,
 			},
 		},


### PR DESCRIPTION
**- What I did**
The [CNAB Specifications](https://github.com/deislabs/cnab-spec/pull/101) now ask for custom actions to be namespaced. This PR adds `com.docker.app` as a namespace to the following actions:
* `inspect`
* `status`

**- Description for the changelog**
* Custom actions are now namespaced in the bundle.json

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/53029944-33198900-346a-11e9-8546-142a111a60a6.png)

