### PR TITLE
Remove namespace leftovers from doc and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ It should look like this:
 version: 0.1.0
 name: hello
 description: ""
-namespace: ""
 maintainers:
 - name: yourusername
   email: ""
@@ -233,18 +232,17 @@ If you want to store additional files in the application package, such as `prod.
 You can push any application to the Hub using `docker-app push`:
 
 ``` bash
-$ docker-app push --namespace myhubuser --tag latest
+$ docker-app push --tag myhubuser/myimage:latest
 ```
 
-This command will push to the Hub an image named `myhubuser/hello.dockerapp:latest`.
+This command will push to the Hub an image named `myhubuser/myimage:latest`.
 
-If you omit the `--tag latest` argument, this command uses the application `version` defined in `metadata.yml` as the tag.
-If you omit the `--namespace myhubuser` argument, this command uses the application `namespace` defined in `metadata.yml` as the image namespace.
+If you omit the `--tag myhubuser/myimage:latest` argument, this command uses the application `version` defined in `metadata.yml` as the tag.
 
 All `docker-app` commands accept an image name as input, which means you can run on a different host:
 
 ``` bash
-$ docker-app inspect myhubuser/hello
+$ docker-app inspect myhubuser/myimage
 ```
 
 ## Next steps

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -21,8 +21,6 @@ version: 0.1.0
 name: hello-world
 # A short description of the application
 description:
-# Namespace to use when pushing to a registry. This is typically your Hub username.
-#namespace: myhubusername
 # List of application maintainers with name and email for each
 maintainers:
   - name: user
@@ -41,7 +39,7 @@ Open `hello-world.dockerapp` with your favorite text editor.
 
 ### Edit metadata
 
-Edit the `description`, `namespace` and `maintainers` fields in the metadata section.
+Edit the `description` and `maintainers` fields in the metadata section.
 
 ### Add variables to the compose file
 

--- a/examples/hello-world/hello-world.dockerapp
+++ b/examples/hello-world/hello-world.dockerapp
@@ -5,8 +5,6 @@ version: 0.1.0
 name: hello-world
 # A short description of the application
 description: "Hello, World!"
-# Namespace to use when pushing to a registry. This is typically your Hub username.
-namespace: myhubusername
 # List of application maintainers with name and email for each
 maintainers:
   - name: user

--- a/examples/voting-app/README.md
+++ b/examples/voting-app/README.md
@@ -11,7 +11,6 @@ Initialize the project using `docker-app init voting-app --compose-file docker-s
 Go to `voting-app.dockerapp/` and open `metadata.yml` and fill the following fields:
 - description
 - maintainers
-- namespace
 
 ### Add variables to the compose file
 

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -136,7 +136,7 @@ wordpress.dockerapp   latest              61f8cafb7762        4 minutes ago     
 
 The image can be pushed to the hub:
 ```
-$ docker push --namespace <username> wordpress
+$ docker push wordpress
 The push refers to repository [docker.io/<username>/wordpress.dockerapp]
 61f8cafb7762: Pushed
 latest: digest: sha256:91b9b526ac1e645e9c89663ff1453c2d7f68535e2dbbca6d4466d365e15ee155 size: 525


### PR DESCRIPTION
Signed-off-by: Ulysses Souza <ulysses.souza@docker.com>

**- What I did**
Removed namespace from example and docs in the push section

**- How to verify it**
Check README.md

**- Description for the changelog**
Remove namespace leftovers from doc and example
