### PR TITLE
Improve make -f docker.Makefile vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ clean: ## clean build artifacts
 
 vendor: ## update vendoring
 	$(call rmdir,vendor)
-	dep ensure -v
+	dep ensure -v $(DEP_ARGS)
 
 specification/bindata.go: specification/schemas/*.json
 	go generate github.com/docker/app/specification

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -110,10 +110,12 @@ lint: ## run linter(s)
 
 vendor: build_dev_image
 	$(info Update Vendoring...)
-	rm -rf ./vendor
 	docker rm -f docker-app-vendoring || true
-	docker create --name docker-app-vendoring -v docker-app-vendor-cache://dep-cache -e DEPCACHEDIR=//dep-cache $(DEV_IMAGE_NAME) sh -c "rm -rf ./vendor && make vendor"
-	docker start -i -a docker-app-vendoring
+	# git bash, mingw and msys by default rewrite args that seems to be linux paths and try to expand that to a meaningful windows path
+	# we don't want that to happen when mounting paths referring to files located in the container. Thus we use the double "//" prefix that works
+	# both on windows, linux and macos
+	docker run -it --name docker-app-vendoring -v docker-app-vendor-cache://dep-cache -e DEPCACHEDIR=//dep-cache $(DEV_IMAGE_NAME) sh -c "rm -rf ./vendor && make vendor DEP_ARGS=\"$(DEP_ARGS)\""	
+	rm -rf ./vendor
 	docker cp docker-app-vendoring:/go/src/github.com/docker/app/vendor .
 	docker cp docker-app-vendoring:/go/src/github.com/docker/app/Gopkg.lock .
 	docker rm -f docker-app-vendoring

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -110,7 +110,13 @@ lint: ## run linter(s)
 
 vendor: build_dev_image
 	$(info Update Vendoring...)
-	docker run --rm -v "$(CURDIR)":/go/src/github.com/docker/app/ $(DEV_IMAGE_NAME) make vendor
+	rm -rf ./vendor
+	docker rm -f docker-app-vendoring || echo ""
+	docker create --name docker-app-vendoring -v docker-app-vendor-cache://dep-cache -e DEPCACHEDIR=//dep-cache $(DEV_IMAGE_NAME) sh -c "rm -rf ./vendor && make vendor"
+	docker start -i -a docker-app-vendoring
+	docker cp docker-app-vendoring:/go/src/github.com/docker/app/vendor .
+	docker cp docker-app-vendoring:/go/src/github.com/docker/app/Gopkg.lock .
+	docker rm -f docker-app-vendoring
 	$(warning You may need to reset permissions on vendor/*)
 
 check-vendor: build_dev_image

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -119,7 +119,9 @@ vendor: build_dev_image
 	docker rm -f docker-app-vendoring
 	$(warning You may need to reset permissions on vendor/*)
 
-check-vendor: build_dev_image
+clean-vendor-cache:
+	docker rm -f docker-app-vendoring || echo ""
+	docker volume rm -f docker-app-vendor-cachecheck-vendor: build_dev_image
 	$(info Check Vendoring...)
 	docker run --rm $(DEV_IMAGE_NAME) sh -c "make vendor && hack/check-git-diff vendor"
 

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -111,7 +111,7 @@ lint: ## run linter(s)
 vendor: build_dev_image
 	$(info Update Vendoring...)
 	rm -rf ./vendor
-	docker rm -f docker-app-vendoring || echo ""
+	docker rm -f docker-app-vendoring || true
 	docker create --name docker-app-vendoring -v docker-app-vendor-cache://dep-cache -e DEPCACHEDIR=//dep-cache $(DEV_IMAGE_NAME) sh -c "rm -rf ./vendor && make vendor"
 	docker start -i -a docker-app-vendoring
 	docker cp docker-app-vendoring:/go/src/github.com/docker/app/vendor .
@@ -120,8 +120,10 @@ vendor: build_dev_image
 	$(warning You may need to reset permissions on vendor/*)
 
 clean-vendor-cache:
-	docker rm -f docker-app-vendoring || echo ""
-	docker volume rm -f docker-app-vendor-cachecheck-vendor: build_dev_image
+	docker rm -f docker-app-vendoring || true
+	docker volume rm -f docker-app-vendor-cache
+	
+check-vendor: build_dev_image
 	$(info Check Vendoring...)
 	docker run --rm $(DEV_IMAGE_NAME) sh -c "make vendor && hack/check-git-diff vendor"
 


### PR DESCRIPTION
**- What I did**

Initial work from @ijc brought a containerized vendoring which was great
but had a few issues:
- did not work on Windows: dependencies containing symlinks could not be
written by golang/dep on a cifs-mounted volume (wich is the case when
mounting a windows dir in Docker Desktop)
- slow: 2 reasons for that: doing the vendoring accross a cifs or osxfs
bind mount was far from ideal due to FS latency and caching issues.
There was no cache preservation between 2 calls.

This PR fixes those issues.

**- How I did it**

- Not using bind mounts: we resolve the vendoring directly in the
container RootFS, then copy back the vendor dir and the Gopkg.lock file
(which might have been updated) to the host
- Mounting a volume in which golang/dep will keep repo info and git
clones in cache

Note that the dep-cache mount point and DEPCACHEDIR env var are
//dep-cache and not /dep-cache. From a Unix FS point of view both paths
are equivalent. But some windows shells (like the bash version shipped
with Git on Windows) tries to do clever conversions to win32 paths when detecting unix-style
paths in command line arguments, which makes docker trying to mount the
volume in "c:\Program Files\Git\bin\..." which makes no sense in a Linux
container. Doubling the initial "/" disable this behavior.

**- How to verify it**

try `make -f docker.Makefile` on Windows
