### PR TITLE
Fix credential set error

### DIFF
--- a/internal/commands/cnab.go
+++ b/internal/commands/cnab.go
@@ -54,6 +54,9 @@ func addNamedCredentialSets(credStore appstore.CredentialStore, namedCredentials
 				c, err = credentials.Load(file)
 			} else {
 				c, err = credStore.Read(file)
+				if os.IsNotExist(err) {
+					err = e
+				}
 			}
 			if err != nil {
 				return err


### PR DESCRIPTION
Print the original error message, the one checking the file locally, instead of the one looking for the credential set in the credential store.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/59288515-4304e500-8c74-11e9-98c9-8eff8e8e0c65.png)
