### PR TITLE
Push: platform filters

### DIFF
--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -44,7 +44,7 @@ func pushCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.tag, "tag", "t", "", "Target registry reference (default: <name>:<version> from metadata)")
-	flags.StringSliceVar(&opts.platforms, "platforms", nil, "For multi-arch service images, only push the sepcified platforms")
+	flags.StringSliceVar(&opts.platforms, "platform", nil, "For multi-arch service images, only push the specified platforms")
 	opts.registry.addFlags(flags)
 	return cmd
 }

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -27,8 +27,9 @@ import (
 )
 
 type pushOptions struct {
-	registry registryOptions
-	tag      string
+	registry  registryOptions
+	tag       string
+	platforms []string
 }
 
 func pushCmd(dockerCli command.Cli) *cobra.Command {
@@ -43,6 +44,7 @@ func pushCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.tag, "tag", "t", "", "Target registry reference (default: <name>:<version> from metadata)")
+	flags.StringSliceVar(&opts.platforms, "platforms", nil, "For multi-arch service images, only push the sepcified platforms")
 	opts.registry.addFlags(flags)
 	return cmd
 }
@@ -94,8 +96,14 @@ func runPush(dockerCli command.Cli, name string, opts pushOptions) error {
 	if term.IsTerminal(os.Stdout.Fd()) {
 		display = &interactiveDisplay{out: os.Stdout}
 	}
+	fixupOptions := []remotes.FixupOption{
+		remotes.WithEventCallback(display.onEvent),
+	}
+	if len(opts.platforms) > 0 {
+		fixupOptions = append(fixupOptions, remotes.WithComponentImagePlatforms(opts.platforms))
+	}
 	// bundle fixup
-	err = remotes.FixupBundle(context.Background(), bndl, retag.cnabRef, resolverConfig, remotes.WithEventCallback(display.onEvent))
+	err = remotes.FixupBundle(context.Background(), bndl, retag.cnabRef, resolverConfig, fixupOptions...)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
**- What I did**

Allows to filter witch platforms to push when pushing a docker-app referencing multi-arch images

**- How I did it**

Leveraging the corresponding feature in cnab-to-oci

**- How to verify it**

`docker app push -t <hub huser>/wordpress:test ./examples/wordpress/wordpress.docker-app --platforms linux/amd64 --platforms linux/arm`

Based on #503
