### PR TITLE
Mute warning when pushing to a registry

### DIFF
--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/app/types/metadata"
@@ -23,6 +24,7 @@ import (
 	"github.com/morikuni/aec"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -127,12 +129,19 @@ func runPush(dockerCli command.Cli, name string, opts pushOptions) error {
 		return errors.Wrapf(err, "fixing up %q for push", retag.cnabRef)
 	}
 	// push bundle manifest
-	descriptor, err := remotes.Push(context.Background(), bndl, retag.cnabRef, resolverConfig.Resolver, true, withAppAnnotations)
+	descriptor, err := remotes.Push(newMuteLogContext(), bndl, retag.cnabRef, resolverConfig.Resolver, true, withAppAnnotations)
 	if err != nil {
 		return errors.Wrapf(err, "pushing to %q", retag.cnabRef)
 	}
 	fmt.Fprintf(os.Stdout, "Successfully pushed bundle to %s. Digest is %s.\n", retag.cnabRef.String(), descriptor.Digest)
 	return nil
+}
+
+func newMuteLogContext() context.Context {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	logger.SetOutput(ioutil.Discard)
+	return log.WithLogger(context.Background(), logrus.NewEntry(logger))
 }
 
 func withAppAnnotations(index *ocischemav1.Index) error {


### PR DESCRIPTION
When accepting config media type application/vnd.cnab.config.v1+json,
containerd client lib emits the following line:
```
warning: WARN[0015] reference for unknown type: application/vnd.cnab.config.v1+json on stderr.
```

**- What I did**
To avoid this, this PR set a muted logger to the push context
Based on: https://github.com/docker/cnab-to-oci/commit/f709439464571705617ed4464773661421797dd3

**- How I did it**
I did it by muting the logger when pushing

**- How to verify it**
```
$ docker app push --tag <user>/<repo>
```
The warning must be disappeared 

**- Description for the changelog**
Mute warning when pushing to a registry

**- A picture of a cute animal (not mandatory but encouraged)**
![swan](https://user-images.githubusercontent.com/373485/60956114-72a21e00-a302-11e9-8900-424595a4be1b.jpg)