### PR TITLE
Make sure Load is consistent

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -91,7 +91,7 @@ During the automated CI, the unit tests and end-to-end tests are run as
 part of the PR validation. As a developer you can run these tests
 locally by using any of the following `Makefile` targets:
 
-- `make test`: run all non-end-to-end tests
+- `make test-unit`: run all non-end-to-end tests
 - `make test-e2e`: run all end-to-end tests
 
 To execute a specific test or set of tests you can use the `go test`

--- a/types/parameters/load.go
+++ b/types/parameters/load.go
@@ -30,13 +30,18 @@ func Load(data []byte, ops ...func(*Options)) (Parameters, error) {
 	if err != nil {
 		return nil, err
 	}
-	parameters := converted.(map[string]interface{})
+	params := converted.(map[string]interface{})
 	if options.prefix != "" {
-		parameters = map[string]interface{}{
-			options.prefix: parameters,
+		params = map[string]interface{}{
+			options.prefix: params,
 		}
 	}
-	return parameters, nil
+	// Make sure params are always loaded expanded
+	expandedParams, err := FromFlatten(flatten(params))
+	if err != nil {
+		return nil, err
+	}
+	return expandedParams, nil
 }
 
 // LoadMultiple loads multiple data in parameters

--- a/types/parameters/load_test.go
+++ b/types/parameters/load_test.go
@@ -43,6 +43,16 @@ baz:
 	}))
 }
 
+func TestLoadSameWithDifferentNotation(t *testing.T) {
+	flatParameters, err := Load([]byte(`foo.bar: baz`))
+	assert.NilError(t, err)
+	expandedParameters, err := Load([]byte(`
+foo:
+  bar: "baz"`))
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(flatParameters, expandedParameters))
+}
+
 func TestLoadWithPrefix(t *testing.T) {
 	parameters, err := Load([]byte(`
 foo: bar


### PR DESCRIPTION
**- What I did**

Load used to load differently files that don't have the same notation, for example:
```yaml
foo.bar: baz
```
Would load as `map[foo.bar:baz]` while 
```yaml
foo:
  bar: baz
```
would load as `map[foo:map[bar:baz]]`

This commit fixes it, both parameter files will now load as `map[foo:map[bar:baz]]`.

Closes #549 

**- How I did it**

Before returning `Load` will flatten and then expand the parameters, making sure that it always returns the same map.

**- How to verify it**

Run unit tests

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/59616410-ab484080-9124-11e9-8673-3bae867467c8.png)


