### PR TITLE
Push prints error messages correctly

### DIFF
--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -48,7 +48,7 @@ func pushCmd(dockerCli command.Cli) *cobra.Command {
 }
 
 func runPush(dockerCli command.Cli, name string, opts pushOptions) error {
-	muteDockerCli(dockerCli)
+	defer muteDockerCli(dockerCli)()
 	app, err := packager.Extract(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
**- What I did**

When using docker-app as a plugin, error messages did not appear in the
console.
This is due to the fact that we did never un-mute the docker CLI structure
when Pushing, and that the RunPlugin uses dockerCli.Err() to report
error messages to the user.

This fixes the issue by using the `defer muteDockerCli(cli)()` pattern
that is used everywhere else.

**- How I did it**

Make sure the docker CLI is unmuted when leaving runPush using the `defer muteDockerCli(cli)()` pattern.

**- How to verify it**

Try to push a bundle in a repo you don't have push right in.


