### PR TITLE
Add a --all-contexts flag to list all the installations

### DIFF
--- a/internal/commands/list_test.go
+++ b/internal/commands/list_test.go
@@ -1,31 +1,35 @@
 package commands
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
+	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/docker/app/internal/store"
+	appStore "github.com/docker/app/internal/store"
 	"gotest.tools/assert"
 	"gotest.tools/fs"
+	"gotest.tools/golden"
 )
 
 func TestGetInstallationsSorted(t *testing.T) {
 	tmpDir := fs.NewDir(t, "")
 	defer tmpDir.Remove()
-	appstore, err := store.NewApplicationStore(tmpDir.Path())
+	appstore, err := appStore.NewApplicationStore(tmpDir.Path())
 	assert.NilError(t, err)
 	installationStore, err := appstore.InstallationStore("my-context")
 	assert.NilError(t, err)
 	now := time.Now()
 
-	oldInstallation := &store.Installation{
+	oldInstallation := &appStore.Installation{
 		Claim: claim.Claim{
 			Name:     "old-installation",
 			Modified: now.Add(-1 * time.Hour),
 		},
 	}
-	newInstallation := &store.Installation{
+	newInstallation := &appStore.Installation{
 		Claim: claim.Claim{
 			Name:     "new-installation",
 			Modified: now,
@@ -40,4 +44,58 @@ func TestGetInstallationsSorted(t *testing.T) {
 	// First installation is the last modified
 	assert.Equal(t, installations[0].Name, "new-installation")
 	assert.Equal(t, installations[1].Name, "old-installation")
+}
+
+func TestGetInstallationsAllContexts(t *testing.T) {
+	tmpDir := fs.NewDir(t, "")
+	defer tmpDir.Remove()
+
+	// Create one installation per context
+	appstore, err := store.NewApplicationStore(tmpDir.Path())
+	assert.NilError(t, err)
+
+	installationStore1, err := appstore.InstallationStore("context1")
+	assert.NilError(t, err)
+	installation1 := &store.Installation{
+		Claim: claim.Claim{
+			Name:     "installation1",
+			Created:  time.Now().Add(-24 * time.Hour),
+			Modified: time.Now().Add(-24 * time.Hour),
+			Result: claim.Result{
+				Action: claim.ActionInstall,
+				Status: claim.StatusSuccess,
+			},
+			Bundle: &bundle.Bundle{
+				Name:    "Application",
+				Version: "1.0.0",
+			},
+		},
+		Reference: "user/application:1",
+	}
+	assert.NilError(t, installationStore1.Store(installation1))
+
+	installationStore2, err := appstore.InstallationStore("context2")
+	assert.NilError(t, err)
+	installation2 := &store.Installation{
+		Claim: claim.Claim{
+			Name:     "installation2",
+			Created:  time.Now().Add(-30 * 24 * time.Hour),
+			Modified: time.Now().Add(-30 * 24 * time.Hour),
+			Result: claim.Result{
+				Action: claim.ActionUpgrade,
+				Status: claim.StatusFailure,
+			},
+			Bundle: &bundle.Bundle{
+				Name:    "OtherApplication",
+				Version: "0.2.0",
+			},
+		},
+		Reference: "myregistry.com/user/application:2",
+	}
+	assert.NilError(t, installationStore2.Store(installation2))
+
+	out := bytes.NewBuffer(nil)
+	err = printInstallations(out, tmpDir.Path(), []string{"context1", "context2"})
+	assert.NilError(t, err)
+	golden.Assert(t, out.String(), "list-all-contexts.golden")
 }

--- a/internal/commands/testdata/list-all-contexts.golden
+++ b/internal/commands/testdata/list-all-contexts.golden
@@ -1,0 +1,3 @@
+INSTALLATION  APPLICATION              LAST ACTION RESULT  CREATED  MODIFIED REFERENCE
+installation1 Application (1.0.0)      install     success 24 hours 24 hours user/application:1
+installation2 OtherApplication (0.2.0) upgrade     failure 4 weeks  4 weeks  myregistry.com/user/application:2


### PR DESCRIPTION
**- What I did**
Using `--all-contexts` will list all your contexts, then list all the installations per context.
Adding a new column "CONTEXT", only showed if this flag is enabled.

**- How to verify it**
Run the unit tests, or test it manually:

```console
$ docker app ls --all-contexts
INSTALLATION        APPLICATION                 LAST ACTION RESULT  CREATED MODIFIED REFERENCE               CONTEXT
app1                hello-world (0.1.0)         install     success 3 weeks 3 weeks  myuser/example:v1.0.0 
   kube
cnab-with-status    cnab-with-status (0.1.0)    install     success 3 weeks 3 weeks                          default
cnab-without-status cnab-without-status (0.1.0) install     success 3 weeks 3 weeks                          default
app1                hello-world (0.1.0)         install     success 3 weeks 3 weeks  myuser/example:v1.0.0 
  default
```

**- Description for the changelog**
* Add --all-contexts flag to the docker app ls command

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/57712358-b82ecb80-7670-11e9-96b5-ea52ec0e4683.png)

