### PR TITLE
List installations per last modification date

### DIFF
--- a/internal/commands/list_test.go
+++ b/internal/commands/list_test.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"testing"
+	"time"
+
+	"github.com/deislabs/duffle/pkg/claim"
+	"github.com/docker/app/internal/store"
+	"gotest.tools/assert"
+	"gotest.tools/fs"
+)
+
+func TestGetInstallationsSorted(t *testing.T) {
+	tmpDir := fs.NewDir(t, "")
+	defer tmpDir.Remove()
+	appstore, err := store.NewApplicationStore(tmpDir.Path())
+	assert.NilError(t, err)
+	installationStore, err := appstore.InstallationStore("my-context")
+	assert.NilError(t, err)
+	now := time.Now()
+
+	oldInstallation := &store.Installation{
+		Claim: claim.Claim{
+			Name:     "old-installation",
+			Modified: now.Add(-1 * time.Hour),
+		},
+	}
+	newInstallation := &store.Installation{
+		Claim: claim.Claim{
+			Name:     "new-installation",
+			Modified: now,
+		},
+	}
+	assert.NilError(t, installationStore.Store(newInstallation))
+	assert.NilError(t, installationStore.Store(oldInstallation))
+
+	installations, err := getInstallations("my-context", tmpDir.Path())
+	assert.NilError(t, err)
+	assert.Equal(t, len(installations), 2)
+	// First installation is the last modified
+	assert.Equal(t, installations[0].Name, "new-installation")
+	assert.Equal(t, installations[1].Name, "old-installation")
+}


### PR DESCRIPTION
**- How to verify it**
Last installed application is listed first:
```sh
$ docker app ls
INSTALLATION        APPLICATION                 LAST ACTION RESULT  CREATED  MODIFIED REFERENCE
hello-world         hello-world (0.1.0)         install     failure 24 hours 24 hours docker.io/slubecki/example:v2.0.0
cnab-with-status    cnab-with-status (0.1.0)    install     success 43 hours 43 hours
cnab-without-status cnab-without-status (0.1.0) install     success 43 hours 43 hours docker.io/slubecki/example:v1.0.0
```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/56676672-1fcfa780-66bf-11e9-8532-70d7f73248fd.png)
