### PR TITLE
Fix example cnab-simple upgrade command in readme

### DIFF
--- a/examples/cnab-simple/README.md
+++ b/examples/cnab-simple/README.md
@@ -44,7 +44,7 @@ $ docker-app status hello
 Upgrade the installation, demonstrating setting parameters:
 
 ```console
-$ docker-app upgrade--set port=9876 --set text="hello DockerCon EU"
+$ docker-app upgrade --set port=9876 --set text="hello DockerCon EU" hello
 ```
 
 Uninstall the application installation:


### PR DESCRIPTION
Fix example cnab-simple upgrade command in readme

Signed-off-by: Nick Adcock <nick.adcock@docker.com>

**- What I did**
Fixed the example command in the cnab-simple readme for upgrading the app

**- How I did it**
Replaced:
`$ docker-app upgrade--set port=9876 --set text="hello DockerCon EU"`
With:
`$ docker-app upgrade --set port=9876 --set text="hello DockerCon EU" hello`


**- How to verify it**
Run the commands in the readme in sequence and see if they pass