### PR TITLE
Add a containerized dep target

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                         dir('src/github.com/docker/app') {
                             checkout scm
                             sh 'make -f docker.Makefile lint'
-                            sh 'make -f docker.Makefile vendor'
+                            sh 'make -f docker.Makefile check-vendor'
                         }
                     }
                     post {

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -108,8 +108,8 @@ lint: ## run linter(s)
 	docker build -t $(LINT_IMAGE_NAME) -f Dockerfile.lint .
 	docker run --rm $(LINT_IMAGE_NAME) make lint
 
-vendor: build_dev_image
-	$(info Vendoring...)
+check-vendor: build_dev_image
+	$(info Check Vendoring...)
 	docker run --rm $(DEV_IMAGE_NAME) sh -c "make vendor && hack/check-git-diff vendor"
 
 specification/bindata.go: specification/schemas/*.json build_dev_image
@@ -137,4 +137,4 @@ push-invocation-image:
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-.PHONY: lint test-e2e test-unit test cli-cross cross e2e-cross coverage gradle-test shell build_dev_image tars vendor schemas help invocation-image save-invocation-image save-invocation-image-tag push-invocation-image
+.PHONY: lint test-e2e test-unit test cli-cross cross e2e-cross coverage gradle-test shell build_dev_image tars check-vendor schemas help invocation-image save-invocation-image save-invocation-image-tag push-invocation-image

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -108,6 +108,11 @@ lint: ## run linter(s)
 	docker build -t $(LINT_IMAGE_NAME) -f Dockerfile.lint .
 	docker run --rm $(LINT_IMAGE_NAME) make lint
 
+vendor: build_dev_image
+	$(info Update Vendoring...)
+	docker run --rm -v "$(CURDIR)":/go/src/github.com/docker/app/ $(DEV_IMAGE_NAME) make vendor
+	$(warning You may need to reset permissions on vendor/*)
+
 check-vendor: build_dev_image
 	$(info Check Vendoring...)
 	docker run --rm $(DEV_IMAGE_NAME) sh -c "make vendor && hack/check-git-diff vendor"
@@ -137,4 +142,4 @@ push-invocation-image:
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-.PHONY: lint test-e2e test-unit test cli-cross cross e2e-cross coverage gradle-test shell build_dev_image tars check-vendor schemas help invocation-image save-invocation-image save-invocation-image-tag push-invocation-image
+.PHONY: lint test-e2e test-unit test cli-cross cross e2e-cross coverage gradle-test shell build_dev_image tars vendor check-vendor schemas help invocation-image save-invocation-image save-invocation-image-tag push-invocation-image


### PR DESCRIPTION
To do so first rename the `vendor` target in `docker.Makefile` to `check-vendor` and then add a new `vendor` target there:
```
commit 7a03644f839230c6f22fd4caa6d30ad254cbddb7
Author: Ian Campbell <ijc@docker.com>
Date:   Wed Mar 13 13:31:35 2019 +0000

    Add a containerized make target to revendor
    
    Uses the exact same version as the CI.
    
    This avoids needing to rely on everyone having the same version of `dep`
    installed in order to avoid spurious changes (especially inconvenient if you
    have multiple projects with different ideas).
    
    It's slightly annoying because (on Linux at least) it causes `vendor/*` to
    become owned by root (needing a `sudo chown` to repair), that's less annoying
    than having spurious vendoring changes due to tooling differences. Those who
    disagree can continue to use the non-containerized vendor target.
    
    Signed-off-by: Ian Campbell <ijc@docker.com>

commit 6c881fcd5f614f31b82f4a1a8a57c85057a5c265
Author: Ian Campbell <ijc@docker.com>
Date:   Wed Mar 13 13:09:17 2019 +0000

    Rename containerized `vendor` make target to `check-vendor`
    
    Having `make vendor` and `make -f dockerfile.Makefile vendor` do different
    things (the first updates, the second checks) is confusing.
    
    I want to add a containerized vendor update target, which would only be more
    confusing if it weren't called `vendor`.
    
    Signed-off-by: Ian Campbell <ijc@docker.com>
```
