### PR TITLE
Bump docker/cli 19.03 with rollback_config interpolation fix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -221,7 +221,7 @@
 
 [[projects]]
   branch = "19.03"
-  digest = "1:40bdcf28756970bfa940ffcce99e7592d5511313ba950a842947736a9a386d5c"
+  digest = "1:e0d546e1b6582adce85a80829128887eb287f6d3bd5d7a9636b27df0798a71c5"
   name = "github.com/docker/cli"
   packages = [
     "cli",
@@ -276,7 +276,7 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "a1b83ffd2cbeefc0752e5aa7a543d49c1ddfd2cb"
+  revision = "5b38d82aa0767e32f53b5821a9a5044f20eeef29"
 
 [[projects]]
   branch = "master"
@@ -1319,6 +1319,7 @@
     "github.com/imdario/mergo",
     "github.com/morikuni/aec",
     "github.com/opencontainers/go-digest",
+    "github.com/opencontainers/image-spec/specs-go/v1",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",

--- a/vendor/github.com/docker/cli/cli/command/cli_options.go
+++ b/vendor/github.com/docker/cli/cli/command/cli_options.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/docker/cli/cli/context/docker"
-	"github.com/docker/cli/cli/context/kubernetes"
 	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/cli/cli/streams"
 	clitypes "github.com/docker/cli/types"
@@ -97,7 +96,7 @@ func WithContainerizedClient(containerizedFn func(string) (clitypes.Containerize
 func WithContextEndpointType(endpointName string, endpointType store.TypeGetter) DockerCliOption {
 	return func(cli *DockerCli) error {
 		switch endpointName {
-		case docker.DockerEndpoint, kubernetes.KubernetesEndpoint:
+		case docker.DockerEndpoint:
 			return fmt.Errorf("cannot change %q endpoint type", endpointName)
 		}
 		cli.contextStoreConfig.SetEndpoint(endpointName, endpointType)

--- a/vendor/github.com/docker/cli/cli/compose/loader/interpolate.go
+++ b/vendor/github.com/docker/cli/cli/compose/loader/interpolate.go
@@ -16,6 +16,8 @@ var interpolateTypeCastMapping = map[interp.Path]interp.Cast{
 	servicePath("deploy", "replicas"):                                toInt,
 	servicePath("deploy", "update_config", "parallelism"):            toInt,
 	servicePath("deploy", "update_config", "max_failure_ratio"):      toFloat,
+	servicePath("deploy", "rollback_config", "parallelism"):          toInt,
+	servicePath("deploy", "rollback_config", "max_failure_ratio"):    toFloat,
 	servicePath("deploy", "restart_policy", "max_attempts"):          toInt,
 	servicePath("ports", interp.PathMatchList, "target"):             toInt,
 	servicePath("ports", interp.PathMatchList, "published"):          toInt,

--- a/vendor/github.com/docker/cli/cli/context/store/io_utils.go
+++ b/vendor/github.com/docker/cli/cli/context/store/io_utils.go
@@ -1,0 +1,29 @@
+package store
+
+import (
+	"errors"
+	"io"
+)
+
+// LimitedReader is a fork of io.LimitedReader to override Read.
+type LimitedReader struct {
+	R io.Reader
+	N int64 // max bytes remaining
+}
+
+// Read is a fork of io.LimitedReader.Read that returns an error when limit exceeded.
+func (l *LimitedReader) Read(p []byte) (n int, err error) {
+	if l.N < 0 {
+		return 0, errors.New("read exceeds the defined limit")
+	}
+	if l.N == 0 {
+		return 0, io.EOF
+	}
+	// have to cap N + 1 otherwise we won't hit limit err
+	if int64(len(p)) > l.N+1 {
+		p = p[0 : l.N+1]
+	}
+	n, err = l.R.Read(p)
+	l.N -= int64(n)
+	return n, err
+}

--- a/vendor/github.com/docker/cli/cli/context/store/store.go
+++ b/vendor/github.com/docker/cli/cli/context/store/store.go
@@ -2,12 +2,16 @@ package store
 
 import (
 	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"bytes"
 	_ "crypto/sha256" // ensure ids can be computed
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"path"
 	"path/filepath"
 	"strings"
@@ -259,12 +263,44 @@ func Export(name string, s Reader) io.ReadCloser {
 	return reader
 }
 
+const (
+	maxAllowedFileSizeToImport int64  = 10 << 20
+	zipType                    string = "application/zip"
+)
+
+func getImportContentType(r *bufio.Reader) (string, error) {
+	head, err := r.Peek(512)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	return http.DetectContentType(head), nil
+}
+
 // Import imports an exported context into a store
 func Import(name string, s Writer, reader io.Reader) error {
-	tr := tar.NewReader(reader)
+	// Buffered reader will not advance the buffer, needed to determine content type
+	r := bufio.NewReader(reader)
+
+	importContentType, err := getImportContentType(r)
+	if err != nil {
+		return err
+	}
+	switch importContentType {
+	case zipType:
+		return importZip(name, s, r)
+	default:
+		// Assume it's a TAR (TAR does not have a "magic number")
+		return importTar(name, s, r)
+	}
+}
+
+func importTar(name string, s Writer, reader io.Reader) error {
+	tr := tar.NewReader(&LimitedReader{R: reader, N: maxAllowedFileSizeToImport})
 	tlsData := ContextTLSData{
 		Endpoints: map[string]EndpointTLSData{},
 	}
+	var importedMetaFile bool
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -282,35 +318,117 @@ func Import(name string, s Writer, reader io.Reader) error {
 			if err != nil {
 				return err
 			}
-			var meta Metadata
-			if err := json.Unmarshal(data, &meta); err != nil {
+			meta, err := parseMetadata(data, name)
+			if err != nil {
 				return err
 			}
-			meta.Name = name
 			if err := s.CreateOrUpdate(meta); err != nil {
 				return err
 			}
+			importedMetaFile = true
 		} else if strings.HasPrefix(hdr.Name, "tls/") {
-			relative := strings.TrimPrefix(hdr.Name, "tls/")
-			parts := strings.SplitN(relative, "/", 2)
-			if len(parts) != 2 {
-				return errors.New("archive format is invalid")
-			}
-			endpointName := parts[0]
-			fileName := parts[1]
 			data, err := ioutil.ReadAll(tr)
 			if err != nil {
 				return err
 			}
-			if _, ok := tlsData.Endpoints[endpointName]; !ok {
-				tlsData.Endpoints[endpointName] = EndpointTLSData{
-					Files: map[string][]byte{},
-				}
+			if err := importEndpointTLS(&tlsData, hdr.Name, data); err != nil {
+				return err
 			}
-			tlsData.Endpoints[endpointName].Files[fileName] = data
 		}
 	}
+	if !importedMetaFile {
+		return errdefs.InvalidParameter(errors.New("invalid context: no metadata found"))
+	}
 	return s.ResetTLSMaterial(name, &tlsData)
+}
+
+func importZip(name string, s Writer, reader io.Reader) error {
+	body, err := ioutil.ReadAll(&LimitedReader{R: reader, N: maxAllowedFileSizeToImport})
+	if err != nil {
+		return err
+	}
+	zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		return err
+	}
+	tlsData := ContextTLSData{
+		Endpoints: map[string]EndpointTLSData{},
+	}
+
+	var importedMetaFile bool
+	for _, zf := range zr.File {
+		fi := zf.FileInfo()
+		if fi.IsDir() {
+			// skip this entry, only taking files into account
+			continue
+		}
+		if zf.Name == metaFile {
+			f, err := zf.Open()
+			if err != nil {
+				return err
+			}
+
+			data, err := ioutil.ReadAll(&LimitedReader{R: f, N: maxAllowedFileSizeToImport})
+			defer f.Close()
+			if err != nil {
+				return err
+			}
+			meta, err := parseMetadata(data, name)
+			if err != nil {
+				return err
+			}
+			if err := s.CreateOrUpdate(meta); err != nil {
+				return err
+			}
+			importedMetaFile = true
+		} else if strings.HasPrefix(zf.Name, "tls/") {
+			f, err := zf.Open()
+			if err != nil {
+				return err
+			}
+			data, err := ioutil.ReadAll(f)
+			defer f.Close()
+			if err != nil {
+				return err
+			}
+			err = importEndpointTLS(&tlsData, zf.Name, data)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if !importedMetaFile {
+		return errdefs.InvalidParameter(errors.New("invalid context: no metadata found"))
+	}
+	return s.ResetTLSMaterial(name, &tlsData)
+}
+
+func parseMetadata(data []byte, name string) (Metadata, error) {
+	var meta Metadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return meta, err
+	}
+	meta.Name = name
+	return meta, nil
+}
+
+func importEndpointTLS(tlsData *ContextTLSData, path string, data []byte) error {
+	parts := strings.SplitN(strings.TrimPrefix(path, "tls/"), "/", 2)
+	if len(parts) != 2 {
+		// TLS endpoints require archived file directory with 2 layers
+		// i.e. tls/{endpointName}/{fileName}
+		return errors.New("archive format is invalid")
+	}
+
+	epName := parts[0]
+	fileName := parts[1]
+	if _, ok := tlsData.Endpoints[epName]; !ok {
+		tlsData.Endpoints[epName] = EndpointTLSData{
+			Files: map[string][]byte{},
+		}
+	}
+	tlsData.Endpoints[epName].Files[fileName] = data
+	return nil
 }
 
 type setContextName interface {

--- a/vendor/github.com/docker/cli/cli/context/store/storeconfig.go
+++ b/vendor/github.com/docker/cli/cli/context/store/storeconfig.go
@@ -30,6 +30,16 @@ func (c Config) SetEndpoint(name string, getter TypeGetter) {
 	c.endpointTypes[name] = getter
 }
 
+// ForeachEndpointType calls cb on every endpoint type registered with the Config
+func (c Config) ForeachEndpointType(cb func(string, TypeGetter) error) error {
+	for n, ep := range c.endpointTypes {
+		if err := cb(n, ep); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // NewConfig creates a config object
 func NewConfig(contextType TypeGetter, endpoints ...NamedTypeGetter) Config {
 	res := Config{


### PR DESCRIPTION
**- What I did**
It bumps docker/cli with this fix: https://github.com/docker/cli/pull/1973
Fix #559 

**- How to verify it**
docker app rendering the following file does not fail:
```sh
$ cat test.dockerapp
# This section contains your application metadata.
# Version of the application
version: 0.1.0
# Name of the application
name: hello-world
# A short description of the application
description: "Hello, World!"
# List of application maintainers with name and email for each
maintainers:
  - name: user
    email: "user@email.com"
---
# This section contains the Compose file that describes your application services.
version: "3.7"
services:
  hello:
    image: hashicorp/http-echo
    command: ["-text", "${text}"]
    ports:
      - ${port}:5678
    deploy:
      rollback_config:
        parallelism: "${deploy.rollback-config.parallelism}"
        max_failure_ratio: "${deploy.rollback-config.max_failure_ratio}"
---
# This section contains the default values for your application parameters.
port: 8080
text: Hello, World!
deploy:
  rollback-config:
    parallelism: 3
    max_failure_ratio: 0.9

$ docker app render test.dockerapp
...
```
**- Description for the changelog**
* Bump docker/cli 19.03 with rollback_config interpolation fix

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/61127281-1fb99980-a4af-11e9-8e25-e62d06727622.png)
