### PR TITLE
Don't print logs when "-o -" flag is set

### DIFF
--- a/internal/commands/bundle.go
+++ b/internal/commands/bundle.go
@@ -63,7 +63,6 @@ func runBundle(dockerCli command.Cli, appName string, opts bundleOptions) error 
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, "Invocation image %q successfully built\n", bundle.InvocationImages[0].Image)
 	bundleBytes, err := json.MarshalIndent(bundle, "", "\t")
 	if err != nil {
 		return err
@@ -72,10 +71,11 @@ func runBundle(dockerCli command.Cli, appName string, opts bundleOptions) error 
 		_, err = dockerCli.Out().Write(bundleBytes)
 		return err
 	}
+	fmt.Fprintf(os.Stdout, "Invocation image %q successfully built\n", bundle.InvocationImages[0].Image)
 	if err := ioutil.WriteFile(opts.out, bundleBytes, 0644); err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stdout, "Bundle saved in %s\n", opts.out)
+	fmt.Fprintf(os.Stdout, "Bundle saved to %s\n", opts.out)
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**

Made it so that only the bundle is printed when "-o -" flag is given.

**- How to verify it**

Run `docker app bundle examples/hello-world/example-hello-world.dockerapp -o - | grep Invocation`, this should print out 0 lines

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/63704966-76dfb780-c82c-11e9-95e9-e9daadde17dd.png)
