### PR TITLE
Init validate name

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -145,7 +145,8 @@ maintainers:
 
 	// validate metadata with JSON Schema
 	cmd.Command = dockerCli.Command("app", "validate", testAppName)
-	icmd.RunCmd(cmd).Assert(t, icmd.Success)
+	stdOut = icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined()
+	golden.Assert(t, stdOut, "validate-output.golden")
 
 	// test single-file init
 	cmd.Command = dockerCli.Command("app",

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -131,7 +131,8 @@ maintainers:
 		"--description", "my cool app",
 		"--maintainer", "dev1",
 		"--maintainer", "dev2:dev2@example.com")
-	icmd.RunCmd(cmd).Assert(t, icmd.Success)
+	stdOut := icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined()
+	golden.Assert(t, stdOut, "init-output.golden")
 
 	manifest := fs.Expected(
 		t,

--- a/e2e/testdata/init-output.golden
+++ b/e2e/testdata/init-output.golden
@@ -1,0 +1,2 @@
+You will need to edit parameters.yml to fill in default values.
+Created "app-test.dockerapp"

--- a/e2e/testdata/validate-output.golden
+++ b/e2e/testdata/validate-output.golden
@@ -1,0 +1,1 @@
+Validated "app-test.dockerapp"

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -1,8 +1,11 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +16,7 @@ var (
 	initSingleFile  bool
 )
 
-func initCmd() *cobra.Command {
+func initCmd(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "init APP_NAME [--compose-file COMPOSE_FILE] [--description DESCRIPTION] [--maintainer NAME:EMAIL ...] [OPTIONS]",
 		Short:   "Initialize Docker Application definition",
@@ -21,7 +24,12 @@ func initCmd() *cobra.Command {
 		Example: `$ docker app init myapp --description "a useful description"`,
 		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return packager.Init(args[0], initComposeFile, initDescription, initMaintainers, initSingleFile)
+			created, err := packager.Init(args[0], initComposeFile, initDescription, initMaintainers, initSingleFile)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(dockerCli.Out(), "Created %q\n", created)
+			return nil
 		},
 	}
 	cmd.Flags().StringVar(&initComposeFile, "compose-file", "", "Compose file to use as application base (optional)")

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -32,7 +32,7 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		mergeCmd(dockerCli),
 		renderCmd(dockerCli),
 		splitCmd(),
-		validateCmd(),
+		validateCmd(dockerCli),
 		versionCmd(dockerCli),
 		completionCmd(dockerCli, cmd),
 		bundleCmd(dockerCli),

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -27,7 +27,7 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		upgradeCmd(dockerCli),
 		uninstallCmd(dockerCli),
 		statusCmd(dockerCli),
-		initCmd(),
+		initCmd(dockerCli),
 		inspectCmd(dockerCli),
 		mergeCmd(dockerCli),
 		renderCmd(dockerCli),

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -1,10 +1,13 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/render"
 	"github.com/docker/app/types"
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
 	cliopts "github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +16,7 @@ type validateOptions struct {
 	parametersOptions
 }
 
-func validateCmd() *cobra.Command {
+func validateCmd(dockerCli command.Cli) *cobra.Command {
 	var opts validateOptions
 	cmd := &cobra.Command{
 		Use:   "validate [APP_NAME] [--set KEY=VALUE ...] [--parameters-file PARAMETERS_FILE]",
@@ -29,7 +32,11 @@ func validateCmd() *cobra.Command {
 			defer app.Cleanup()
 			argParameters := cliopts.ConvertKVStringsToMap(opts.overrides)
 			_, err = render.Render(app, argParameters, nil)
-			return err
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(dockerCli.Out(), "Validated %q\n", app.Path)
+			return nil
 		},
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Added an output on `init`: `Created "my-app.dockerapp"`
* Added an output on `validate`: `Validated "my-app.dockerapp"`

While doing this, I found that we're writing `"You will need to edit parameters.yml to fill in default values."` when one initialises an application with a Compose file that has variables. We shouldn't write this out from the packager and I'm not sure if we should have this functionality at all.

**- How to verify it**

```console
$ docker app init my-app
Created "my-app.dockerapp"
```

```console
$ docker app validate examples/hello-world/hello-world.dockerapp
Validated "examples/hello-world/hello-world.dockerapp"
```

**- Description for the changelog**
* Add outputs for successful `init` and `validate` commands
