### PR TITLE
Rewrite Docker-Desktop contexts

### DIFF
--- a/internal/commands/cnab.go
+++ b/internal/commands/cnab.go
@@ -33,6 +33,8 @@ type bindMount struct {
 const defaultSocketPath string = "/var/run/docker.sock"
 
 func prepareCredentialSet(contextName string, contextStore store.Store, b *bundle.Bundle, namedCredentialsets []string) (map[string]string, error) {
+	// docker desktop contexts require some rewriting for being used within a container
+	contextStore = dockerDesktopAwareStore{Store: contextStore}
 	creds := map[string]string{}
 	for _, file := range namedCredentialsets {
 		if _, err := os.Stat(file); err != nil {

--- a/internal/commands/cnab_test.go
+++ b/internal/commands/cnab_test.go
@@ -4,12 +4,14 @@ import (
 	"testing"
 
 	"github.com/docker/cli/cli/command"
+	cliflags "github.com/docker/cli/cli/flags"
 	"gotest.tools/assert"
 )
 
 func TestRequiresBindMount(t *testing.T) {
 	dockerCli, err := command.NewDockerCli()
 	assert.NilError(t, err)
+	dockerCli.Initialize(cliflags.NewClientOptions())
 
 	testCases := []struct {
 		name               string
@@ -39,7 +41,7 @@ func TestRequiresBindMount(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			result, err := requiredBindMount(testCase.targetContextName, testCase.targetOrchestrator, dockerCli)
+			result, err := requiredBindMount(testCase.targetContextName, testCase.targetOrchestrator, dockerCli.ContextStore())
 			if testCase.expectedError == "" {
 				assert.NilError(t, err)
 			} else {

--- a/internal/commands/dockerdesktop.go
+++ b/internal/commands/dockerdesktop.go
@@ -1,0 +1,153 @@
+package commands
+
+import (
+	"fmt"
+	"net/url"
+	"runtime"
+
+	"github.com/pkg/errors"
+
+	"github.com/docker/cli/cli/context/docker"
+	"github.com/docker/cli/cli/context/kubernetes"
+	"github.com/docker/cli/cli/context/store"
+	"github.com/docker/docker/client"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type dockerDesktopHostProvider func() (string, bool)
+
+func defaultDockerDesktopHostProvider() (string, bool) {
+	switch runtime.GOOS {
+	case "windows", "darwin":
+	default:
+		// platforms other than windows or mac can't be Docker Desktop
+		return "", false
+	}
+	return client.DefaultDockerHost, true
+}
+
+type dockerDesktopLinuxKitIPProvider func() (string, error)
+
+type dockerDesktopDockerEndpointRewriter struct {
+	defaultHostProvider dockerDesktopHostProvider
+}
+
+func (r *dockerDesktopDockerEndpointRewriter) rewrite(ep *docker.EndpointMeta) {
+	defaultHost, isDockerDesktop := r.defaultHostProvider()
+	if !isDockerDesktop {
+		return
+	}
+	// on docker desktop, any context with host="" or host=<default host> should be rewritten as host="unix:///var/run/docker.sock" (docker socket path within the linuxkit VM)
+	if ep.Host == "" || ep.Host == defaultHost {
+		ep.Host = "unix:///var/run/docker.sock"
+	}
+}
+
+type dockerDesktopKubernetesEndpointRewriter struct {
+	defaultHostProvider dockerDesktopHostProvider
+	linuxKitIPProvider  dockerDesktopLinuxKitIPProvider
+}
+
+func (r *dockerDesktopKubernetesEndpointRewriter) rewrite(ep *kubernetes.EndpointMeta) {
+	// any error while rewriting makes as if no rewriting rule applies
+	if _, isDockerDesktop := r.defaultHostProvider(); !isDockerDesktop {
+		return
+	}
+	// if the kube endpoint host points to localhost or 127.0.0.1, we need to rewrite it to whatever is linuxkit VM IP is (with port 6443)
+	hostURL, err := url.Parse(ep.Host)
+	if err != nil {
+		return
+	}
+	hostName := hostURL.Hostname()
+	switch hostName {
+	case "localhost", "127.0.0.1":
+	default:
+		// we are on a context targeting a remote Kubernetes cluster, nothing to rewrite
+		return
+	}
+	ip, err := r.linuxKitIPProvider()
+	if err != nil {
+		return
+	}
+	ep.Host = fmt.Sprintf("https://%s:6443", ip)
+}
+
+func makeLinuxkitIPProvider(contextName string, s store.Store) dockerDesktopLinuxKitIPProvider {
+	return func() (string, error) {
+		clientCfg, err := kubernetes.ConfigFromContext(contextName, s)
+		if err != nil {
+			return "", err
+		}
+		restCfg, err := clientCfg.ClientConfig()
+		if err != nil {
+			return "", err
+		}
+		coreClient, err := v1.NewForConfig(restCfg)
+		if err != nil {
+			return "", err
+		}
+		nodes, err := coreClient.Nodes().List(metav1.ListOptions{})
+		if err != nil {
+			return "", err
+		}
+		if len(nodes.Items) == 0 {
+			return "", errors.New("no node found")
+		}
+		for _, address := range nodes.Items[0].Status.Addresses {
+			if address.Type == apiv1.NodeInternalIP {
+				return address.Address, nil
+			}
+		}
+		return "", errors.New("no ip found")
+	}
+}
+
+func rewriteContextIfDockerDesktop(meta *store.ContextMetadata, s store.Store) {
+	// errors are treated as "don't rewrite"
+	rewriter := dockerDesktopDockerEndpointRewriter{
+		defaultHostProvider: defaultDockerDesktopHostProvider,
+	}
+	dockerEp, err := docker.EndpointFromContext(*meta)
+	if err != nil {
+		return
+	}
+	rewriter.rewrite(&dockerEp)
+	meta.Endpoints[docker.DockerEndpoint] = dockerEp
+	kubeEp := kubernetes.EndpointFromContext(*meta)
+	if kubeEp == nil {
+		return
+	}
+	kubeRewriter := dockerDesktopKubernetesEndpointRewriter{
+		defaultHostProvider: defaultDockerDesktopHostProvider,
+		linuxKitIPProvider:  makeLinuxkitIPProvider(meta.Name, s),
+	}
+	kubeRewriter.rewrite(kubeEp)
+	meta.Endpoints[kubernetes.KubernetesEndpoint] = *kubeEp
+}
+
+type dockerDesktopAwareStore struct {
+	store.Store
+}
+
+func (s dockerDesktopAwareStore) ListContexts() ([]store.ContextMetadata, error) {
+	contexts, err := s.Store.ListContexts()
+	if err != nil {
+		return nil, err
+	}
+	for ix, c := range contexts {
+		rewriteContextIfDockerDesktop(&c, s.Store)
+		contexts[ix] = c
+	}
+	return contexts, nil
+}
+
+func (s dockerDesktopAwareStore) GetContextMetadata(name string) (store.ContextMetadata, error) {
+	context, err := s.Store.GetContextMetadata(name)
+	if err != nil {
+		return store.ContextMetadata{}, err
+	}
+	rewriteContextIfDockerDesktop(&context, s.Store)
+	return context, nil
+}

--- a/internal/commands/dockerdesktop_test.go
+++ b/internal/commands/dockerdesktop_test.go
@@ -1,0 +1,145 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/docker/cli/cli/context"
+	"github.com/docker/cli/cli/context/docker"
+	"github.com/docker/cli/cli/context/kubernetes"
+	"github.com/pkg/errors"
+	"gotest.tools/assert"
+)
+
+var (
+	noDesktopProvider = func() (string, bool) {
+		return "", false
+	}
+	desktopProvider = func() (string, bool) {
+		return "unix:///test", true
+	}
+)
+
+func TestDockerDesktopDockerEndpointRewriter(t *testing.T) {
+	cases := []struct {
+		name         string
+		hostProvider dockerDesktopHostProvider
+		currentHost  string
+		expectedHost string
+	}{
+		{
+			name:         "no-desktop",
+			hostProvider: noDesktopProvider,
+			currentHost:  "",
+			expectedHost: "",
+		},
+		{
+			name:         "no-desktop-custom-host",
+			hostProvider: noDesktopProvider,
+			currentHost:  "test",
+			expectedHost: "test",
+		},
+		{
+			name:         "desktop-empty-host",
+			hostProvider: desktopProvider,
+			currentHost:  "",
+			expectedHost: "unix:///var/run/docker.sock",
+		},
+		{
+			name:         "desktop-default-host",
+			hostProvider: desktopProvider,
+			currentHost:  "unix:///test",
+			expectedHost: "unix:///var/run/docker.sock",
+		},
+		{
+			name:         "desktop-custom-host",
+			hostProvider: desktopProvider,
+			currentHost:  "test",
+			expectedHost: "test",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			testee := dockerDesktopDockerEndpointRewriter{
+				defaultHostProvider: c.hostProvider,
+			}
+			ep := docker.EndpointMeta{
+				Host: c.currentHost,
+			}
+			testee.rewrite(&ep)
+			assert.Check(t, ep.Host == c.expectedHost)
+		})
+	}
+}
+
+func TestDockerDesktopKubernetesEndpointRewriter(t *testing.T) {
+	cases := []struct {
+		name         string
+		hostProvider dockerDesktopHostProvider
+		ipProvider   dockerDesktopLinuxKitIPProvider
+		currentHost  string
+		expectedHost string
+	}{
+		{
+			name:         "no-desktop",
+			hostProvider: noDesktopProvider,
+			currentHost:  "https://localhost:6443",
+			expectedHost: "https://localhost:6443",
+		},
+		{
+			name:         "no-desktop-custom-host",
+			hostProvider: noDesktopProvider,
+			currentHost:  "https://custom:6443",
+			expectedHost: "https://custom:6443",
+		},
+		{
+			name:         "desktop-localhost",
+			hostProvider: desktopProvider,
+			currentHost:  "https://localhost:4242",
+			expectedHost: "https://42.42.42.42:6443",
+		},
+		{
+			name:         "desktop-127.0.0.01",
+			hostProvider: desktopProvider,
+			currentHost:  "https://127.0.0.1:4242",
+			expectedHost: "https://42.42.42.42:6443",
+		},
+		{
+			name:         "desktop-custom-host",
+			hostProvider: desktopProvider,
+			currentHost:  "https://custom:6443",
+			expectedHost: "https://custom:6443",
+		},
+		{
+			name:         "no-rewrite-on-error",
+			hostProvider: desktopProvider,
+			ipProvider: func() (string, error) {
+				return "", errors.New("boom")
+			},
+			currentHost:  "https://127.0.0.1:4242",
+			expectedHost: "https://127.0.0.1:4242",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ipProvider := c.ipProvider
+			if ipProvider == nil {
+				ipProvider = func() (string, error) {
+					return "42.42.42.42", nil
+				}
+			}
+			testee := dockerDesktopKubernetesEndpointRewriter{
+				defaultHostProvider: c.hostProvider,
+				linuxKitIPProvider:  ipProvider,
+			}
+			ep := kubernetes.EndpointMeta{
+				EndpointMetaBase: context.EndpointMetaBase{
+					Host: c.currentHost,
+				},
+			}
+			testee.rewrite(&ep)
+			assert.Check(t, ep.Host == c.expectedHost)
+		})
+	}
+}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -73,7 +73,7 @@ func runInstall(dockerCli command.Cli, appname string, opts installOptions) erro
 		return errors.New("with-registry-auth is not supported at the moment")
 	}
 	targetContext := getTargetContext(opts.targetContext, dockerCli.CurrentContext())
-	bind, err := requiredBindMount(targetContext, opts.orchestrator, dockerCli)
+	bind, err := requiredBindMount(targetContext, opts.orchestrator, dockerCli.ContextStore())
 	if err != nil {
 		return err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -33,7 +33,6 @@ func storePath(ref reference.Named) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
 	storeDir := filepath.Join(baseDir, filepath.FromSlash(name))
 
 	// We rely here on _ not being valid in a name meaning there can be no clashes due to nesting of repositories.


### PR DESCRIPTION
Now based on #482
**- What I did**

With Docker Desktop, contexts that target the local daemon/kubernetes
endpoints need to be rewriten, because they are not usable from within a
container (for swarm on windows, npipe:////./pipe/docker_engine must be
renamed to unix:///var/run/docker.sock, for both mac and windows,
Kubernetes Host https://localhost:* must be renamed to https://<linuxkit
vm ip>:6443)

**- How I did it**

Introduced a "proxy" context store handling those cases

**- How to verify it**

Unit-tests included, still need to figure how to e2e test that though.

**- Description for the changelog**

Docker-Desktop users don't have to create a "cnab" context anymore


