### PR TITLE
Push directly from bundle

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -66,14 +66,15 @@ func testRenderApp(appPath string, env ...string) func(*testing.T) {
 		}
 		cmd.Command = args
 		cmd.Env = append(cmd.Env, env...)
-		// Check rendering to stdout
-		result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		assert.Assert(t, is.Equal(readFile(t, filepath.Join(appPath, "expected.txt")), result.Stdout()), "rendering mismatch")
-		// Checks rendering to a file
-		cmd.Command = append(cmd.Command, "--output="+dir.Join("actual.yaml"))
-		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-
-		assert.Assert(t, is.Equal(readFile(t, filepath.Join(appPath, "expected.txt")), readFile(t, dir.Join("actual.yaml"))), "rendering mismatch")
+		t.Run("stdout", func(t *testing.T) {
+			result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
+			assert.Assert(t, is.Equal(readFile(t, filepath.Join(appPath, "expected.txt")), result.Stdout()), "rendering mismatch")
+		})
+		t.Run("file", func(t *testing.T) {
+			cmd.Command = append(cmd.Command, "--output="+dir.Join("actual.yaml"))
+			icmd.RunCmd(cmd).Assert(t, icmd.Success)
+			assert.Assert(t, is.Equal(readFile(t, filepath.Join(appPath, "expected.txt")), readFile(t, dir.Join("actual.yaml"))), "rendering mismatch")
+		})
 	}
 }
 

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -85,11 +85,11 @@ func runPush(dockerCli command.Cli, name string, opts pushOptions) error {
 		RegistryAuth: encodedAuth,
 	})
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "starting push of %q", retag.invocationImageRef.String())
 	}
 	defer reader.Close()
 	if err = jsonmessage.DisplayJSONMessagesStream(reader, ioutil.Discard, 0, false, nil); err != nil {
-		return err
+		return errors.Wrapf(err, "pushing to %q", retag.invocationImageRef.String())
 	}
 
 	resolverConfig := remotes.NewResolverConfigFromDockerConfigFile(dockerCli.ConfigFile(), opts.registry.insecureRegistries...)
@@ -107,12 +107,12 @@ func runPush(dockerCli command.Cli, name string, opts pushOptions) error {
 	err = remotes.FixupBundle(context.Background(), bndl, retag.cnabRef, resolverConfig, fixupOptions...)
 
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "fixing up %q for push", retag.cnabRef)
 	}
 	// push bundle manifest
 	descriptor, err := remotes.Push(context.Background(), bndl, retag.cnabRef, resolverConfig.Resolver, true)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "pushing to %q", retag.cnabRef)
 	}
 	fmt.Printf("Successfully pushed bundle to %s. Digest is %s.\n", retag.cnabRef.String(), descriptor.Digest)
 	return nil

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -78,6 +78,18 @@ func prepareStores(targetContext string) (store.BundleStore, store.InstallationS
 	return bundleStore, installationStore, credentialStore, nil
 }
 
+func prepareBundleStore() (store.BundleStore, error) {
+	appstore, err := store.NewApplicationStore(config.Dir())
+	if err != nil {
+		return nil, err
+	}
+	bundleStore, err := appstore.BundleStore()
+	if err != nil {
+		return nil, err
+	}
+	return bundleStore, nil
+}
+
 type parametersOptions struct {
 	parametersFiles []string
 	overrides       []string

--- a/types/metadata/metadata.go
+++ b/types/metadata/metadata.go
@@ -2,6 +2,8 @@ package metadata
 
 import (
 	"strings"
+
+	"github.com/deislabs/cnab-go/bundle"
 )
 
 // Maintainer represents one of the apps's maintainers
@@ -37,4 +39,20 @@ type AppMetadata struct {
 	Name        string      `json:"name"`
 	Description string      `json:"description,omitempty"`
 	Maintainers Maintainers `json:"maintainers,omitempty"`
+}
+
+// Metadata extracts the docker-app metadata from the bundle
+func FromBundle(bndl *bundle.Bundle) AppMetadata {
+	meta := AppMetadata{
+		Name:        bndl.Name,
+		Version:     bndl.Version,
+		Description: bndl.Description,
+	}
+	for _, m := range bndl.Maintainers {
+		meta.Maintainers = append(meta.Maintainers, Maintainer{
+			Name:  m.Name,
+			Email: m.Email,
+		})
+	}
+	return meta
 }


### PR DESCRIPTION
Adjust `push` to behave the same as `install` and autodetect whether the argument is a `.dockerapp` or a bundle or a ref and Do The Right Thing.

Fixes #526. Lacking tests so WIP, but @silvin-lubecki would be good to know if this is what you were thinking of.