### PR TITLE
fix example context create command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ CNAB specifies three actions which `docker-app` provides as commands:
 **Note**: These commands need a Docker Context so that `docker-app` knows which endpoint and orchestrator to target.
 
 ```console
-$ docker context create swarm --description "swarm context" --default-stack-orchestrator=swarm --docker=host=unix:///var/run/docker.sock
+$ docker context create swarm --description "swarm context" --default-stack-orchestrator=swarm --docker-host=unix:///var/run/docker.sock
 swarm
 Successfully created context "swarm"
 


### PR DESCRIPTION
fix example context create command in readme

Signed-off-by: Nick Adcock <nick.adcock@docker.com>

**- What I did**
Fixed example context create command in the readme so that the arguments are not invalid

**- How I did it**
Replaced example command:
`docker context create swarm --description "swarm context" --default-stack-orchestrator=swarm --docker=host=unix:///var/run/docker.sock`
with:
`docker context create swarm --description "swarm context" --default-stack-orchestrator=swarm --docker-host=unix:///var/run/docker.sock`

**- How to verify it**
Run the example command and see if it successfully creates the swarm context
