### PR TITLE
resto: Include URI for failed pushes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ check_go_env:
 	@test $$(go list) = "$(PKG_NAME)" || \
 		(echo "Invalid Go environment - The local directory structure must match:  $(PKG_NAME)" && false)
 
-cross: bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-windows.exe ## cross-compile binaries (linux, darwin, windows)
+# cross: bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-windows.exe ## cross-compile binaries (linux, darwin, windows)
+cross: bin/$(BIN_NAME)-linux
 
 e2e-cross: bin/$(BIN_NAME)-e2e-linux bin/$(BIN_NAME)-e2e-darwin bin/$(BIN_NAME)-e2e-windows.exe
 

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -41,12 +41,12 @@ cross: create_bin ## cross-compile binaries (linux, darwin, windows)
 	docker build $(BUILD_ARGS) --target=cross -t $(CROSS_IMAGE_NAME)  .
 	docker create --name $(CROSS_CTNR_NAME) $(CROSS_IMAGE_NAME) noop
 	docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-linux
-	docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-darwin
-	docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-windows.exe bin/$(BIN_NAME)-windows.exe
+	#docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-darwin
+	#docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-windows.exe bin/$(BIN_NAME)-windows.exe
 	docker rm $(CROSS_CTNR_NAME)
 	@$(call chmod,+x,bin/$(BIN_NAME)-linux)
-	@$(call chmod,+x,bin/$(BIN_NAME)-darwin)
-	@$(call chmod,+x,bin/$(BIN_NAME)-windows.exe)
+	#@$(call chmod,+x,bin/$(BIN_NAME)-darwin)
+	#@$(call chmod,+x,bin/$(BIN_NAME)-windows.exe)
 
 cli-cross: create_bin
 	docker build $(BUILD_ARGS) --target=build -t $(CLI_IMAGE_NAME)  .

--- a/pkg/resto/resto.go
+++ b/pkg/resto/resto.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/distribution/registry/client"
 	digest "github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -280,6 +281,9 @@ func PushConfigMulti(ctx context.Context, payload map[string]string, repoTag str
 	}
 	if _, ok := err.(unsupportedMediaType); ok {
 		return pushConfigLegacy(ctx, payload, pr, repo, labels)
+	}
+	if err != nil {
+		err = errors.Wrapf(err, "Unable to push to: %s/%s", pr.domain, pr.path)
 	}
 	return digest, err
 }


### PR DESCRIPTION
This allows the error message for a failed push to be more informative
by including the URI of the failed push. For example, the code
currently doesn't honor the "namespace" attribute in
hello-world.dockerapp, which lead to some confusion on my part. With
this change the error became:

 ./bin/docker-app-linux -D push hello-world.dockerapp
  Error: Unable to push to: https://registry-1.docker.io/library/hello-world
  errors:
  denied: requested access to the resource is denied
  unauthorized: authentication required

Not the greatest error, but it might save someone the effort of
having to recompile with printfs to understand.

Signed-off-by: Andy Doan <andy@foundries.io>
