### PR TITLE
fix: Add empty build args map on build

### DIFF
--- a/internal/commands/bundle.go
+++ b/internal/commands/bundle.go
@@ -98,6 +98,7 @@ func makeBundleFromApp(dockerCli command.Cli, app *types.App, refOverride refere
 	buildResp, err := dockerCli.Client().ImageBuild(context.TODO(), buildContext, dockertypes.ImageBuildOptions{
 		Dockerfile: "Dockerfile",
 		Tags:       []string{invocationImageName},
+		BuildArgs:  map[string]*string{},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**- What I did**

Docker client sends the BuildArgs even if it's nil, adding an empty map
makes sure we don't send nil container objects.

**- How I did it**

Added an empty `BuildArgs` when calling `ImageBuild`

**- How to verify it**

`docker app install` should work

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/60589237-4e41c100-9d99-11e9-90e7-a7934d820588.png)

