### PR TITLE
Fix coverage step

### DIFF
--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -80,7 +80,7 @@ pipeline {
         }
         stage('Test') {
             parallel {
-                stage("Coverage") {
+                stage("Unit Coverage") {
                     environment {
                         CODECOV_TOKEN = credentials('jenkins-codecov-token')
                     }

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -89,8 +89,7 @@ test-e2e: build_dev_image invocation-image ## run end-to-end tests
 COV_LABEL := com.docker.app.cov-run=$(TAG)
 coverage: build_dev_image ## run tests with coverage
 	@$(call mkdir,_build)
-	docker run -v /var/run:/var/run:ro --name $(COV_CTNR_NAME) --network="host" -tid $(DEV_IMAGE_NAME) make COMMIT=${COMMIT} TAG=${TAG} EXPERIMENTAL=$(EXPERIMENTAL) coverage
-	docker logs -f $(COV_CTNR_NAME)
+	docker run -v /var/run:/var/run:ro --name $(COV_CTNR_NAME) --network="host" -t $(DEV_IMAGE_NAME) make COMMIT=${COMMIT} TAG=${TAG} EXPERIMENTAL=$(EXPERIMENTAL) coverage
 	docker cp $(COV_CTNR_NAME):$(PKG_PATH)/_build/cov/ ./_build/ci-cov
 	docker rm $(COV_CTNR_NAME)
 


### PR DESCRIPTION
The coverage (and so the unit tests) was running as detached, so if one test fails the target won't fail because of it, but just because it can't find the coverage files.

Fixed this running the tests in attached mode + renaming Coverage step in the jenkinsfile to a more obvious step Unit Coverage.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/53087235-edf76480-3506-11e9-90e6-a871da057453.png)

