### PR TITLE
Print a warning when undefined parameters are passed to docker app

### DIFF
--- a/internal/commands/cnab.go
+++ b/internal/commands/cnab.go
@@ -368,6 +368,7 @@ func prepareCustomAction(actionName string, dockerCli command.Cli, appname strin
 	if err := mergeBundleParameters(installation,
 		withFileParameters(paramsOpts.parametersFiles),
 		withCommandLineParameters(paramsOpts.overrides),
+		withStrictMode(paramsOpts.strictMode),
 	); err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -117,6 +117,7 @@ func runInstall(dockerCli command.Cli, appname string, opts installOptions) erro
 		withCommandLineParameters(opts.overrides),
 		withOrchestratorParameters(opts.orchestrator, opts.kubeNamespace),
 		withSendRegistryAuth(opts.sendRegistryAuth),
+		withStrictMode(opts.strictMode),
 	); err != nil {
 		return err
 	}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -94,11 +94,13 @@ func prepareBundleStore() (store.BundleStore, error) {
 type parametersOptions struct {
 	parametersFiles []string
 	overrides       []string
+	strictMode      bool
 }
 
 func (o *parametersOptions) addFlags(flags *pflag.FlagSet) {
 	flags.StringArrayVar(&o.parametersFiles, "parameters-file", []string{}, "Override parameters file")
 	flags.StringArrayVarP(&o.overrides, "set", "s", []string{}, "Override parameter value")
+	flags.BoolVar(&o.strictMode, "strict", false, "Fail when a paramater is undefined instead of displaying a warning")
 }
 
 type credentialOptions struct {

--- a/internal/commands/upgrade.go
+++ b/internal/commands/upgrade.go
@@ -67,6 +67,7 @@ func runUpgrade(dockerCli command.Cli, installationName string, opts upgradeOpti
 		withFileParameters(opts.parametersFiles),
 		withCommandLineParameters(opts.overrides),
 		withSendRegistryAuth(opts.sendRegistryAuth),
+		withStrictMode(opts.strictMode),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Instead of failing the rendering when an undefined parameter is set, print a warning.
Add a ``--strict`` flag which fails instead of printing a warning
Fixes #551 

**- How to verify it**
Update the unit tests to verify the warning and the strict mode.

**- Description for the changelog**
Passing an undefined variable now makes the compose file rendering fails only when the `--strict` falg is set. Otherwise a warning message is printed to indicate that an undefined variable has been set.

**- A picture of a cute animal (not mandatory but encouraged)**

![Cute-and-Fluffy-Animals-Aww-35](https://user-images.githubusercontent.com/470082/61060907-95fcc400-a3fb-11e9-87f3-e90e62bceb18.jpeg)
