### PR TITLE
inspect: sort services, networks, volumes and secrets by name

### DIFF
--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -34,6 +34,9 @@ func Inspect(out io.Writer, app *types.App, argParameters map[string]string, ima
 
 	// Add Service section
 	printSection(out, len(config.Services), func(w io.Writer) {
+		sort.Slice(config.Services, func(i, j int) bool {
+			return config.Services[i].Name < config.Services[j].Name
+		})
 		for _, service := range config.Services {
 			fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", service.Name, getReplicas(service), getPorts(service.Ports), service.Image)
 		}
@@ -41,21 +44,36 @@ func Inspect(out io.Writer, app *types.App, argParameters map[string]string, ima
 
 	// Add Network section
 	printSection(out, len(config.Networks), func(w io.Writer) {
+		names := make([]string, 0, len(config.Networks))
 		for name := range config.Networks {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
 			fmt.Fprintln(w, name)
 		}
 	}, "Network")
 
 	// Add Volume section
 	printSection(out, len(config.Volumes), func(w io.Writer) {
+		names := make([]string, 0, len(config.Volumes))
 		for name := range config.Volumes {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
 			fmt.Fprintln(w, name)
 		}
 	}, "Volume")
 
 	// Add Secret section
 	printSection(out, len(config.Secrets), func(w io.Writer) {
+		names := make([]string, 0, len(config.Secrets))
 		for name := range config.Secrets {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
 			fmt.Fprintln(w, name)
 		}
 	}, "Secret")

--- a/internal/inspect/testdata/inspect-full.golden
+++ b/internal/inspect/testdata/inspect-full.golden
@@ -4,21 +4,25 @@ Maintained by: dev <dev@example.com>
 
 some description
 
-Service (1) Replicas Ports     Image
------------ -------- -----     -----
-web         2        8080-8100 nginx:latest
+Services (2) Replicas Ports     Image
+------------ -------- -----     -----
+web1         2        8080-8100 nginx:latest
+web2         2        9080-9100 nginx:latest
 
-Network (1)
+Networks (2)
+------------
+my-network1
+my-network2
+
+Volumes (2)
 -----------
-my-network
+my-volume1
+my-volume2
 
-Volume (1)
-----------
-my-volume
-
-Secret (1)
-----------
-my-secret
+Secrets (2)
+-----------
+my-secret1
+my-secret2
 
 Parameters (2) Value
 -------------- -----


### PR DESCRIPTION
```
    Networks, Volumes and Secrets are maps so iteration is randomized by the
    runtime. Although Services are an slice here they have, at some point, be
    laundered through a map and so also need sorting.
    
    Test by adding a second instance of each to the "full" test case and by always
    inspecting twice (in case the first one got lucky).
    
    Fixes: #525
    
    Signed-off-by: Ian Campbell <ijc@docker.com>
```

After that I added a second commit which uses reflection to reduce the boilerplate/repetition. I'm not sure about that though, maybe it's overkill. Would be fine to drop that commit if people prefer.