### PR TITLE
Show application reference in the list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Commands:
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
   install     Install an application
+  list        List the installations and their last known installation result
   merge       Merge a directory format Docker Application definition into a single file
   pull        Pull an application package from a registry
   push        Push an application package to a registry

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -350,6 +350,14 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 			fmt.Sprintf("[[:alnum:]]+        %s_api   replicated          [0-1]/1                 python:3.6", appName),
 		})
 
+	// List the installed applications
+	cmd.Command = dockerCli.Command("app", "list")
+	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
+		[]string{
+			`INSTALLATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED`,
+			fmt.Sprintf(`%s\s+install\s+success\s+[[:alnum:]]+\ssecond.\s+[[:alnum:]]+\ssecond`, appName),
+		})
+
 	// Installing again the same application is forbidden
 	cmd.Command = dockerCli.Command("app", "install", "testdata/simple/simple.dockerapp", "--name", appName)
 	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
@@ -420,6 +428,6 @@ func initializeDockerAppEnvironment(t *testing.T, cmd *icmd.Cmd, tmpDir *fs.Dir,
 func checkContains(t *testing.T, combined string, expectedLines []string) {
 	for _, expected := range expectedLines {
 		exp := regexp.MustCompile(expected)
-		assert.Assert(t, exp.MatchString(combined), expected, combined)
+		assert.Assert(t, exp.MatchString(combined), "expected %q != actual %q", expected, combined)
 	}
 }

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -320,7 +320,14 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 		ExitCode: 1,
 		Err:      "error decoding 'Ports': Invalid hostPort: -1",
 	})
-	// TODO: List the installation and check the failed status
+
+	// List the installation and check the failed status
+	cmd.Command = dockerCli.Command("app", "list")
+	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
+		[]string{
+			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED`,
+			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+failure\s+.+second?\s+.+second`, appName),
+		})
 
 	// Upgrading a failed installation is not allowed
 	cmd.Command = dockerCli.Command("app", "upgrade", appName)
@@ -350,12 +357,12 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 			fmt.Sprintf("[[:alnum:]]+        %s_api   replicated          [0-1]/1                 python:3.6", appName),
 		})
 
-	// List the installed applications
+	// List the installed application
 	cmd.Command = dockerCli.Command("app", "list")
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 		[]string{
-			`INSTALLATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED`,
-			fmt.Sprintf(`%s\s+install\s+success\s+[[:alnum:]]+\ssecond.\s+[[:alnum:]]+\ssecond`, appName),
+			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED`,
+			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+success\s+.+second.\s+.+second`, appName),
 		})
 
 	// Installing again the same application is forbidden

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -325,8 +325,8 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 	cmd.Command = dockerCli.Command("app", "list")
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 		[]string{
-			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED`,
-			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+failure\s+.+second?\s+.+second`, appName),
+			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
+			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+failure\s+.+second[s]?\s+.+second[s]?\s+`, appName),
 		})
 
 	// Upgrading a failed installation is not allowed
@@ -361,8 +361,8 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 	cmd.Command = dockerCli.Command("app", "list")
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 		[]string{
-			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED`,
-			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+success\s+.+second.\s+.+second`, appName),
+			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
+			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+success\s+.+second[s]?\s+.+second[s]?\s+`, appName),
 		})
 
 	// Installing again the same application is forbidden

--- a/e2e/testdata/plugin-usage-experimental.golden
+++ b/e2e/testdata/plugin-usage-experimental.golden
@@ -9,6 +9,7 @@ Commands:
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
   install     Install an application
+  list        List the installations and their last known installation result
   merge       Merge a directory format Docker Application definition into a single file
   pull        Pull an application package from a registry
   push        Push an application package to a registry

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -9,6 +9,7 @@ Commands:
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
   install     Install an application
+  list        List the installations and their last known installation result
   merge       Merge a directory format Docker Application definition into a single file
   pull        Pull an application package from a registry
   push        Push an application package to a registry

--- a/internal/commands/inspect.go
+++ b/internal/commands/inspect.go
@@ -34,11 +34,11 @@ func inspectCmd(dockerCli command.Cli) *cobra.Command {
 
 func runInspect(dockerCli command.Cli, appname string, opts inspectOptions) error {
 	defer muteDockerCli(dockerCli)()
-	a, c, errBuf, err := prepareCustomAction(internal.ActionInspectName, dockerCli, appname, nil, opts.registryOptions, opts.pullOptions, opts.parametersOptions)
+	action, installation, errBuf, err := prepareCustomAction(internal.ActionInspectName, dockerCli, appname, nil, opts.registryOptions, opts.pullOptions, opts.parametersOptions)
 	if err != nil {
 		return err
 	}
-	if err := a.Run(c, nil, nil); err != nil {
+	if err := action.Run(&installation.Claim, nil, nil); err != nil {
 		return fmt.Errorf("inspect failed: %s", errBuf)
 	}
 	return nil

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -27,6 +27,7 @@ var (
 		value  func(c *claim.Claim) string
 	}{
 		{"INSTALLATION", func(c *claim.Claim) string { return c.Name }},
+		{"APPLICATION", func(c *claim.Claim) string { return fmt.Sprintf("%s (%s)", c.Bundle.Name, c.Bundle.Version) }},
 		{"LAST ACTION", func(c *claim.Claim) string { return c.Result.Action }},
 		{"RESULT", func(c *claim.Claim) string { return c.Result.Status }},
 		{"CREATED", func(c *claim.Claim) string { return units.HumanDuration(time.Since(c.Created)) }},

--- a/internal/commands/parameters.go
+++ b/internal/commands/parameters.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/duffle/pkg/claim"
 	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/store"
 	"github.com/docker/app/types/parameters"
 	cliopts "github.com/docker/cli/opts"
 	"github.com/pkg/errors"
@@ -61,10 +61,10 @@ func withOrchestratorParameters(orchestrator string, kubeNamespace string) merge
 	}
 }
 
-func mergeBundleParameters(c *claim.Claim, ops ...mergeBundleOpt) error {
-	bndl := c.Bundle
-	if c.Parameters == nil {
-		c.Parameters = make(map[string]interface{})
+func mergeBundleParameters(installation *store.Installation, ops ...mergeBundleOpt) error {
+	bndl := installation.Bundle
+	if installation.Parameters == nil {
+		installation.Parameters = make(map[string]interface{})
 	}
 	userParams := map[string]string{}
 	for _, op := range ops {
@@ -72,11 +72,11 @@ func mergeBundleParameters(c *claim.Claim, ops ...mergeBundleOpt) error {
 			return err
 		}
 	}
-	if err := matchAndMergeParametersDefinition(c.Parameters, userParams, bndl.Parameters); err != nil {
+	if err := matchAndMergeParametersDefinition(installation.Parameters, userParams, bndl.Parameters); err != nil {
 		return err
 	}
 	var err error
-	c.Parameters, err = bundle.ValuesOrDefaults(c.Parameters, bndl)
+	installation.Parameters, err = bundle.ValuesOrDefaults(installation.Parameters, bndl)
 	return err
 }
 

--- a/internal/commands/parameters_test.go
+++ b/internal/commands/parameters_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/duffle/pkg/claim"
 	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/store"
 	"gotest.tools/assert"
 	"gotest.tools/assert/cmp"
 	"gotest.tools/fs"
@@ -106,8 +107,8 @@ func TestMergeBundleParameters(t *testing.T) {
 				},
 			},
 		}
-		c := &claim.Claim{Bundle: bundle}
-		err := mergeBundleParameters(c,
+		i := &store.Installation{Claim: claim.Claim{Bundle: bundle}}
+		err := mergeBundleParameters(i,
 			first,
 			second,
 		)
@@ -115,7 +116,7 @@ func TestMergeBundleParameters(t *testing.T) {
 		expected := map[string]interface{}{
 			"param": "second",
 		}
-		assert.Assert(t, cmp.DeepEqual(c.Parameters, expected))
+		assert.Assert(t, cmp.DeepEqual(i.Parameters, expected))
 	})
 
 	t.Run("Default values", func(t *testing.T) {
@@ -127,13 +128,13 @@ func TestMergeBundleParameters(t *testing.T) {
 				},
 			},
 		}
-		c := &claim.Claim{Bundle: bundle}
-		err := mergeBundleParameters(c)
+		i := &store.Installation{Claim: claim.Claim{Bundle: bundle}}
+		err := mergeBundleParameters(i)
 		assert.NilError(t, err)
 		expected := map[string]interface{}{
 			"param": "default",
 		}
-		assert.Assert(t, cmp.DeepEqual(c.Parameters, expected))
+		assert.Assert(t, cmp.DeepEqual(i.Parameters, expected))
 	})
 
 	t.Run("Converting values", func(t *testing.T) {
@@ -149,13 +150,13 @@ func TestMergeBundleParameters(t *testing.T) {
 				},
 			},
 		}
-		c := &claim.Claim{Bundle: bundle}
-		err := mergeBundleParameters(c, withIntValue)
+		i := &store.Installation{Claim: claim.Claim{Bundle: bundle}}
+		err := mergeBundleParameters(i, withIntValue)
 		assert.NilError(t, err)
 		expected := map[string]interface{}{
 			"param": 1,
 		}
-		assert.Assert(t, cmp.DeepEqual(c.Parameters, expected))
+		assert.Assert(t, cmp.DeepEqual(i.Parameters, expected))
 	})
 
 	t.Run("Default values", func(t *testing.T) {
@@ -167,13 +168,13 @@ func TestMergeBundleParameters(t *testing.T) {
 				},
 			},
 		}
-		c := &claim.Claim{Bundle: bundle}
-		err := mergeBundleParameters(c)
+		i := &store.Installation{Claim: claim.Claim{Bundle: bundle}}
+		err := mergeBundleParameters(i)
 		assert.NilError(t, err)
 		expected := map[string]interface{}{
 			"param": "default",
 		}
-		assert.Assert(t, cmp.DeepEqual(c.Parameters, expected))
+		assert.Assert(t, cmp.DeepEqual(i.Parameters, expected))
 	})
 
 	t.Run("Undefined parameter is rejected", func(t *testing.T) {
@@ -184,8 +185,8 @@ func TestMergeBundleParameters(t *testing.T) {
 		bundle := &bundle.Bundle{
 			Parameters: map[string]bundle.ParameterDefinition{},
 		}
-		c := &claim.Claim{Bundle: bundle}
-		err := mergeBundleParameters(c, withUndefined)
+		i := &store.Installation{Claim: claim.Claim{Bundle: bundle}}
+		err := mergeBundleParameters(i, withUndefined)
 		assert.ErrorContains(t, err, "is not defined in the bundle")
 	})
 
@@ -201,8 +202,8 @@ func TestMergeBundleParameters(t *testing.T) {
 				},
 			},
 		}
-		c := &claim.Claim{Bundle: bundle}
-		err := mergeBundleParameters(c, withIntValue)
+		i := &store.Installation{Claim: claim.Claim{Bundle: bundle}}
+		err := mergeBundleParameters(i, withIntValue)
 		assert.ErrorContains(t, err, "invalid value for parameter")
 	})
 
@@ -219,8 +220,8 @@ func TestMergeBundleParameters(t *testing.T) {
 				},
 			},
 		}
-		c := &claim.Claim{Bundle: bundle}
-		err := mergeBundleParameters(c, withIntValue)
+		i := &store.Installation{Claim: claim.Claim{Bundle: bundle}}
+		err := mergeBundleParameters(i, withIntValue)
 		assert.ErrorContains(t, err, "invalid value for parameter")
 	})
 }

--- a/internal/commands/render.go
+++ b/internal/commands/render.go
@@ -53,13 +53,13 @@ func runRender(dockerCli command.Cli, appname string, opts renderOptions) error 
 		w = f
 	}
 
-	a, c, errBuf, err := prepareCustomAction(internal.ActionRenderName, dockerCli, appname, w, opts.registryOptions, opts.pullOptions, opts.parametersOptions)
+	action, installation, errBuf, err := prepareCustomAction(internal.ActionRenderName, dockerCli, appname, w, opts.registryOptions, opts.pullOptions, opts.parametersOptions)
 	if err != nil {
 		return err
 	}
-	c.Parameters[internal.ParameterRenderFormatName] = opts.formatDriver
+	installation.Parameters[internal.ParameterRenderFormatName] = opts.formatDriver
 
-	if err := a.Run(c, nil, nil); err != nil {
+	if err := action.Run(&installation.Claim, nil, nil); err != nil {
 		return fmt.Errorf("render failed: %s", errBuf)
 	}
 	return nil

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -26,6 +26,7 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		installCmd(dockerCli),
 		upgradeCmd(dockerCli),
 		uninstallCmd(dockerCli),
+		listCmd(dockerCli),
 		statusCmd(dockerCli),
 		initCmd(dockerCli),
 		inspectCmd(dockerCli),

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -38,11 +38,11 @@ func runStatus(dockerCli command.Cli, installationName string, opts credentialOp
 		return err
 	}
 
-	c, err := installationStore.Read(installationName)
+	installation, err := installationStore.Read(installationName)
 	if err != nil {
 		return err
 	}
-	bind, err := requiredClaimBindMount(c, opts.targetContext, dockerCli)
+	bind, err := requiredClaimBindMount(installation.Claim, opts.targetContext, dockerCli)
 	if err != nil {
 		return err
 	}
@@ -50,23 +50,23 @@ func runStatus(dockerCli command.Cli, installationName string, opts credentialOp
 	if err != nil {
 		return err
 	}
-	if err := mergeBundleParameters(&c,
+	if err := mergeBundleParameters(installation,
 		withSendRegistryAuth(opts.sendRegistryAuth),
 	); err != nil {
 		return err
 	}
-	creds, err := prepareCredentialSet(c.Bundle, opts.CredentialSetOpts(dockerCli, credentialStore)...)
+	creds, err := prepareCredentialSet(installation.Bundle, opts.CredentialSetOpts(dockerCli, credentialStore)...)
 	if err != nil {
 		return err
 	}
-	if err := credentials.Validate(creds, c.Bundle.Credentials); err != nil {
+	if err := credentials.Validate(creds, installation.Bundle.Credentials); err != nil {
 		return err
 	}
 	status := &action.RunCustom{
 		Action: internal.ActionStatusName,
 		Driver: driverImpl,
 	}
-	if err := status.Run(&c, creds, dockerCli.Out()); err != nil {
+	if err := status.Run(&installation.Claim, creds, dockerCli.Out()); err != nil {
 		return fmt.Errorf("status failed: %s\n%s", err, errBuf)
 	}
 	return nil

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -37,11 +37,11 @@ func runUninstall(dockerCli command.Cli, installationName string, opts credentia
 		return err
 	}
 
-	c, err := installationStore.Read(installationName)
+	installation, err := installationStore.Read(installationName)
 	if err != nil {
 		return err
 	}
-	bind, err := requiredClaimBindMount(c, opts.targetContext, dockerCli)
+	bind, err := requiredClaimBindMount(installation.Claim, opts.targetContext, dockerCli)
 	if err != nil {
 		return err
 	}
@@ -49,18 +49,18 @@ func runUninstall(dockerCli command.Cli, installationName string, opts credentia
 	if err != nil {
 		return err
 	}
-	creds, err := prepareCredentialSet(c.Bundle, opts.CredentialSetOpts(dockerCli, credentialStore)...)
+	creds, err := prepareCredentialSet(installation.Bundle, opts.CredentialSetOpts(dockerCli, credentialStore)...)
 	if err != nil {
 		return err
 	}
-	if err := credentials.Validate(creds, c.Bundle.Credentials); err != nil {
+	if err := credentials.Validate(creds, installation.Bundle.Credentials); err != nil {
 		return err
 	}
 	uninst := &action.Uninstall{
 		Driver: driverImpl,
 	}
-	if err := uninst.Run(&c, creds, os.Stdout); err != nil {
-		if err2 := installationStore.Store(c); err2 != nil {
+	if err := uninst.Run(&installation.Claim, creds, os.Stdout); err != nil {
+		if err2 := installationStore.Store(installation); err2 != nil {
 			return fmt.Errorf("%s while %s", err2, errBuf)
 		}
 		return fmt.Errorf("Uninstall failed: %s", errBuf)

--- a/internal/store/app.go
+++ b/internal/store/app.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/deislabs/duffle/pkg/claim"
 	"github.com/deislabs/duffle/pkg/utils/crud"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -57,8 +56,7 @@ func (a ApplicationStore) InstallationStore(context string) (InstallationStore, 
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return nil, errors.Wrapf(err, "failed to create installation store directory for context %q", context)
 	}
-	claimStore := claim.NewClaimStore(crud.NewFileSystemStore(path, "json"))
-	return &installationStore{claimStore: claimStore}, nil
+	return &installationStore{store: crud.NewFileSystemStore(path, "json")}, nil
 }
 
 // CredentialStore initializes and returns a context based credential store

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -1,41 +1,73 @@
 package store
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/deislabs/duffle/pkg/claim"
+	"github.com/deislabs/duffle/pkg/utils/crud"
 )
 
-// InstallationStore is an interface to persist claims.
+// InstallationStore is an interface to persist, delete, list and read installations.
 type InstallationStore interface {
 	List() ([]string, error)
-	Store(installation claim.Claim) error
-	Read(installationName string) (claim.Claim, error)
+	Store(installation *Installation) error
+	Read(installationName string) (*Installation, error)
 	Delete(installationName string) error
+}
+
+// Installation is a CNAB claim with an information of where the bundle comes from.
+// It persists the result of an installation and its parameters and context.
+type Installation struct {
+	claim.Claim
+	Reference string `json:"reference,omitempty"`
+}
+
+func NewInstallation(name string, reference string) (*Installation, error) {
+	c, err := claim.New(name)
+	if err != nil {
+		return nil, err
+	}
+	return &Installation{
+		Claim:     *c,
+		Reference: reference,
+	}, nil
 }
 
 var _ InstallationStore = &installationStore{}
 
 type installationStore struct {
-	claimStore claim.Store
+	store crud.Store
 }
 
 func (i installationStore) List() ([]string, error) {
-	return i.claimStore.List()
+	return i.store.List()
 }
 
-func (i installationStore) Store(installation claim.Claim) error {
-	return i.claimStore.Store(installation)
-}
-
-func (i installationStore) Read(installationName string) (claim.Claim, error) {
-	c, err := i.claimStore.Read(installationName)
-	if err == claim.ErrClaimNotFound {
-		return claim.Claim{}, fmt.Errorf("Installation %q not found", installationName)
+func (i installationStore) Store(installation *Installation) error {
+	data, err := json.MarshalIndent(installation, "", "  ")
+	if err != nil {
+		return err
 	}
-	return c, err
+	return i.store.Store(installation.Name, data)
+}
+
+func (i installationStore) Read(installationName string) (*Installation, error) {
+	data, err := i.store.Read(installationName)
+	if err != nil {
+		if err == crud.ErrFileDoesNotExist {
+			return nil, fmt.Errorf("Installation %q not found", installationName)
+
+		}
+		return nil, err
+	}
+	var installation Installation
+	if err := json.Unmarshal(data, &installation); err != nil {
+		return nil, err
+	}
+	return &installation, nil
 }
 
 func (i installationStore) Delete(installationName string) error {
-	return i.claimStore.Delete(installationName)
+	return i.store.Delete(installationName)
 }

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -18,7 +18,12 @@ func TestStoreAndReadInstallation(t *testing.T) {
 	installationStore, err := appstore.InstallationStore("my-context")
 	assert.NilError(t, err)
 
-	expectedInstallation := claim.Claim{Name: "installation-name"}
+	expectedInstallation := &Installation{
+		Claim: claim.Claim{
+			Name: "installation-name",
+		},
+		Reference: "mybundle:mytag",
+	}
 
 	// Store the installation
 	err = installationStore.Store(expectedInstallation)


### PR DESCRIPTION
**- What I did**
Added a REFERENCE column, showing the registry reference, or "local" if the application was installed from a local CNAB bundle.

⚠️ On top of #510 

**- How to verify it**
```
$ docker app install slubecki/example:v1.0.0 --name toto
Creating network toto_default
Creating service toto_hello
Application "toto" installed on context "default"
                                                                                                                                    
$ docker app ls
INSTALLATION APPLICATION          LAST ACTION RESULT  CREATED    MODIFIED  REFERENCE
simple       simple (1.1.0-beta1) install     failure 16 hours   16 hours
toto         hello-world (0.1.0)  install     success 11 seconds 8 seconds docker.io/slubecki/example:v1.0.0
```

**- Description for the changelog**
* Show application reference in the list command

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/56429775-65a5fd80-62c4-11e9-8a7d-7a2de510a6f0.png)
