### PR TITLE
Improve missing invoc img err

### DIFF
--- a/internal/packager/packing.go
+++ b/internal/packager/packing.go
@@ -14,10 +14,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-var dockerFile = `FROM docker/cnab-app-base:` + internal.Version + `
-COPY . .`
+const (
+	// CNABBaseImageName is the name of the base invocation image.
+	CNABBaseImageName = "docker/cnab-app-base"
 
-const dockerIgnore = "Dockerfile"
+	dockerIgnore = "Dockerfile"
+)
+
+var dockerFile = `FROM ` + CNABBaseImageName + `:` + internal.Version + `
+COPY . .`
 
 func tarAdd(tarout *tar.Writer, path, file string) error {
 	payload, err := ioutil.ReadFile(file)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add a better error message for when Docker App cannot find the base invocation image.

**- How I did it**

**- How to verify it**
Build a version of `docker-app` without a corresponding base invocation image on the Hub. Run `docker-app inspect examples/hello-world/hello-world.dockerapp`. Expect to see:
```
unable to resolve Docker App base image: docker/cnab-app-base:v0.6.0-204-g4409f471e5-dirty
```

**- Description for the changelog**
None


**- A picture of a cute animal (not mandatory but encouraged)**
