### PR TITLE
Add warnings for env_file entries not copied

### DIFF
--- a/e2e/testdata/init-output-warning-multiple-envfiles.golden
+++ b/e2e/testdata/init-output-warning-multiple-envfiles.golden
@@ -1,0 +1,2 @@
+nginx.env_file "myenv1.env" will not be copied into app-test.dockerapp. Please copy it manually and update the path accordingly in the compose file.
+nginx.env_file "myenv2.env" will not be copied into app-test.dockerapp. Please copy it manually and update the path accordingly in the compose file.

--- a/e2e/testdata/init-output-warning-single-envfile.golden
+++ b/e2e/testdata/init-output-warning-single-envfile.golden
@@ -1,0 +1,1 @@
+nginx.env_file "myenv1.env" will not be copied into app-test.dockerapp. Please copy it manually and update the path accordingly in the compose file.

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -21,7 +21,7 @@ func initCmd(dockerCli command.Cli) *cobra.Command {
 $ docker app init myapp --compose-file docker-compose.yml`,
 		Args: cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			created, err := packager.Init(args[0], initComposeFile)
+			created, err := packager.Init(dockerCli.Err(), args[0], initComposeFile)
 			if err != nil {
 				return err
 			}

--- a/internal/packager/init_test.go
+++ b/internal/packager/init_test.go
@@ -32,7 +32,7 @@ services:
 	)
 	defer dir.Remove()
 
-	err := initFromComposeFile(dir.Join(appName), inputDir.Join(internal.ComposeFileName))
+	err := initFromComposeFile(nil, dir.Join(appName), inputDir.Join(internal.ComposeFileName))
 	assert.NilError(t, err)
 
 	manifest := fs.Expected(
@@ -73,7 +73,7 @@ services:
 	)
 	defer dir.Remove()
 
-	err := initFromComposeFile(dir.Join(appName), inputDir.Join(internal.ComposeFileName))
+	err := initFromComposeFile(nil, dir.Join(appName), inputDir.Join(internal.ComposeFileName))
 	assert.NilError(t, err)
 
 	const expectedParameters = `ports:
@@ -108,7 +108,7 @@ services:
 }
 
 func TestInitFromInvalidComposeFile(t *testing.T) {
-	err := initFromComposeFile("my.dockerapp", "doesnotexist")
+	err := initFromComposeFile(nil, "my.dockerapp", "doesnotexist")
 	assert.ErrorContains(t, err, "failed to read")
 }
 
@@ -131,7 +131,7 @@ services:
 	)
 	defer dir.Remove()
 
-	err := initFromComposeFile(dir.Join(appName), inputDir.Join(internal.ComposeFileName))
+	err := initFromComposeFile(nil, dir.Join(appName), inputDir.Join(internal.ComposeFileName))
 	assert.ErrorContains(t, err, "unsupported Compose file version")
 }
 
@@ -151,7 +151,7 @@ nginx:
 	)
 	defer dir.Remove()
 
-	err := initFromComposeFile(dir.Join(appName), inputDir.Join(internal.ComposeFileName))
+	err := initFromComposeFile(nil, dir.Join(appName), inputDir.Join(internal.ComposeFileName))
 	assert.ErrorContains(t, err, "unsupported Compose file version")
 }
 


### PR DESCRIPTION
As 'env_file' entries are not taken in account,
we warn the user to copy that and fix it's
compose file.

**- What I did**
Add a warning for each `env_file` entry on each service

**- How I did it**
By checking the env_file block for each service entry in `docker app init`

**- How to verify it**
Create a `docker-compose.yml` file with:
```
version: '3.7'
services:
  front:
    image: "nginx"
    env_file:
     - "myenv.env1"
     - "myenv.env2"
```
Run:
```
docker app init --compose-file docker-compose.yml myapp
```

**- Description for the changelog**
Add warnings for `env_file` entries not copied

**- A picture of a cute animal (not mandatory but encouraged)**
![sweater-baby-goat](https://user-images.githubusercontent.com/373485/64631794-20f83b80-d3f8-11e9-89b4-e6954165d74f.jpg)

