### PR TITLE
Allow the user to specify individual credentials on the command line

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -44,6 +44,7 @@ func (d dockerCliCommand) createTestCmd(ops ...ConfigFileOperator) (icmd.Cmd, fu
 	if err != nil {
 		panic(err)
 	}
+	defer configFile.Close()
 	err = json.NewEncoder(configFile).Encode(config)
 	if err != nil {
 		panic(err)

--- a/e2e/testdata/credential-install-bundle.json
+++ b/e2e/testdata/credential-install-bundle.json
@@ -1,0 +1,24 @@
+{
+    "name": "example-credentials",
+    "version": "0.0.1",
+    "schemaVersion": "v1.0.0-WD",
+    "invocationImages": [
+        {
+        "imageType": "docker",
+        "image": "cnab/example-credentials@sha256:b93f7279bdc9610d4ef275dab5d0a1d19cc613a784e2522977866747090059f4"
+      }
+    ],
+    "credentials": {
+        "secret1": {
+            "env" :"SECRET_ONE"
+        },
+        "secret2": {
+            "path": "/var/secret_two/data.txt"
+        },
+        "secret3": {
+            "env": "SECRET_THREE",
+            "path": "/var/secret_three/data.txt"
+        }
+    }
+}
+

--- a/e2e/testdata/credential-install-full.golden
+++ b/e2e/testdata/credential-install-full.golden
@@ -1,0 +1,7 @@
+SECRET_ONE: foo
+/var/secret_two/data.txt
+bar
+SECRET_THREE: baz
+/var/secret_three/data.txt
+baz
+Application "full" installed on context "default"

--- a/e2e/testdata/credential-install-missing.golden
+++ b/e2e/testdata/credential-install-missing.golden
@@ -1,0 +1,1 @@
+bundle requires credential for secret2

--- a/e2e/testdata/credential-install-mixed.golden
+++ b/e2e/testdata/credential-install-mixed.golden
@@ -1,0 +1,7 @@
+SECRET_ONE: secret1value
+/var/secret_two/data.txt
+secret2value
+SECRET_THREE: xyzzy
+/var/secret_three/data.txt
+xyzzy
+Application "mixed" installed on context "default"

--- a/e2e/testdata/credential-install-overload.golden
+++ b/e2e/testdata/credential-install-overload.golden
@@ -1,0 +1,1 @@
+ambiguous credential resolution: "secret1" is already present in base credential sets, cannot merge

--- a/internal/commands/cnab.go
+++ b/internal/commands/cnab.go
@@ -60,6 +60,33 @@ func addNamedCredentialSets(credStore appstore.CredentialStore, namedCredentials
 	}
 }
 
+func parseCommandlineCredential(c string) (string, string, error) {
+	split := strings.SplitN(c, "=", 2)
+	if len(split) != 2 || split[0] == "" {
+		return "", "", errors.Errorf("failed to parse %q as a credential name=value", c)
+	}
+	name := split[0]
+	value := split[1]
+	return name, value, nil
+}
+
+func addCredentials(strcreds []string) credentialSetOpt {
+	return func(_ *bundle.Bundle, creds credentials.Set) error {
+		for _, c := range strcreds {
+			name, value, err := parseCommandlineCredential(c)
+			if err != nil {
+				return err
+			}
+			if err := creds.Merge(credentials.Set{
+				name: value,
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
 func addDockerCredentials(contextName string, store contextstore.Store) credentialSetOpt {
 	// docker desktop contexts require some rewriting for being used within a container
 	store = dockerDesktopAwareStore{Store: store}

--- a/internal/commands/cnab_test.go
+++ b/internal/commands/cnab_test.go
@@ -230,3 +230,34 @@ func TestShareRegistryCreds(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCommandlineCredential(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		n, v string
+		err  string // either err or n+v are non-""
+	}{
+		{in: "", err: `failed to parse "" as a credential name=value`},
+		{in: "A", err: `failed to parse "A" as a credential name=value`},
+		{in: "=B", err: `failed to parse "=B" as a credential name=value`},
+		{in: "A=", n: "A", v: ""},
+		{in: "A=B", n: "A", v: "B"},
+		{in: "A==", n: "A", v: "="},
+		{in: "A=B=C", n: "A", v: "B=C"},
+	} {
+		n := tc.in
+		if n == "" {
+			n = "«empty»"
+		}
+		t.Run(n, func(t *testing.T) {
+			n, v, err := parseCommandlineCredential(tc.in)
+			if tc.err != "" {
+				assert.Error(t, err, tc.err)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, tc.n, n)
+				assert.Equal(t, tc.v, v)
+			}
+		})
+	}
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -91,12 +91,14 @@ func (o *parametersOptions) addFlags(flags *pflag.FlagSet) {
 type credentialOptions struct {
 	targetContext    string
 	credentialsets   []string
+	credentials      []string
 	sendRegistryAuth bool
 }
 
 func (o *credentialOptions) addFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.targetContext, "target-context", "", "Context on which the application is installed (default: <current-context>)")
 	flags.StringArrayVar(&o.credentialsets, "credential-set", []string{}, "Use a YAML file containing a credential set or a credential set present in the credential store")
+	flags.StringArrayVar(&o.credentials, "credential", nil, "Add a single credential, additive ontop of any --credential-set used")
 	flags.BoolVar(&o.sendRegistryAuth, "with-registry-auth", false, "Sends registry auth")
 }
 
@@ -107,6 +109,7 @@ func (o *credentialOptions) SetDefaultTargetContext(dockerCli command.Cli) {
 func (o *credentialOptions) CredentialSetOpts(dockerCli command.Cli, credentialStore store.CredentialStore) []credentialSetOpt {
 	return []credentialSetOpt{
 		addNamedCredentialSets(credentialStore, o.credentialsets),
+		addCredentials(o.credentials),
 		addDockerCredentials(o.targetContext, dockerCli.ContextStore()),
 		addRegistryCredentials(o.sendRegistryAuth, dockerCli),
 	}


### PR DESCRIPTION
e.g.

    docker app install --credential name=somevalue bundle.json

Credentials added with `--credential` always come after those added with
`--credential-set` (irrespective of the order on the command line).

A credential specified with `--credential` cannot override any previous
credential, including those specified in a credential set.

The test bnudle used is based on
https://github.com/deislabs/example-bundles/blob/0e8af9a2f1270bd72045a515637a432e74743d5d/example-credentials/bundle.json
But with `cnab/example-credentials:latest` → a digested ref (with the digest I
pulled today)

Signed-off-by: Ian Campbell <ijc@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

