### PR TITLE
Fix handling parameters for generic CNAB bundle

### DIFF
--- a/e2e/testdata/cnab-parameters/bundle.json
+++ b/e2e/testdata/cnab-parameters/bundle.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "v1.0.0-WD",
+  "name": "cnab-parameters",
+  "version": "0.1.0",
+  "invocationImages": [
+    {
+      "imageType": "docker",
+      "image": "e2e/cnab-parameters:v0.1.0"
+    }
+  ],
+  "definitions": {
+    "boolParam_type": {
+      "type": "boolean"
+    },
+    "stringParam_type": {
+      "type": "string"
+    },
+    "intParam_type": {
+      "type": "integer"
+    },
+    "floatParam_type": {
+      "type": "number"
+    }
+  },
+  "parameters": {
+    "fields": {
+      "boolParam": {
+        "definition": "boolParam_type",
+        "destination": {
+          "env": "BOOL_PARAM"
+        }
+      },
+      "stringParam": {
+        "definition": "stringParam_type",
+        "destination": {
+          "env": "STRING_PARAM"
+        }
+      },
+      "intParam": {
+        "definition": "intParam_type",
+        "destination": {
+          "env": "INT_PARAM"
+        }
+      },
+      "floatParam": {
+        "definition": "floatParam_type",
+        "destination": {
+          "env": "FLOAT_PARAM"
+        }
+      }
+    }
+  }
+}

--- a/e2e/testdata/cnab-parameters/cnab/app/run
+++ b/e2e/testdata/cnab-parameters/cnab/app/run
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+action=$CNAB_ACTION
+name=$CNAB_INSTALLATION_NAME
+
+case $action in
+    install)
+    echo "Install action"
+    echo "boolParam=$BOOL_PARAM" 
+    echo "stringParam=$STRING_PARAM" 
+    echo "intParam=$INT_PARAM" 
+    echo "floatParam=$FLOAT_PARAM" 
+    ;;
+    uninstall)
+    echo "uninstall action"
+    ;;
+    upgrade)
+    echo "Upgrade action"
+    ;;
+    *)
+    echo "No action for $action"
+    ;;
+esac
+echo "Action $action complete for $name"

--- a/e2e/testdata/cnab-parameters/cnab/build/Dockerfile
+++ b/e2e/testdata/cnab-parameters/cnab/build/Dockerfile
@@ -1,0 +1,7 @@
+ARG ALPINE_VERSION=3.9.2
+
+FROM alpine:${ALPINE_VERSION}
+
+COPY cnab/app/run /cnab/app/run
+
+CMD /cnab/app/run


### PR DESCRIPTION
**- What I did**
Fix parameter handling in generic CNAB bundle. App failed to process CNAB parameters when the parameter name and definition name were different in the bundle. 

**- How to verify it**
A new e2e test has been added for regression

**- A picture of a cute animal (not mandatory but encouraged)**

![dwjixxh9cah11](https://user-images.githubusercontent.com/470082/61720843-cfbcbb80-ad67-11e9-8191-84bd2cf5b049.jpg)
