### PR TITLE
Auto parameters

### DIFF
--- a/cmd/cnab-run/inspect.go
+++ b/cmd/cnab-run/inspect.go
@@ -1,14 +1,21 @@
 package main
 
 import (
+	"bytes"
 	"os"
 
 	appinspect "github.com/docker/app/internal/inspect"
 	"github.com/docker/app/internal/packager"
+	"github.com/docker/app/types"
+	"github.com/pkg/errors"
 )
 
 func inspectAction(instanceName string) error {
-	app, err := packager.Extract("")
+	overrides, err := parseOverrides()
+	if err != nil {
+		return errors.Wrap(err, "unable to parse auto-parameter values")
+	}
+	app, err := packager.Extract("", types.WithComposes(bytes.NewReader(overrides)))
 	// todo: merge additional compose file
 	if err != nil {
 		return err

--- a/cmd/cnab-run/install.go
+++ b/cmd/cnab-run/install.go
@@ -1,27 +1,33 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/deislabs/duffle/pkg/bundle"
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/render"
+	"github.com/docker/app/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/stack"
 	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/cli/cli/command/stack/swarm"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (
 	// imageMapFilePath is the path where the CNAB runtime will put the actual
 	// service to image mapping to use
 	imageMapFilePath = "/cnab/app/image-map.json"
+	overridesDir     = "/cnab/app/overrides"
 )
 
 func installAction(instanceName string) error {
@@ -29,7 +35,11 @@ func installAction(instanceName string) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to restore docker context")
 	}
-	app, err := packager.Extract("")
+	overrides, err := parseOverrides()
+	if err != nil {
+		return errors.Wrap(err, "unable to parse auto-parameter values")
+	}
+	app, err := packager.Extract("", types.WithComposes(bytes.NewReader(overrides)))
 	// todo: merge additional compose file
 	if err != nil {
 		return err
@@ -83,4 +93,42 @@ func getBundleImageMap() (map[string]bundle.Image, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+func parseOverrides() ([]byte, error) {
+	root := make(map[string]interface{})
+	if err := filepath.Walk(overridesDir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !fi.IsDir() {
+			bytes, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if len(bytes) > 0 {
+				rel, err := filepath.Rel(overridesDir, path)
+				if err != nil {
+					return err
+				}
+				splitPath := strings.Split(rel, "/")
+				setValue(root, splitPath, string(bytes))
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(root)
+}
+
+func setValue(root map[string]interface{}, path []string, value string) {
+	key, sub := path[0], path[1:]
+	if len(sub) == 0 {
+		root[key] = value
+		return
+	}
+	subMap := make(map[string]interface{})
+	setValue(subMap, sub, value)
+	root[key] = subMap
 }

--- a/cmd/cnab-run/render.go
+++ b/cmd/cnab-run/render.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
 	"github.com/docker/app/internal"
+	"github.com/docker/app/types"
+	"github.com/pkg/errors"
 
 	"github.com/docker/app/internal/formatter"
 	"github.com/docker/app/internal/packager"
@@ -12,7 +15,11 @@ import (
 )
 
 func renderAction(instanceName string) error {
-	app, err := packager.Extract("")
+	overrides, err := parseOverrides()
+	if err != nil {
+		return errors.Wrap(err, "unable to parse auto-parameter values")
+	}
+	app, err := packager.Extract("", types.WithComposes(bytes.NewReader(overrides)))
 	// todo: merge additional compose file
 	if err != nil {
 		return err

--- a/internal/packager/cnab_test.go
+++ b/internal/packager/cnab_test.go
@@ -2,12 +2,13 @@ package packager
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
-	"gotest.tools/golden"
-
+	"github.com/deislabs/duffle/pkg/bundle"
 	"github.com/docker/app/types"
 	"gotest.tools/assert"
+	"gotest.tools/golden"
 )
 
 func TestToCNAB(t *testing.T) {
@@ -18,4 +19,55 @@ func TestToCNAB(t *testing.T) {
 	actualJSON, err := json.MarshalIndent(actual, "", "  ")
 	assert.NilError(t, err)
 	golden.Assert(t, string(actualJSON), "bundle-json.golden")
+}
+
+func TestCnabAutomaticParameters(t *testing.T) {
+	app, err := types.NewAppFromDefaultFiles("testdata/packages/auto-parameters.dockerapp")
+	assert.NilError(t, err)
+	actual, err := ToCNAB(app, "test-image")
+	assert.NilError(t, err)
+	checkOverrideParameter(t, actual, "services.nothing-specified.deploy.replicas")
+	checkOverrideParameter(t, actual, "services.nothing-specified.deploy.resources.limits.cpus")
+	checkOverrideParameter(t, actual, "services.nothing-specified.deploy.resources.limits.memory")
+	checkOverrideParameter(t, actual, "services.nothing-specified.deploy.resources.reservations.cpus")
+	checkOverrideParameter(t, actual, "services.nothing-specified.deploy.resources.reservations.memory")
+	checkNoParameter(t, actual, "services.replicas-fixed.deploy.replicas")
+	checkOverrideParameter(t, actual, "services.replicas-fixed.deploy.resources.limits.cpus")
+	checkOverrideParameter(t, actual, "services.replicas-fixed.deploy.resources.limits.memory")
+	checkOverrideParameter(t, actual, "services.replicas-fixed.deploy.resources.reservations.cpus")
+	checkOverrideParameter(t, actual, "services.replicas-fixed.deploy.resources.reservations.memory")
+	checkCustomParameter(t, actual, "services.parameter-names-used.deploy.replicas")
+	checkCustomParameter(t, actual, "services.parameter-names-used.deploy.resources.limits.cpus")
+	checkCustomParameter(t, actual, "services.parameter-names-used.deploy.resources.limits.memory")
+	checkCustomParameter(t, actual, "services.parameter-names-used.deploy.resources.reservations.cpus")
+	checkCustomParameter(t, actual, "services.parameter-names-used.deploy.resources.reservations.memory")
+}
+
+func checkOverrideParameter(t *testing.T, b *bundle.Bundle, parameterName string) {
+	t.Helper()
+	parameterDest := "/cnab/app/overrides/" + strings.ReplaceAll(parameterName, ".", "/")
+	param, ok := b.Parameters[parameterName]
+	if !ok {
+		t.Fatalf("parameter %q is not present", parameterName)
+	}
+	assert.Check(t, param.Destination != nil)
+	assert.Equal(t, param.Destination.Path, parameterDest)
+}
+
+func checkNoParameter(t *testing.T, b *bundle.Bundle, parameterName string) {
+	t.Helper()
+	_, ok := b.Parameters[parameterName]
+	if ok {
+		t.Fatalf("parameter %q is present", parameterName)
+	}
+}
+
+func checkCustomParameter(t *testing.T, b *bundle.Bundle, parameterName string) {
+	t.Helper()
+	param, ok := b.Parameters[parameterName]
+	if !ok {
+		t.Fatalf("parameter %q is not present", parameterName)
+	}
+	assert.Check(t, param.Destination != nil)
+	assert.Equal(t, param.Destination.Path, "")
 }

--- a/internal/packager/testdata/bundle-json.golden
+++ b/internal/packager/testdata/bundle-json.golden
@@ -114,6 +114,114 @@
         "env": "DOCKER_SHARE_REGISTRY_CREDS"
       }
     },
+    "services.app-watcher.deploy.replicas": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/app-watcher/deploy/replicas"
+      }
+    },
+    "services.app-watcher.deploy.resources.limits.cpus": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/app-watcher/deploy/resources/limits/cpus"
+      }
+    },
+    "services.app-watcher.deploy.resources.limits.memory": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/app-watcher/deploy/resources/limits/memory"
+      }
+    },
+    "services.app-watcher.deploy.resources.reservations.cpus": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/app-watcher/deploy/resources/reservations/cpus"
+      }
+    },
+    "services.app-watcher.deploy.resources.reservations.memory": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/app-watcher/deploy/resources/reservations/memory"
+      }
+    },
+    "services.debug.deploy.replicas": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/debug/deploy/replicas"
+      }
+    },
+    "services.debug.deploy.resources.limits.cpus": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/debug/deploy/resources/limits/cpus"
+      }
+    },
+    "services.debug.deploy.resources.reservations.cpus": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/debug/deploy/resources/reservations/cpus"
+      }
+    },
+    "services.debug.deploy.resources.reservations.memory": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/debug/deploy/resources/reservations/memory"
+      }
+    },
+    "services.front.deploy.resources.limits.cpus": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/front/deploy/resources/limits/cpus"
+      }
+    },
+    "services.front.deploy.resources.limits.memory": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/front/deploy/resources/limits/memory"
+      }
+    },
+    "services.front.deploy.resources.reservations.cpus": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/front/deploy/resources/reservations/cpus"
+      }
+    },
+    "services.front.deploy.resources.reservations.memory": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/front/deploy/resources/reservations/memory"
+      }
+    },
+    "services.monitor.deploy.replicas": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/monitor/deploy/replicas"
+      }
+    },
+    "services.monitor.deploy.resources.limits.cpus": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/monitor/deploy/resources/limits/cpus"
+      }
+    },
+    "services.monitor.deploy.resources.limits.memory": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/monitor/deploy/resources/limits/memory"
+      }
+    },
+    "services.monitor.deploy.resources.reservations.cpus": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/monitor/deploy/resources/reservations/cpus"
+      }
+    },
+    "services.monitor.deploy.resources.reservations.memory": {
+      "type": "string",
+      "destination": {
+        "path": "/cnab/app/overrides/services/monitor/deploy/resources/reservations/memory"
+      }
+    },
     "watcher.cmd": {
       "type": "string",
       "defaultValue": "foo",

--- a/internal/packager/testdata/packages/auto-parameters.dockerapp/docker-compose.yml
+++ b/internal/packager/testdata/packages/auto-parameters.dockerapp/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.7"
+services:
+  nothing-specified:
+    image: nginx
+  replicas-fixed:
+    image: nginx
+    deploy:
+      replicas: 1
+  parameter-names-used:
+    image: nginx

--- a/internal/packager/testdata/packages/auto-parameters.dockerapp/metadata.yml
+++ b/internal/packager/testdata/packages/auto-parameters.dockerapp/metadata.yml
@@ -1,0 +1,8 @@
+version: 0.1.0
+name: auto-parameters
+description: "test-package-for-auto-params-generation"
+maintainers:
+  - name: dev1
+    email: dev1@example.com
+  - name: dev2
+    email: dev2@example.com

--- a/internal/packager/testdata/packages/auto-parameters.dockerapp/parameters.yml
+++ b/internal/packager/testdata/packages/auto-parameters.dockerapp/parameters.yml
@@ -1,0 +1,11 @@
+services:
+  parameter-names-used:
+    deploy:
+      replicas: 2
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 50M
+        reservations:
+          cpus: '0.25'
+          memory: 20M


### PR DESCRIPTION
**- What I did**

Added a range of automatically generated parameters for
- replicas
- limits
- reservations

**- How I did it**

Overrides are materialized to CNAB parameters, whose destination is a file path mirroring the structure of the compose file.
When the run tool extract the package, it reconstructs the overrides as an "overriding compose file"

This means that we can use this to easily add new "automatic parameters" in the future

**- How to verify it**
//TODO

**- Description for the changelog**
//TODO

**- A picture of a cute animal (not mandatory but encouraged)**
//TODO
