### PR TITLE
Add suport for immutable parameters

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -218,7 +218,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0b31d075847995f6b74ab66aac4b64c588fdb0737aa3a2731b432f03cb7a1faa"
+  digest = "1:57222ef01ff3930c9010c1387d0311974ec5a1c3627ed63e41374aef6341a12d"
   name = "github.com/deislabs/cnab-go"
   packages = [
     "action",
@@ -230,7 +230,7 @@
     "utils/crud",
   ]
   pruneopts = "NUT"
-  revision = "5ca85500e801be695748cf1f360f2254f425d19c"
+  revision = "d0e47f49ea9a4ef8aedf1043b11ffa7506fc10d7"
 
 [[projects]]
   digest = "1:719fa8aafc69a874805bde687d292fc9160f74385c235943d0b7f010e3c135d3"
@@ -1304,6 +1304,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/cbroglie/mustache",
+    "github.com/containerd/containerd/log",
     "github.com/containerd/containerd/platforms",
     "github.com/deislabs/cnab-go/action",
     "github.com/deislabs/cnab-go/bundle",

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ ifeq ($(OS),Windows_NT)
   EXEC_EXT := .exe
 endif
 
+INCLUDE_E2E :=
+ifneq ($(E2E_TESTS),)
+  INCLUDE_E2E := -run $(E2E_TESTS)
+endif
+
 TEST_RESULTS_DIR = _build/test-results
 STATIC_FLAGS= CGO_ENABLED=0
 GO_BUILD = $(STATIC_FLAGS) go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
@@ -78,7 +83,7 @@ lint: ## run linter(s)
 test-e2e: bin/$(BIN_NAME) ## run end-to-end tests
 	@echo "Running e2e tests..."
 	@$(call mkdir,$(TEST_RESULTS_DIR))
-	$(call GO_TESTSUM,e2e.xml) -v ./e2e/
+	$(call GO_TESTSUM,e2e.xml) -v ./e2e/ $(INCLUDE_E2E)
 
 test-unit: ## run unit tests
 	@echo "Running unit tests..."

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -478,6 +478,13 @@ STATUS
 			fmt.Sprintf("Updating service %s_web", appName),
 		})
 
+	// Upgrade the application, changing the orchestrator, fails because this parameters is immutable
+	cmd.Command = dockerCli.Command("app", "upgrade", appName, "--set", "com.docker.app.orchestrator=kubernetes")
+	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+		ExitCode: 1,
+		Err:      fmt.Sprint("parameter com.docker.app.orchestrator is immutable and cannot be overridden with value kubernetes"),
+	})
+
 	// Query the application status again, the port should have change
 	cmd.Command = dockerCli.Command("app", "status", appName)
 	icmd.RunCmd(cmd).Assert(t, icmd.Expected{ExitCode: 0, Out: "8081"})

--- a/e2e/testdata/bundle-with-tag.json.golden
+++ b/e2e/testdata/bundle-with-tag.json.golden
@@ -63,7 +63,8 @@
 				],
 				"destination": {
 					"env": "DOCKER_KUBERNETES_NAMESPACE"
-				}
+				},
+				"immutable": true
 			},
 			"com.docker.app.orchestrator": {
 				"definition": "com.docker.app.orchestrator",
@@ -75,7 +76,8 @@
 				],
 				"destination": {
 					"env": "DOCKER_STACK_ORCHESTRATOR"
-				}
+				},
+				"immutable": true
 			},
 			"com.docker.app.render-format": {
 				"definition": "com.docker.app.render-format",

--- a/e2e/testdata/simple-bundle.json.golden
+++ b/e2e/testdata/simple-bundle.json.golden
@@ -63,7 +63,8 @@
 				],
 				"destination": {
 					"env": "DOCKER_KUBERNETES_NAMESPACE"
-				}
+				},
+				"immutable": true
 			},
 			"com.docker.app.orchestrator": {
 				"definition": "com.docker.app.orchestrator",
@@ -75,7 +76,8 @@
 				],
 				"destination": {
 					"env": "DOCKER_STACK_ORCHESTRATOR"
-				}
+				},
+				"immutable": true
 			},
 			"com.docker.app.render-format": {
 				"definition": "com.docker.app.render-format",

--- a/internal/packager/cnab.go
+++ b/internal/packager/cnab.go
@@ -64,6 +64,7 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 					"uninstall",
 					internal.ActionStatusName,
 				},
+				Immutable:  true,
 				Definition: internal.ParameterOrchestratorName,
 			},
 			internal.ParameterKubernetesNamespaceName: {
@@ -76,6 +77,7 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 					"uninstall",
 					internal.ActionStatusName,
 				},
+				Immutable:  true,
 				Definition: internal.ParameterKubernetesNamespaceName,
 			},
 			internal.ParameterRenderFormatName: {

--- a/internal/packager/testdata/bundle-json.golden
+++ b/internal/packager/testdata/bundle-json.golden
@@ -62,7 +62,8 @@
         ],
         "destination": {
           "env": "DOCKER_KUBERNETES_NAMESPACE"
-        }
+        },
+        "immutable": true
       },
       "com.docker.app.orchestrator": {
         "definition": "com.docker.app.orchestrator",
@@ -74,7 +75,8 @@
         ],
         "destination": {
           "env": "DOCKER_STACK_ORCHESTRATOR"
-        }
+        },
+        "immutable": true
       },
       "com.docker.app.render-format": {
         "definition": "com.docker.app.render-format",

--- a/vendor/github.com/deislabs/cnab-go/bundle/parameters.go
+++ b/vendor/github.com/deislabs/cnab-go/bundle/parameters.go
@@ -11,4 +11,5 @@ type ParameterDefinition struct {
 	ApplyTo     []string  `json:"applyTo,omitempty" mapstructure:"applyTo,omitempty"`
 	Description string    `json:"description,omitempty" mapstructure:"description"`
 	Destination *Location `json:"destination,omitemtpty" mapstructure:"destination"`
+	Immutable   bool      `json:"immutable,omitempty" mapstructure:"immutable,omitempty"`
 }

--- a/vendor/github.com/deislabs/cnab-go/claim/claim.go
+++ b/vendor/github.com/deislabs/cnab-go/claim/claim.go
@@ -42,6 +42,7 @@ type Claim struct {
 	Bundle        *bundle.Bundle            `json:"bundle"`
 	Result        Result                    `json:"result"`
 	Parameters    map[string]interface{}    `json:"parameters"`
+	Outputs       map[string]interface{}    `json:"outputs"`
 	Files         map[string]string         `json:"files"`
 	RelocationMap bundle.ImageRelocationMap `json:"relocationMap"`
 }
@@ -67,6 +68,7 @@ func New(name string) (*Claim, error) {
 			Status: StatusUnknown,
 		},
 		Parameters:    map[string]interface{}{},
+		Outputs:       map[string]interface{}{},
 		RelocationMap: bundle.ImageRelocationMap{},
 	}, nil
 }

--- a/vendor/github.com/deislabs/cnab-go/driver/driver.go
+++ b/vendor/github.com/deislabs/cnab-go/driver/driver.go
@@ -34,7 +34,7 @@ type Operation struct {
 	// Files contains files that should be injected into the invocation image.
 	Files map[string]string `json:"files"`
 	// Output stream for log messages from the driver
-	Out io.Writer
+	Out io.Writer `json:"-"`
 }
 
 // ResolvedCred is a credential that has been resolved and is ready for injection into the runtime.


### PR DESCRIPTION
**- What I did**
- Bump cnab-go dependency
- Fails any installation upgrade when an immutable parameter is overridden
- Mark `com.docker.app.orchestrator` and `com.docker.app.kubernetes-namespace` parameters as immutable

**- How I did it**
On installation upgrade, when merging user-defined and current parameters values, ensure that no overridden parameter is immutable.

**- A picture of a cute animal (not mandatory but encouraged)**

![cute-otter-pic-14-800x800](https://user-images.githubusercontent.com/470082/61458476-e4b1dd00-a96a-11e9-8ca3-fc99e54214ec.jpg)
