### PR TITLE
Bundle command now saves the bundle to the bundle store

### DIFF
--- a/e2e/testdata/bundle-with-tag.json.golden
+++ b/e2e/testdata/bundle-with-tag.json.golden
@@ -1,0 +1,142 @@
+{
+	"name": "simple",
+	"version": "1.1.0-beta1",
+	"description": "new fancy webapp with microservices",
+	"maintainers": [
+		{
+			"name": "John Developer",
+			"email": "john.dev@example.com"
+		},
+		{
+			"name": "Jane Developer",
+			"email": "jane.dev@example.com"
+		}
+	],
+	"invocationImages": [
+		{
+			"imageType": "docker",
+			"image": "myimage:mytag-invoc"
+		}
+	],
+	"images": {
+		"api": {
+			"imageType": "docker",
+			"image": "python:3.6",
+			"description": "python:3.6"
+		},
+		"db": {
+			"imageType": "docker",
+			"image": "postgres:9.3",
+			"description": "postgres:9.3"
+		},
+		"web": {
+			"imageType": "docker",
+			"image": "nginx:latest",
+			"description": "nginx:latest"
+		}
+	},
+	"actions": {
+		"com.docker.app.inspect": {
+			"stateless": true
+		},
+		"com.docker.app.render": {
+			"stateless": true
+		},
+		"com.docker.app.status": {}
+	},
+	"parameters": {
+		"api_host": {
+			"type": "string",
+			"defaultValue": "example.com",
+			"destination": {
+				"env": "docker_param1"
+			}
+		},
+		"com.docker.app.kubernetes-namespace": {
+			"type": "string",
+			"defaultValue": "",
+			"metadata": {
+				"description": "Namespace in which to deploy"
+			},
+			"destination": {
+				"env": "DOCKER_KUBERNETES_NAMESPACE"
+			},
+			"apply-to": [
+				"install",
+				"upgrade",
+				"uninstall",
+				"com.docker.app.status"
+			]
+		},
+		"com.docker.app.orchestrator": {
+			"type": "string",
+			"defaultValue": "",
+			"allowedValues": [
+				"",
+				"swarm",
+				"kubernetes"
+			],
+			"metadata": {
+				"description": "Orchestrator on which to deploy"
+			},
+			"destination": {
+				"env": "DOCKER_STACK_ORCHESTRATOR"
+			},
+			"apply-to": [
+				"install",
+				"upgrade",
+				"uninstall",
+				"com.docker.app.status"
+			]
+		},
+		"com.docker.app.render-format": {
+			"type": "string",
+			"defaultValue": "yaml",
+			"allowedValues": [
+				"yaml",
+				"json"
+			],
+			"metadata": {
+				"description": "Output format for the render command"
+			},
+			"destination": {
+				"env": "DOCKER_RENDER_FORMAT"
+			},
+			"apply-to": [
+				"com.docker.app.render"
+			]
+		},
+		"com.docker.app.share-registry-creds": {
+			"type": "bool",
+			"defaultValue": false,
+			"metadata": {
+				"description": "Share registry credentials with the invocation image"
+			},
+			"destination": {
+				"env": "DOCKER_SHARE_REGISTRY_CREDS"
+			}
+		},
+		"static_subdir": {
+			"type": "string",
+			"defaultValue": "data/static",
+			"destination": {
+				"env": "docker_param2"
+			}
+		},
+		"web_port": {
+			"type": "string",
+			"defaultValue": "8082",
+			"destination": {
+				"env": "docker_param3"
+			}
+		}
+	},
+	"credentials": {
+		"com.docker.app.registry-creds": {
+			"path": "/cnab/app/registry-creds.json"
+		},
+		"docker.context": {
+			"path": "/cnab/app/context.dockercontext"
+		}
+	}
+}

--- a/internal/commands/bundle.go
+++ b/internal/commands/bundle.go
@@ -10,10 +10,12 @@ import (
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/packager"
+	"github.com/docker/app/internal/store"
 	"github.com/docker/app/types"
 	"github.com/docker/app/types/metadata"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config"
 	"github.com/docker/distribution/reference"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -23,6 +25,7 @@ import (
 
 type bundleOptions struct {
 	out string
+	tag string
 }
 
 func bundleCmd(dockerCli command.Cli) *cobra.Command {
@@ -38,17 +41,27 @@ func bundleCmd(dockerCli command.Cli) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.out, "output", "o", "bundle.json", "Output file (- for stdout)")
+	cmd.Flags().StringVarP(&opts.tag, "tag", "t", "", "Name and optionally a tag in the 'name:tag' format")
 	return cmd
 }
 
 func runBundle(dockerCli command.Cli, appName string, opts bundleOptions) error {
-	bundle, err := makeBundle(dockerCli, appName)
+	ref, err := getNamedTagged(opts.tag)
+	if err != nil {
+		return err
+	}
+
+	bundle, err := makeBundle(dockerCli, appName, ref)
 	if err != nil {
 		return err
 	}
 	if bundle == nil || len(bundle.InvocationImages) == 0 {
 		return fmt.Errorf("failed to create bundle %q", appName)
 	}
+	if err := persistInBundleStore(ref, bundle); err != nil {
+		return err
+	}
+
 	fmt.Fprintf(dockerCli.Out(), "Invocation image %q successfully built\n", bundle.InvocationImages[0].Image)
 	bundleBytes, err := json.MarshalIndent(bundle, "", "\t")
 	if err != nil {
@@ -61,18 +74,18 @@ func runBundle(dockerCli command.Cli, appName string, opts bundleOptions) error 
 	return ioutil.WriteFile(opts.out, bundleBytes, 0644)
 }
 
-func makeBundle(dockerCli command.Cli, appName string) (*bundle.Bundle, error) {
+func makeBundle(dockerCli command.Cli, appName string, refOverride reference.NamedTagged) (*bundle.Bundle, error) {
 	app, err := packager.Extract(appName)
 	if err != nil {
 		return nil, err
 	}
 	defer app.Cleanup()
-	return makeBundleFromApp(dockerCli, app)
+	return makeBundleFromApp(dockerCli, app, refOverride)
 }
 
-func makeBundleFromApp(dockerCli command.Cli, app *types.App) (*bundle.Bundle, error) {
+func makeBundleFromApp(dockerCli command.Cli, app *types.App, refOverride reference.NamedTagged) (*bundle.Bundle, error) {
 	meta := app.Metadata()
-	invocationImageName, err := makeInvocationImageName(meta)
+	invocationImageName, err := makeInvocationImageName(meta, refOverride)
 	if err != nil {
 		return nil, err
 	}
@@ -102,14 +115,47 @@ func makeBundleFromApp(dockerCli command.Cli, app *types.App) (*bundle.Bundle, e
 	return packager.ToCNAB(app, invocationImageName)
 }
 
-func makeInvocationImageName(meta metadata.AppMetadata) (string, error) {
-	return makeCNABImageName(meta, "-invoc")
+func makeInvocationImageName(meta metadata.AppMetadata, refOverride reference.NamedTagged) (string, error) {
+	if refOverride != nil {
+		return makeCNABImageName(reference.FamiliarName(refOverride), refOverride.Tag(), "-invoc")
+	}
+	return makeCNABImageName(meta.Name, meta.Version, "-invoc")
 }
 
-func makeCNABImageName(meta metadata.AppMetadata, suffix string) (string, error) {
-	name := fmt.Sprintf("%s:%s%s", meta.Name, meta.Version, suffix)
+func makeCNABImageName(appName, appVersion, suffix string) (string, error) {
+	name := fmt.Sprintf("%s:%s%s", appName, appVersion, suffix)
 	if _, err := reference.ParseNormalizedNamed(name); err != nil {
 		return "", errors.Wrapf(err, "image name %q is invalid, please check name and version fields", name)
 	}
 	return name, nil
+}
+
+func persistInBundleStore(ref reference.Named, bndle *bundle.Bundle) error {
+	if ref == nil {
+		return nil
+	}
+	appstore, err := store.NewApplicationStore(config.Dir())
+	if err != nil {
+		return err
+	}
+	bundleStore, err := appstore.BundleStore()
+	if err != nil {
+		return err
+	}
+	return bundleStore.Store(ref, bndle)
+}
+
+func getNamedTagged(tag string) (reference.NamedTagged, error) {
+	if tag == "" {
+		return nil, nil
+	}
+	namedRef, err := reference.ParseNormalizedNamed(tag)
+	if err != nil {
+		return nil, err
+	}
+	ref, ok := reference.TagNameOnly(namedRef).(reference.NamedTagged)
+	if !ok {
+		return nil, fmt.Errorf("tag %q must be name with a tag in the 'name:tag' format", tag)
+	}
+	return ref, nil
 }

--- a/internal/commands/bundle_test.go
+++ b/internal/commands/bundle_test.go
@@ -11,6 +11,7 @@ func TestMakeInvocationImage(t *testing.T) {
 	testcases := []struct {
 		name     string
 		meta     metadata.AppMetadata
+		tag      string
 		expected string
 		err      string
 	}{
@@ -20,14 +21,22 @@ func TestMakeInvocationImage(t *testing.T) {
 			expected: "name:version-invoc",
 		},
 		{
-			name: "simple-metadata",
+			name:     "tag-override",
+			meta:     metadata.AppMetadata{Name: "name", Version: "version"},
+			expected: "myimage:mytag-invoc",
+			tag:      "myimage:mytag",
+		},
+		{
+			name: "invalid-metadata",
 			meta: metadata.AppMetadata{Name: "WrongName&%*", Version: "version"},
 			err:  "invalid",
 		},
 	}
 	for _, c := range testcases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := makeInvocationImageName(c.meta)
+			ref, err := getNamedTagged(c.tag)
+			assert.NilError(t, err)
+			actual, err := makeInvocationImageName(c.meta, ref)
 			if c.err != "" {
 				assert.ErrorContains(t, err, c.err)
 				assert.Equal(t, actual, "", "On "+c.meta.Name)

--- a/internal/commands/cnab.go
+++ b/internal/commands/cnab.go
@@ -207,7 +207,7 @@ func extractAndLoadAppBasedBundle(dockerCli command.Cli, name string) (*bundle.B
 		return nil, "", err
 	}
 	defer app.Cleanup()
-	bndl, err := makeBundleFromApp(dockerCli, app)
+	bndl, err := makeBundleFromApp(dockerCli, app, nil)
 	return bndl, "", err
 }
 

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -57,7 +57,7 @@ func runPush(dockerCli command.Cli, name string, opts pushOptions) error {
 		return err
 	}
 	defer app.Cleanup()
-	bndl, err := makeBundleFromApp(dockerCli, app)
+	bndl, err := makeBundleFromApp(dockerCli, app, nil)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func shouldRetagInvocationImage(meta metadata.AppMetadata, bndl *bundle.Bundle, 
 	imgName := tagOverride
 	var err error
 	if imgName == "" {
-		imgName, err = makeCNABImageName(meta, "")
+		imgName, err = makeCNABImageName(meta.Name, meta.Version, "")
 		if err != nil {
 			return retagResult{}, err
 		}


### PR DESCRIPTION
**- What I did**
Add --tag flag to the bundle command to persist the bundle in the loc…al bundle store.
Installation or any other command will be able to use this reference.
Invocation image is using the same name, appending "-invoc" to the tag.

**- How to verify it**
```sh
$ docker app bundle examples/hello-world/example-hello-world.dockerapp --tag myapp:mytag
Invocation image "myapp:mytag-invoc" successfully built
$ docker app inspect myapp:mytag
hello-world 0.1.0

Maintained by: user <user@email.com>

Hello, World!

Service (1) Replicas Ports Image
----------- -------- ----- -----
hello       1        8080  hashicorp/http-echo

Parameters (2) Value
-------------- -----
port           8080
text           Hello, World!
```

**- Description for the changelog**
* Add --tag to the bundle command to store locally the bundle

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/56663277-00785080-66a6-11e9-8353-167b6843891d.png)

