### PR TITLE
Use json-schema 0.7 to benefit "optional": true

### DIFF
--- a/specification/schemas/metadata_schema_v0.2.json
+++ b/specification/schemas/metadata_schema_v0.2.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "id": "metadata_schema_v0.2.json",
     "type": "object",
     "properties": {
@@ -10,10 +10,8 @@
             "type": "string"
         },
         "description": {
-            "type": [
-                "string",
-                "null"
-            ]
+            "type": "string",
+            "optional": true
         },
         "maintainers": {
             "type": "array",
@@ -41,11 +39,9 @@
                     "type": "string"
                 },
                 "email": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "format": "email"
+                    "type": "string",
+                    "format": "email",
+                    "optional": true
                 }
             }
         },


### PR DESCRIPTION
**- What I did**
replaced [ string, null ] type definition with optional strings

**- How I did it**
Updated json-schema requirement to 0.7 so we can rely on `optional`

**- How to verify it**
I used [gojsonschema](https://github.com/xeipuuv/gojsonschema) to generate code and check it match the one from repo
(makes me wonder we could adopt a contract-first approach here)

**- Description for the changelog**
schema updated to rely on json-schema draft-07

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/63846847-ea003f80-c98c-11e9-8ee1-c36a1bece0b9.png)
