### PR TITLE
A credential-set can be a local YAML file

### DIFF
--- a/e2e/testdata/credential-install-mixed-credstore.golden
+++ b/e2e/testdata/credential-install-mixed-credstore.golden
@@ -4,4 +4,4 @@ secret2value
 SECRET_THREE: xyzzy
 /var/secret_three/data.txt
 xyzzy
-Application "mixed" installed on context "default"
+Application "mixed-credstore" installed on context "default"

--- a/e2e/testdata/credential-install-mixed-local-cred.golden
+++ b/e2e/testdata/credential-install-mixed-local-cred.golden
@@ -1,0 +1,7 @@
+SECRET_ONE: secret1value
+/var/secret_two/data.txt
+secret2value
+SECRET_THREE: xyzzy
+/var/secret_three/data.txt
+xyzzy
+Application "mixed-local-cred" installed on context "default"

--- a/internal/commands/cnab.go
+++ b/internal/commands/cnab.go
@@ -44,7 +44,16 @@ type credentialSetOpt func(b *bundle.Bundle, creds credentials.Set) error
 func addNamedCredentialSets(credStore appstore.CredentialStore, namedCredentialsets []string) credentialSetOpt {
 	return func(_ *bundle.Bundle, creds credentials.Set) error {
 		for _, file := range namedCredentialsets {
-			c, err := credStore.Read(file)
+			var (
+				c   *credentials.CredentialSet
+				err error
+			)
+			// Check the credentialset locally first, then try in the credential store
+			if _, e := os.Stat(file); e == nil {
+				c, err = credentials.Load(file)
+			} else {
+				c, err = credStore.Read(file)
+			}
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**- What I did**
The `credential-set` flag can now point to a local credential set file, not necessarily in the credential set store.

**- Description for the changelog**
* The credential-set flag can now point to a local credential set file

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/59017024-e0aa7f80-8842-11e9-9537-6408181abf52.png)
