### PR TITLE
Provide support for using docker app offline

### DIFF
--- a/e2e/base_invocation_image_test.go
+++ b/e2e/base_invocation_image_test.go
@@ -1,0 +1,37 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/packager"
+
+	dockerConfigFile "github.com/docker/cli/cli/config/configfile"
+	"gotest.tools/assert"
+	"gotest.tools/icmd"
+)
+
+func TestBaseInvocationImageVersion(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cmd, cleanup := dockerCli.createTestCmd()
+		defer cleanup()
+		cmd.Command = dockerCli.Command("app", "version", "--base-invocation-image")
+		result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
+		output := strings.TrimSpace(result.Stdout())
+		assert.Equal(t, output, fmt.Sprintf("%s:%s", packager.DefaultCNABBaseImageName, internal.Version))
+	})
+
+	t.Run("config", func(t *testing.T) {
+		imageName := "some-base-image:some-tag"
+		cmd, cleanup := dockerCli.createTestCmd(func(config *dockerConfigFile.ConfigFile) {
+			config.SetPluginConfig("app", "base-invocation-image", imageName)
+		})
+		defer cleanup()
+		cmd.Command = dockerCli.Command("app", "version", "--base-invocation-image")
+		result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
+		output := strings.TrimSpace(result.Stdout())
+		assert.Equal(t, output, imageName)
+	})
+}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -29,12 +29,17 @@ type dockerCliCommand struct {
 	cliPluginDir string
 }
 
-func (d dockerCliCommand) createTestCmd() (icmd.Cmd, func()) {
+type ConfigFileOperator func(configFile *dockerConfigFile.ConfigFile)
+
+func (d dockerCliCommand) createTestCmd(ops ...ConfigFileOperator) (icmd.Cmd, func()) {
 	configDir, err := ioutil.TempDir("", "config")
 	if err != nil {
 		panic(err)
 	}
 	config := dockerConfigFile.ConfigFile{CLIPluginsExtraDirs: []string{d.cliPluginDir}}
+	for _, op := range ops {
+		op(&config)
+	}
 	configFile, err := os.Create(filepath.Join(configDir, "config.json"))
 	if err != nil {
 		panic(err)

--- a/internal/commands/bundle.go
+++ b/internal/commands/bundle.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 
 	"github.com/deislabs/cnab-go/bundle"
-	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/types"
 	"github.com/docker/app/types/metadata"
@@ -78,7 +77,7 @@ func makeBundleFromApp(dockerCli command.Cli, app *types.App) (*bundle.Bundle, e
 	}
 
 	buildContext := bytes.NewBuffer(nil)
-	if err := packager.PackInvocationImageContext(app, buildContext); err != nil {
+	if err := packager.PackInvocationImageContext(dockerCli, app, buildContext); err != nil {
 		return nil, err
 	}
 
@@ -94,8 +93,8 @@ func makeBundleFromApp(dockerCli command.Cli, app *types.App) (*bundle.Bundle, e
 	if err := jsonmessage.DisplayJSONMessagesStream(buildResp.Body, ioutil.Discard, 0, false, func(jsonmessage.JSONMessage) {}); err != nil {
 		// If the invocation image can't be found we will get an error of the form:
 		// manifest for docker/cnab-app-base:v0.6.0-202-gbaf0b246c7 not found
-		if err.Error() == fmt.Sprintf("manifest for %s:%s not found", packager.CNABBaseImageName, internal.Version) {
-			return nil, fmt.Errorf("unable to resolve Docker App base image: %s:%s", packager.CNABBaseImageName, internal.Version)
+		if err.Error() == fmt.Sprintf("manifest for %s not found", packager.BaseInvocationImage(dockerCli)) {
+			return nil, fmt.Errorf("unable to resolve Docker App base image: %s", packager.BaseInvocationImage(dockerCli))
 		}
 		return nil, err
 	}

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -4,16 +4,33 @@ import (
 	"fmt"
 
 	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/packager"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
 func versionCmd(dockerCli command.Cli) *cobra.Command {
-	return &cobra.Command{
+	var onlyBaseImage bool
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
+		Long: `Print version information
+
+The --base-invocation-image will return the base invocation image name only. This can be useful for
+
+	docker pull $(docker app version --base-invocation-image)
+	
+In order to be able to build an invocation images when using docker app from an offline system.
+		`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintln(dockerCli.Out(), internal.FullVersion())
+			image := packager.BaseInvocationImage(dockerCli)
+			if onlyBaseImage {
+				fmt.Fprintln(dockerCli.Out(), image)
+			} else {
+				fmt.Fprintln(dockerCli.Out(), internal.FullVersion(image))
+			}
 		},
 	}
+	cmd.Flags().BoolVar(&onlyBaseImage, "base-invocation-image", false, "Print CNAB base invocation image to be used")
+	return cmd
 }

--- a/internal/packager/packing_test.go
+++ b/internal/packager/packing_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/app/types"
+	"github.com/docker/cli/cli/command"
 	"gotest.tools/assert"
 )
 
@@ -16,7 +17,9 @@ func TestPackInvocationImageContext(t *testing.T) {
 	app, err := types.NewAppFromDefaultFiles("testdata/packages/packing.dockerapp")
 	assert.NilError(t, err)
 	buf := bytes.NewBuffer(nil)
-	assert.NilError(t, PackInvocationImageContext(app, buf))
+	dockerCli, err := command.NewDockerCli()
+	assert.NilError(t, err)
+	assert.NilError(t, PackInvocationImageContext(dockerCli, app, buf))
 	assert.NilError(t, hasExpectedFiles(buf, map[string]bool{
 		"Dockerfile":                                              true,
 		".dockerignore":                                           true,

--- a/internal/version.go
+++ b/internal/version.go
@@ -19,14 +19,15 @@ var (
 )
 
 // FullVersion returns a string of version information.
-func FullVersion() string {
+func FullVersion(invocationBaseImage string) string {
 	res := []string{
-		fmt.Sprintf("Version:      %s", Version),
-		fmt.Sprintf("Git commit:   %s", GitCommit),
-		fmt.Sprintf("Built:        %s", reformatDate(BuildTime)),
-		fmt.Sprintf("OS/Arch:      %s/%s", runtime.GOOS, runtime.GOARCH),
-		fmt.Sprintf("Experimental: %s", Experimental),
-		fmt.Sprintf("Renderers:    %s", strings.Join(renderer.Drivers(), ", ")),
+		fmt.Sprintf("Version:               %s", Version),
+		fmt.Sprintf("Git commit:            %s", GitCommit),
+		fmt.Sprintf("Built:                 %s", reformatDate(BuildTime)),
+		fmt.Sprintf("OS/Arch:               %s/%s", runtime.GOOS, runtime.GOARCH),
+		fmt.Sprintf("Experimental:          %s", Experimental),
+		fmt.Sprintf("Renderers:             %s", strings.Join(renderer.Drivers(), ", ")),
+		fmt.Sprintf("Invocation Base Image: %s", invocationBaseImage),
 	}
 	return strings.Join(res, "\n")
 }


### PR DESCRIPTION
**- What I did**
Add a new --base-invocation-image flag to docker app version command to print the image name. It makes this command possible in order to work "offline"

`docker pull $(docker app version --base-invocation-image)`   

**- How to verify it**
Tests TBD

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![cuteanimal](https://user-images.githubusercontent.com/470082/56675249-eba6b780-66bb-11e9-9067-b0fc7e691102.jpg)
