### PR TITLE
Investigate CI e2e tests failures on mac

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -111,3 +111,13 @@ you forgot to rebuild the base invocation image, simply run
 ```sh
 $ make -f docker.Makefile invocation-image
 ```
+
+### Running specific end-to-end tests
+
+To execute a specific end-to-end test or set of end-to-end tests you can specify
+them with the E2E_TESTS Makefile variable.
+
+```console
+# run the e2e test <TEST_NAME>:
+make E2E_TESTS=<TEST_NAME> test-e2e
+```

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ ifeq ($(OS),Windows_NT)
   EXEC_EXT := .exe
 endif
 
+INCLUDE_E2E :=
+ifneq ($(E2E_TESTS),)
+  INCLUDE_E2E := -run $(E2E_TESTS)
+endif
+
 TEST_RESULTS_DIR = _build/test-results
 STATIC_FLAGS= CGO_ENABLED=0
 GO_BUILD = $(STATIC_FLAGS) go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
@@ -78,7 +83,7 @@ lint: ## run linter(s)
 test-e2e: bin/$(BIN_NAME) ## run end-to-end tests
 	@echo "Running e2e tests..."
 	@$(call mkdir,$(TEST_RESULTS_DIR))
-	$(call GO_TESTSUM,e2e.xml) -v ./e2e/
+	$(call GO_TESTSUM,e2e.xml) -v ./e2e/ $(INCLUDE_E2E)
 
 test-unit: ## run unit tests
 	@echo "Running unit tests..."

--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -107,3 +107,9 @@ func (c *Container) GetPrivateAddress(t *testing.T) string {
 	result := icmd.RunCommand(dockerCli.path, "inspect", container, "-f", "{{.NetworkSettings.IPAddress}}").Assert(t, icmd.Success)
 	return fmt.Sprintf("%s:%d", strings.TrimSpace(result.Stdout()), c.privatePort)
 }
+
+func (c *Container) Logs(t *testing.T) func() string {
+	return func() string {
+		return icmd.RunCommand(dockerCli.path, "logs", c.container).Assert(t, icmd.Success).Combined()
+	}
+}


### PR DESCRIPTION
**- What I did**
Improved the error reporting when pushing/pulling apps in the e2e tests by printing the registry logs. Fix the HTTP call to the registry by adding the missing Accept header.