### PR TITLE
Revert document detection on single file format

### DIFF
--- a/e2e/testdata/render/singlefile/my.dockerapp
+++ b/e2e/testdata/render/singlefile/my.dockerapp
@@ -1,3 +1,9 @@
+version: 0.1.0
+name: myapp
+maintainers:
+  - name: dev
+    email: dev@example.com
+---
 version: "3.4"
 services:
   test:
@@ -8,9 +14,3 @@ myapp:
   command1: cat
   command2: foo
   command3: bar
----
-version: 0.1.0
-name: myapp
-maintainers:
-  - name: dev
-    email: dev@example.com

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -46,10 +46,6 @@ func TestLoadFromSingleFile(t *testing.T) {
 			name: "mixed-carriage-return-line-feed",
 			file: fmt.Sprintf("%s\r\n---\r\n%s\r\n---\n%s", metadata, compose, params),
 		},
-		{
-			name: "unordered-documents",
-			file: fmt.Sprintf("%s\n---\n%s\n---\n%s", params, metadata, compose),
-		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**- What I did**

With the current implementation we lose most of the validation errors while detecting which part is what.

This is clearly not the right solution, so I prefer to revert and go back to the old behavior: fixed order.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/61135001-15080000-a4c1-11e9-92eb-5d0105cd8b52.png)
