### PR TITLE
Mark docker app plugin as experimental

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -y -q --no-install-recommends \
 
 WORKDIR /go/src/github.com/docker/cli
 
-RUN git clone https://github.com/docker/cli . && git checkout 2432af701a7973ea582196b4b9488831156f3458
+RUN git clone https://github.com/docker/cli . && git checkout a1b83ffd2cbeefc0752e5aa7a543d49c1ddfd2cb
 
 RUN make binary-osx binary-windows binary && \
  cp build/docker-linux-amd64 /usr/bin/docker

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -210,7 +210,7 @@
 
 [[projects]]
   branch = "19.03"
-  digest = "1:2f437f78f32178b2951314dd82649fda98e8f114e4d2c42588dd40fc2184a434"
+  digest = "1:40bdcf28756970bfa940ffcce99e7592d5511313ba950a842947736a9a386d5c"
   name = "github.com/docker/cli"
   packages = [
     "cli",
@@ -265,7 +265,7 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "8aebc318062963ba861b65cc2a43425dfdd80fe7"
+  revision = "a1b83ffd2cbeefc0752e5aa7a543d49c1ddfd2cb"
 
 [[projects]]
   branch = "master"

--- a/cmd/docker-app/main.go
+++ b/cmd/docker-app/main.go
@@ -27,5 +27,6 @@ func main() {
 		SchemaVersion: "0.1.0",
 		Vendor:        "Docker Inc.",
 		Version:       internal.Version,
+		Experimental:  true,
 	})
 }

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -61,7 +61,9 @@ func (d dockerCliCommand) createTestCmd(ops ...ConfigFileOperator) (icmd.Cmd, fu
 	cleanup := func() {
 		os.RemoveAll(configDir)
 	}
-	env := append(os.Environ(), "DOCKER_CONFIG="+configDir)
+	env := append(os.Environ(),
+		"DOCKER_CONFIG="+configDir,
+		"DOCKER_CLI_EXPERIMENTAL=enabled") // TODO: Remove this once docker app plugin is no more experimental
 	return icmd.Cmd{Env: env}, cleanup
 }
 

--- a/vendor/github.com/docker/cli/cli-plugins/manager/metadata.go
+++ b/vendor/github.com/docker/cli/cli-plugins/manager/metadata.go
@@ -22,4 +22,7 @@ type Metadata struct {
 	ShortDescription string `json:",omitempty"`
 	// URL is a pointer to the plugin's homepage.
 	URL string `json:",omitempty"`
+	// Experimental specifies whether the plugin is experimental.
+	// Experimental plugins are not displayed on non-experimental CLIs.
+	Experimental bool `json:",omitempty"`
 }

--- a/vendor/github.com/docker/cli/cli-plugins/manager/plugin.go
+++ b/vendor/github.com/docker/cli/cli-plugins/manager/plugin.go
@@ -33,7 +33,9 @@ type Plugin struct {
 // is set, and is always a `pluginError`, but the `Plugin` is still
 // returned with no error. An error is only returned due to a
 // non-recoverable error.
-func newPlugin(c Candidate, rootcmd *cobra.Command) (Plugin, error) {
+//
+// nolint: gocyclo
+func newPlugin(c Candidate, rootcmd *cobra.Command, allowExperimental bool) (Plugin, error) {
 	path := c.Path()
 	if path == "" {
 		return Plugin{}, errors.New("plugin candidate path cannot be empty")
@@ -94,7 +96,10 @@ func newPlugin(c Candidate, rootcmd *cobra.Command) (Plugin, error) {
 		p.Err = wrapAsPluginError(err, "invalid metadata")
 		return p, nil
 	}
-
+	if p.Experimental && !allowExperimental {
+		p.Err = &pluginError{errPluginRequireExperimental(p.Name)}
+		return p, nil
+	}
 	if p.Metadata.SchemaVersion != "0.1.0" {
 		p.Err = NewPluginError("plugin SchemaVersion %q is not valid, must be 0.1.0", p.Metadata.SchemaVersion)
 		return p, nil

--- a/vendor/github.com/docker/cli/cli/command/cli.go
+++ b/vendor/github.com/docker/cli/cli/command/cli.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	dcontext "github.com/docker/cli/cli/context"
 	"github.com/docker/cli/cli/context/docker"
-	kubcontext "github.com/docker/cli/cli/context/kubernetes"
+	kubecontext "github.com/docker/cli/cli/context/kubernetes"
 	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/cli/cli/debug"
 	cliflags "github.com/docker/cli/cli/flags"
@@ -530,6 +530,6 @@ func defaultContextStoreConfig() store.Config {
 	return store.NewConfig(
 		func() interface{} { return &DockerContext{} },
 		store.EndpointTypeGetter(docker.DockerEndpoint, func() interface{} { return &docker.EndpointMeta{} }),
-		store.EndpointTypeGetter(kubcontext.KubernetesEndpoint, func() interface{} { return &kubcontext.EndpointMeta{} }),
+		store.EndpointTypeGetter(kubecontext.KubernetesEndpoint, func() interface{} { return &kubecontext.EndpointMeta{} }),
 	)
 }

--- a/vendor/github.com/docker/cli/cli/context/kubernetes/load.go
+++ b/vendor/github.com/docker/cli/cli/context/kubernetes/load.go
@@ -3,7 +3,7 @@ package kubernetes
 import (
 	"github.com/docker/cli/cli/context"
 	"github.com/docker/cli/cli/context/store"
-	"github.com/docker/cli/kubernetes"
+	api "github.com/docker/compose-on-kubernetes/api"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -91,5 +91,5 @@ func ConfigFromContext(name string, s store.Reader) (clientcmd.ClientConfig, err
 		return ep.KubernetesConfig(), nil
 	}
 	// context has no kubernetes endpoint
-	return kubernetes.NewKubernetesConfig(""), nil
+	return api.NewKubernetesConfig(""), nil
 }

--- a/vendor/github.com/docker/cli/kubernetes/config.go
+++ b/vendor/github.com/docker/cli/kubernetes/config.go
@@ -1,8 +1,0 @@
-package kubernetes
-
-import api "github.com/docker/compose-on-kubernetes/api"
-
-// NewKubernetesConfig resolves the path to the desired Kubernetes configuration file based on
-// the KUBECONFIG environment variable and command line flags.
-// Deprecated: Use github.com/docker/compose-on-kubernetes/api.NewKubernetesConfig instead
-var NewKubernetesConfig = api.NewKubernetesConfig


### PR DESCRIPTION
**- What I did**
- Mark the app plugin as an experimental plugin.

**- How to verify it**

1. Use this [docker/cli](https://github.com/docker/cli/pull/1898)
1. Build the docker app plugin
1. Move it to your `~/.docker/cli-plugins` directory
1. $ docker --help -> `app` does not appear in the manage commands
1. $ DOCKER_CLI_EXPERIMENTAL=enabled docker --help -> `app` appears in the manage commands

**- Description for the changelog**
- app plugin is now experimental and only shown if the docker/cli has its experimental flag enabled.


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/58174258-c5b20a00-7c9d-11e9-8d45-c289df9e172b.png)
