### PR TITLE
Installation is no longer blocked in case of previous failure

### DIFF
--- a/internal/commands/cnab.go
+++ b/internal/commands/cnab.go
@@ -335,3 +335,8 @@ func prepareCustomAction(actionName string, dockerCli command.Cli, appname strin
 	}
 	return a, c, errBuf, nil
 }
+
+func isInstallationFailed(installation *claim.Claim) bool {
+	return installation.Result.Action == claim.ActionInstall &&
+		installation.Result.Status == claim.StatusFailure
+}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -131,12 +131,17 @@ func runInstall(dockerCli command.Cli, appname string, opts installOptions) erro
 	inst := &action.Install{
 		Driver: driverImpl,
 	}
-	err = inst.Run(c, creds, dockerCli.Out())
+	err = inst.Run(c, creds, os.Stdout)
 	// Even if the installation failed, the installation is persisted with its failure status,
 	// so any installation needs a clean uninstallation.
 	err2 := installationStore.Store(*c)
 	if err != nil {
-		return fmt.Errorf("install failed: %s", errBuf)
+		return fmt.Errorf("Installation failed: %s", errBuf)
 	}
-	return err2
+	if err2 != nil {
+		return err2
+	}
+
+	fmt.Printf("Application %q installed on context %q\n", installationName, opts.targetContext)
+	return nil
 }

--- a/internal/commands/upgrade.go
+++ b/internal/commands/upgrade.go
@@ -92,7 +92,11 @@ func runUpgrade(dockerCli command.Cli, installationName string, opts upgradeOpti
 	err = u.Run(&installation, creds, os.Stdout)
 	err2 := installationStore.Store(installation)
 	if err != nil {
-		return fmt.Errorf("upgrade failed: %s", errBuf)
+		return fmt.Errorf("Upgrade failed: %s", errBuf)
 	}
-	return err2
+	if err2 != nil {
+		return err2
+	}
+	fmt.Printf("Application %q upgraded on context %q\n", installationName, opts.targetContext)
+	return nil
 }

--- a/internal/store/app.go
+++ b/internal/store/app.go
@@ -57,7 +57,8 @@ func (a ApplicationStore) InstallationStore(context string) (InstallationStore, 
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return nil, errors.Wrapf(err, "failed to create installation store directory for context %q", context)
 	}
-	return claim.NewClaimStore(crud.NewFileSystemStore(path, "json")), nil
+	claimStore := claim.NewClaimStore(crud.NewFileSystemStore(path, "json"))
+	return &installationStore{claimStore: claimStore}, nil
 }
 
 // CredentialStore initializes and returns a context based credential store

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -1,13 +1,41 @@
 package store
 
-import "github.com/deislabs/duffle/pkg/claim"
+import (
+	"fmt"
+
+	"github.com/deislabs/duffle/pkg/claim"
+)
 
 // InstallationStore is an interface to persist claims.
 type InstallationStore interface {
 	List() ([]string, error)
-	Store(installationName claim.Claim) error
+	Store(installation claim.Claim) error
 	Read(installationName string) (claim.Claim, error)
 	Delete(installationName string) error
 }
 
-var _ InstallationStore = &claim.Store{}
+var _ InstallationStore = &installationStore{}
+
+type installationStore struct {
+	claimStore claim.Store
+}
+
+func (i installationStore) List() ([]string, error) {
+	return i.claimStore.List()
+}
+
+func (i installationStore) Store(installation claim.Claim) error {
+	return i.claimStore.Store(installation)
+}
+
+func (i installationStore) Read(installationName string) (claim.Claim, error) {
+	c, err := i.claimStore.Read(installationName)
+	if err == claim.ErrClaimNotFound {
+		return claim.Claim{}, fmt.Errorf("Installation %q not found", installationName)
+	}
+	return c, err
+}
+
+func (i installationStore) Delete(installationName string) error {
+	return i.claimStore.Delete(installationName)
+}


### PR DESCRIPTION
**- What I did**
* Installation is ok on a previously failed installation
* Installation store now returns an error with installation and not claim
* Add a message in case of success for install/uninstall/upgrade actions

**- How to verify it**
Improve e2e tests with this error workflow.


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/56326359-076b0480-6176-11e9-9ed0-98f708d12f4b.png)

