### PR TITLE
Rename --out to --output in bundle command

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -260,7 +260,7 @@ func TestBundle(t *testing.T) {
 	icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 	// Bundle the docker application package to a CNAB bundle, using the build-context.
-	cmd.Command = dockerCli.Command("app", "bundle", filepath.Join("testdata", "simple", "simple.dockerapp"), "--out", tmpDir.Join("bundle.json"))
+	cmd.Command = dockerCli.Command("app", "bundle", filepath.Join("testdata", "simple", "simple.dockerapp"), "--output", tmpDir.Join("bundle.json"))
 	icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 	// Check the resulting CNAB bundle.json

--- a/e2e/testdata/plugin-usage-experimental.golden
+++ b/e2e/testdata/plugin-usage-experimental.golden
@@ -4,7 +4,7 @@ Usage:	docker app COMMAND
 Build and deploy Docker Application Packages.
 
 Commands:
-  bundle      Create a CNAB invocation image and bundle.json for the application.
+  bundle      Create a CNAB invocation image and bundle.json for the application
   completion  Generates completion scripts for the specified shell (bash or zsh)
   init        Start building a Docker application
   inspect     Shows metadata, parameters and a summary of the compose file for a given application

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -4,7 +4,7 @@ Usage:	docker app COMMAND
 Build and deploy Docker Application Packages.
 
 Commands:
-  bundle      Create a CNAB invocation image and bundle.json for the application.
+  bundle      Create a CNAB invocation image and bundle.json for the application
   completion  Generates completion scripts for the specified shell (bash or zsh)
   init        Start building a Docker application
   inspect     Shows metadata, parameters and a summary of the compose file for a given application

--- a/internal/commands/bundle.go
+++ b/internal/commands/bundle.go
@@ -28,14 +28,14 @@ func bundleCmd(dockerCli command.Cli) *cobra.Command {
 	var opts bundleOptions
 	cmd := &cobra.Command{
 		Use:   "bundle [<app-name>]",
-		Short: "Create a CNAB invocation image and bundle.json for the application.",
+		Short: "Create a CNAB invocation image and bundle.json for the application",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runBundle(dockerCli, firstOrEmpty(args), opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.out, "out", "o", "bundle.json", "path to the output bundle.json (- for stdout)")
+	cmd.Flags().StringVarP(&opts.out, "output", "o", "bundle.json", "path to the output bundle.json (- for stdout)")
 	return cmd
 }
 


### PR DESCRIPTION
All other commands have a `--output` flag, so `bundle` should have it too.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/54939292-7f079400-4f28-11e9-8c93-72105561f372.png)
