### PR TITLE
Add dynamic binary make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,9 @@ ifeq ($(OS),Windows_NT)
   EXEC_EXT := .exe
 endif
 
-GO_BUILD := CGO_ENABLED=0 go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
-GO_TEST := CGO_ENABLED=0 go test -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
+STATIC_FLAGS= CGO_ENABLED=0
+GO_BUILD = $(STATIC_FLAGS) go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
+GO_TEST = $(STATIC_FLAGS) go test -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 
 all: bin/$(BIN_NAME) test
 
@@ -40,6 +41,10 @@ cross-plugin: bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-windo
 cross-standalone: bin/${BIN_STANDALONE_NAME}-linux bin/${BIN_STANDALONE_NAME}-darwin bin/${BIN_STANDALONE_NAME}-windows.exe
 
 e2e-cross: bin/$(BIN_NAME)-e2e-linux bin/$(BIN_NAME)-e2e-darwin bin/$(BIN_NAME)-e2e-windows.exe
+
+.PHONY: dynamic
+dynamic: STATIC_FLAGS :=
+dynamic: bin/$(BIN_NAME)
 
 .PHONY: bin/${BIN_STANDALONE_NAME}-windows
 bin/${BIN_STANDALONE_NAME}-%.exe bin/${BIN_STANDALONE_NAME}-%: cmd/${BIN_STANDALONE_NAME} check_go_env


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Adds a dynamic make target to allow for making a dynamic binary without
having to do ugly `GO_BUILD` mangling.

Default functionality should remain the same.

**- How I did it**

<details>
<summary> expand </summary>

```diff
diff --git a/Makefile b/Makefile
index 2a6e18eb..e3a9fa41 100644
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,9 @@ ifeq ($(OS),Windows_NT)
   EXEC_EXT := .exe
 endif

-GO_BUILD := CGO_ENABLED=0 go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
-GO_TEST := CGO_ENABLED=0 go test -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
+STATIC_FLAGS= CGO_ENABLED=0
+GO_BUILD = $(STATIC_FLAGS) go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
+GO_TEST = $(STATIC_FLAGS) go test -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)

 all: bin/$(BIN_NAME) test

@@ -41,6 +42,10 @@ cross-standalone: bin/${BIN_STANDALONE_NAME}-linux bin/${BIN_STANDALONE_NAME}-da

 e2e-cross: bin/$(BIN_NAME)-e2e-linux bin/$(BIN_NAME)-e2e-darwin bin/$(BIN_NAME)-e2e-windows.exe

+.PHONY: dynamic
+dynamic: STATIC_FLAGS :=
+dynamic: bin/$(BIN_NAME)
+
 .PHONY: bin/${BIN_STANDALONE_NAME}-windows
 bin/${BIN_STANDALONE_NAME}-%.exe bin/${BIN_STANDALONE_NAME}-%: cmd/${BIN_STANDALONE_NAME} check_go_env
        GOOS=$* $(GO_BUILD) -o $@ ./$<
```

</details>

**- How to verify it**
Run, `make dynamic`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
No changelog entry needed

**- A picture of a cute animal (not mandatory but encouraged)**
![wombat](https://media.giphy.com/media/10QeIV66dUxAgU/giphy.gif)
