### PR TITLE
Add List command to list all the installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Commands:
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
   install     Install an application
+  list        List the installations and their last known installation result
   merge       Merge a directory format Docker Application definition into a single file
   pull        Pull an application package from a registry
   push        Push an application package to a registry

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -350,6 +350,14 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 			fmt.Sprintf("[[:alnum:]]+        %s_api   replicated          [0-1]/1                 python:3.6", appName),
 		})
 
+	// List the installed applications
+	cmd.Command = dockerCli.Command("app", "list")
+	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
+		[]string{
+			`INSTALLATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED`,
+			fmt.Sprintf(`%s\s+install\s+success\s+[[:alnum:]]+\ssecond.\s+[[:alnum:]]+\ssecond`, appName),
+		})
+
 	// Installing again the same application is forbidden
 	cmd.Command = dockerCli.Command("app", "install", "testdata/simple/simple.dockerapp", "--name", appName)
 	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
@@ -420,6 +428,6 @@ func initializeDockerAppEnvironment(t *testing.T, cmd *icmd.Cmd, tmpDir *fs.Dir,
 func checkContains(t *testing.T, combined string, expectedLines []string) {
 	for _, expected := range expectedLines {
 		exp := regexp.MustCompile(expected)
-		assert.Assert(t, exp.MatchString(combined), expected, combined)
+		assert.Assert(t, exp.MatchString(combined), "expected %q != actual %q", expected, combined)
 	}
 }

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -320,7 +320,14 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 		ExitCode: 1,
 		Err:      "error decoding 'Ports': Invalid hostPort: -1",
 	})
-	// TODO: List the installation and check the failed status
+
+	// List the installation and check the failed status
+	cmd.Command = dockerCli.Command("app", "list")
+	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
+		[]string{
+			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED`,
+			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+failure\s+.+second?\s+.+second`, appName),
+		})
 
 	// Upgrading a failed installation is not allowed
 	cmd.Command = dockerCli.Command("app", "upgrade", appName)
@@ -350,12 +357,12 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 			fmt.Sprintf("[[:alnum:]]+        %s_api   replicated          [0-1]/1                 python:3.6", appName),
 		})
 
-	// List the installed applications
+	// List the installed application
 	cmd.Command = dockerCli.Command("app", "list")
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 		[]string{
-			`INSTALLATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED`,
-			fmt.Sprintf(`%s\s+install\s+success\s+[[:alnum:]]+\ssecond.\s+[[:alnum:]]+\ssecond`, appName),
+			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED`,
+			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+success\s+.+second.\s+.+second`, appName),
 		})
 
 	// Installing again the same application is forbidden

--- a/e2e/testdata/plugin-usage-experimental.golden
+++ b/e2e/testdata/plugin-usage-experimental.golden
@@ -9,6 +9,7 @@ Commands:
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
   install     Install an application
+  list        List the installations and their last known installation result
   merge       Merge a directory format Docker Application definition into a single file
   pull        Pull an application package from a registry
   push        Push an application package to a registry

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -9,6 +9,7 @@ Commands:
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
   install     Install an application
+  list        List the installations and their last known installation result
   merge       Merge a directory format Docker Application definition into a single file
   pull        Pull an application package from a registry
   push        Push an application package to a registry

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -27,6 +27,7 @@ var (
 		value  func(c *claim.Claim) string
 	}{
 		{"INSTALLATION", func(c *claim.Claim) string { return c.Name }},
+		{"APPLICATION", func(c *claim.Claim) string { return fmt.Sprintf("%s (%s)", c.Bundle.Name, c.Bundle.Version) }},
 		{"LAST ACTION", func(c *claim.Claim) string { return c.Result.Action }},
 		{"RESULT", func(c *claim.Claim) string { return c.Result.Status }},
 		{"CREATED", func(c *claim.Claim) string { return units.HumanDuration(time.Since(c.Created)) }},

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -26,6 +26,7 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		installCmd(dockerCli),
 		upgradeCmd(dockerCli),
 		uninstallCmd(dockerCli),
+		listCmd(dockerCli),
 		statusCmd(dockerCli),
 		initCmd(dockerCli),
 		inspectCmd(dockerCli),


### PR DESCRIPTION
**- What I did**
Add a new top level command `list`/`ls` which lists all the persisted installations from the local installation store, and display all the informations (result, creation and modifications dates, last know action).

**- How to verify it**
```sh
$ docker app install examples/hello-world/hello-world.dockerapp
Creating network hello-world_default
Creating service hello-world_hello
$ docker app ls
INSTALLATION ACTION  RESULT  CREATED   MODIFIED
hello-world  install success 6 seconds 2 seconds
```

**- Description for the changelog**
* Add List command to list all the installations

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/56272927-04333280-60fc-11e9-9a4c-bb56c8250d05.png)
