### PR TITLE
Fix pushing from bundle store

### DIFF
--- a/internal/commands/cnab.go
+++ b/internal/commands/cnab.go
@@ -251,6 +251,9 @@ func extractAndLoadAppBasedBundle(dockerCli command.Cli, name string) (*bundle.B
 	return bndl, "", err
 }
 
+//resolveBundle looks for a CNAB bundle which can be in a Docker App Package format or
+// a bundle stored locally or in the bundle store. It returns a built or found bundle,
+// a reference to the bundle if it is found in the bundlestore, and an error.
 func resolveBundle(dockerCli command.Cli, bundleStore appstore.BundleStore, name string, pullRef bool, insecureRegistries []string) (*bundle.Bundle, string, error) {
 	// resolution logic:
 	// - if there is a docker-app package in working directory, or an http:// / https:// prefix, use packager.Extract result

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -78,9 +78,13 @@ func runPush(dockerCli command.Cli, name string, opts pushOptions) error {
 		return err
 	}
 
-	bndl, _, err := resolveBundle(dockerCli, bundleStore, name, false, nil)
+	bndl, ref, err := resolveBundle(dockerCli, bundleStore, name, false, nil)
 	if err != nil {
 		return err
+	}
+	// Use the bundle reference as a tag
+	if ref != "" && opts.tag == "" {
+		opts.tag = ref
 	}
 	if err := bndl.Validate(); err != nil {
 		return err


### PR DESCRIPTION
**- What I did**

Fix pushing a pre-bundled app from the bundle store shouldn't require an explicit tag.
The push was using the default value (app name + version) as a repo and tag, fixed using the bundle reference.
Added e2e test.

**- How to verify it**
```sh
$ docker app bundle examples/hello-world/example-hello-world.dockerapp --tag <myuser>/myapp:v0.42
...
$ docker app push <myuser>/myapp:v0.42
...
# with the fix
Successfully pushed bundle to docker.io/<myuser>/myapp:v0.42...
# without the fix
Successfully pushed bundle to docker.io/<myuser>/hello-world:v0.1.0...
```

**- Description for the changelog**
* Fix pushing a pre-bundled app from the bundle store shouldn't require an explicit tag.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/60524673-4c222880-9ced-11e9-868f-657f34815773.png)

