### PR TITLE
Fix: A single-file app can have CRLF and random YAML documents order 

### DIFF
--- a/e2e/testdata/render/singlefile/env.yml
+++ b/e2e/testdata/render/singlefile/env.yml
@@ -1,0 +1,1 @@
+myapp.command3: bam

--- a/e2e/testdata/render/singlefile/expected.txt
+++ b/e2e/testdata/render/singlefile/expected.txt
@@ -1,0 +1,8 @@
+version: "3.4"
+services:
+  test:
+    command:
+    - bash
+    - -c
+    - cat bar bam
+    image: alpine:latest

--- a/e2e/testdata/render/singlefile/my.dockerapp
+++ b/e2e/testdata/render/singlefile/my.dockerapp
@@ -1,0 +1,16 @@
+version: "3.4"
+services:
+  test:
+    image: alpine:latest
+    command: bash -c "${myapp.command1} ${myapp.command2} ${myapp.command3}"
+---
+myapp:
+  command1: cat
+  command2: foo
+  command3: bar
+---
+version: 0.1.0
+name: myapp
+maintainers:
+  - name: dev
+    email: dev@example.com

--- a/e2e/testdata/render/singlefile/parameters-0.yml
+++ b/e2e/testdata/render/singlefile/parameters-0.yml
@@ -1,0 +1,3 @@
+myapp:
+  command2: bar
+  command3: baz

--- a/internal/packager/split.go
+++ b/internal/packager/split.go
@@ -45,9 +45,9 @@ func Merge(app *types.App, target io.Writer) error {
 	}
 	for _, data := range [][]byte{
 		app.MetadataRaw(),
-		[]byte(types.SingleFileSeparator),
+		types.YamlSingleFileSeparator(app.HasCRLF()),
 		app.Composes()[0],
-		[]byte(types.SingleFileSeparator),
+		types.YamlSingleFileSeparator(app.HasCRLF()),
 		app.ParametersRaw()[0],
 	} {
 		if _, err := target.Write(data); err != nil {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -7,16 +7,55 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/docker/cli/cli/compose/loader"
-
-	"github.com/docker/app/specification"
-	"github.com/docker/cli/cli/compose/schema"
-
 	"github.com/docker/app/internal"
+	"github.com/docker/app/specification"
 	"github.com/docker/app/types"
+	"github.com/docker/cli/cli/compose/loader"
+	"github.com/docker/cli/cli/compose/schema"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/pkg/errors"
 )
+
+var (
+	crlf       = []byte{'\r', '\n'}
+	lf         = []byte{'\n'}
+	delimiters = [][]byte{
+		[]byte("\r\n---\r\n"),
+		[]byte("\n---\r\n"),
+		[]byte("\r\n---\n"),
+		[]byte("\n---\n"),
+	}
+)
+
+// useCRLF detects which line break should be used
+func useCRLF(data []byte) bool {
+	nbCrlf := bytes.Count(data, crlf)
+	nbLf := bytes.Count(data, lf)
+	switch {
+	case nbCrlf == nbLf:
+		// document contains only CRLF
+		return true
+	case nbCrlf == 0:
+		// document does not contain any CRLF
+		return false
+	default:
+		// document contains mixed line breaks, so use the OS default
+		return bytes.Equal(defaultLineBreak, crlf)
+	}
+}
+
+// splitSingleFile split a multidocument using all possible document delimiters
+func splitSingleFile(data []byte) [][]byte {
+	parts := [][]byte{data}
+	for _, delimiter := range delimiters {
+		var intermediate [][]byte
+		for _, part := range parts {
+			intermediate = append(intermediate, bytes.Split(part, delimiter)...)
+		}
+		parts = intermediate
+	}
+	return parts
+}
 
 // LoadFromSingleFile loads a docker app from a single-file format (as a reader)
 func LoadFromSingleFile(path string, r io.Reader, ops ...func(*types.App) error) (*types.App, error) {
@@ -24,9 +63,8 @@ func LoadFromSingleFile(path string, r io.Reader, ops ...func(*types.App) error)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading single-file")
 	}
-	hasCRLF := bytes.Contains(data, []byte{'\r', '\n'})
 
-	parts := bytes.Split(data, types.YamlSingleFileSeparator(hasCRLF))
+	parts := splitSingleFile(data)
 	if len(parts) != 3 {
 		return nil, errors.Errorf("malformed single-file application: expected 3 documents, got %d", len(parts))
 	}
@@ -51,11 +89,12 @@ func LoadFromSingleFile(path string, r io.Reader, ops ...func(*types.App) error)
 			return nil, errors.New("malformed single-file application")
 		}
 	}
+
 	appOps := append([]func(*types.App) error{
 		types.WithComposes(compose),
 		types.WithParameters(params),
 		types.Metadata(metadata),
-		types.WithCRLF(hasCRLF),
+		types.WithCRLF(useCRLF(data)),
 	}, ops...)
 	return types.NewApp(path, appOps...)
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -20,10 +20,10 @@ const (
 	metadata = `name: my-app
 version: 1.0.0
 `
-	compose = `services:
+	compose = `version: "3.1"
+services:
   web:
     image: nginx
-version: "3.1"
 `
 	params = `foo: bar
 `
@@ -41,6 +41,10 @@ func TestLoadFromSingleFile(t *testing.T) {
 		{
 			name: "carriage-return-line-feed",
 			file: fmt.Sprintf("%s\r\n---\r\n%s\r\n---\r\n%s", metadata, compose, params),
+		},
+		{
+			name: "mixed-carriage-return-line-feed",
+			file: fmt.Sprintf("%s\r\n---\r\n%s\r\n---\n%s", metadata, compose, params),
 		},
 		{
 			name: "unordered-documents",

--- a/loader/loader_unix.go
+++ b/loader/loader_unix.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package loader
+
+var (
+	defaultLineBreak = []byte{'\n'}
+)

--- a/loader/loader_windows.go
+++ b/loader/loader_windows.go
@@ -1,0 +1,5 @@
+package loader
+
+var (
+	defaultLineBreak = []byte{'\r', '\n'}
+)

--- a/specification/schema.go
+++ b/specification/schema.go
@@ -36,5 +36,4 @@ func Validate(config map[string]interface{}, version string) error {
 	}
 
 	return nil
-
 }


### PR DESCRIPTION
**- What I did**

Fix CRLF detection on single-file app (https://github.com/docker/app/issues/553)
Fix YAML documents order detection for single-file apps (https://github.com/docker/app/issues/249)

- Split and Merge remembers the CRLF detection while outputting the result

**- How to verify it**
Add e2e tests: 
- split/merge a single file with CRLF
- render a single file with documents in random order

**- Description for the changelog**
* Fix CRLF detection on single-file app
* Fix YAML documents order detection for single-file apps

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/60347117-ea944e00-99bc-11e9-94d7-f4ab5c3411b8.png)

