### PR TITLE
APP-190 -- Updated status/list output times (added 'ago' at the end)

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -377,7 +377,7 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 		[]string{
 			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
-			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+failure\s+.+second[s]?\s+.+second[s]?\s+`, appName),
+			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+failure\s+.+second[s]?\sago\s+.+second[s]?\sago\s+`, appName),
 		})
 
 	// Upgrading a failed installation is not allowed
@@ -437,7 +437,7 @@ STATUS
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 		[]string{
 			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
-			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+success\s+.+second[s]?\s+.+second[s]?\s+`, appName),
+			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+success\s+.+second[s]?\sago\s+.+second[s]?\sago\s+`, appName),
 		})
 
 	// Installing again the same application is forbidden

--- a/e2e/pushpull_test.go
+++ b/e2e/pushpull_test.go
@@ -224,7 +224,7 @@ func TestPushPullInstall(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "list")
 		checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 			[]string{
-				fmt.Sprintf(`%s\s+push-pull \(1.1.0-beta1\)\s+install\s+success\s+.+second[s]?\s+.+second[s]?\s+%s`, t.Name(), ref+tag),
+				fmt.Sprintf(`%s\s+push-pull \(1.1.0-beta1\)\s+install\s+success\s+.+second[s]?\sago\s+.+second[s]?\sago\s+%s`, t.Name(), ref+tag),
 			})
 
 		// install with --pull should fail (registry is stopped)

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -29,8 +29,12 @@ var (
 		{"APPLICATION", func(i *store.Installation) string { return fmt.Sprintf("%s (%s)", i.Bundle.Name, i.Bundle.Version) }},
 		{"LAST ACTION", func(i *store.Installation) string { return i.Result.Action }},
 		{"RESULT", func(i *store.Installation) string { return i.Result.Status }},
-		{"CREATED", func(i *store.Installation) string { return units.HumanDuration(time.Since(i.Created)) }},
-		{"MODIFIED", func(i *store.Installation) string { return units.HumanDuration(time.Since(i.Modified)) }},
+		{"CREATED", func(i *store.Installation) string {
+			return fmt.Sprintf("%s ago", units.HumanDuration(time.Since(i.Created)))
+		}},
+		{"MODIFIED", func(i *store.Installation) string {
+			return fmt.Sprintf("%s ago", units.HumanDuration(time.Since(i.Modified)))
+		}},
 		{"REFERENCE", func(i *store.Installation) string { return i.Reference }},
 	}
 )

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -95,10 +95,11 @@ func runStatus(dockerCli command.Cli, installationName string, opts credentialOp
 
 func displayInstallationStatus(w io.Writer, installation *store.Installation) {
 	printHeader(w, "INSTALLATION")
+
 	tab := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
 	printValue(tab, "Name", installation.Name)
-	printValue(tab, "Created", units.HumanDuration(time.Since(installation.Created)))
-	printValue(tab, "Modified", units.HumanDuration(time.Since(installation.Modified)))
+	printValue(tab, "Created", fmt.Sprintf("%s ago", units.HumanDuration(time.Since(installation.Created))))
+	printValue(tab, "Modified", fmt.Sprintf("%s ago", units.HumanDuration(time.Since(installation.Modified))))
 	printValue(tab, "Revision", installation.Revision)
 	printValue(tab, "Last Action", installation.Result.Action)
 	printValue(tab, "Result", strings.ToUpper(installation.Result.Status))


### PR DESCRIPTION
Signed-off-by: Anca Iordache <anca.iordache@docker.com>

**- What I did**
Added 'ago' to the created/modified time in the status/list command output.

**- How to verify it**

Before:
```
$ docker app list
INSTALLATION APPLICATION         LAST ACTION RESULT  CREATED MODIFIED REFERENCE
hello-world  hello-world (0.1.0) install     success 3 hours 3 hours  

```

After:
```
$ docker app list
INSTALLATION APPLICATION         LAST ACTION RESULT  CREATED     MODIFIED    REFERENCE
hello-world  hello-world (0.1.0) install     success 3 hours ago 3 hours ago 

```



**- Description for the changelog**
Added 'ago' to status/list commands output times.


**- A picture of a cute animal (not mandatory but encouraged)**

![aZLZzZV_460swp](https://user-images.githubusercontent.com/809903/63770447-7bac7600-c8d5-11e9-862e-ee317eca9040.jpg)
