### PR TITLE
Remove the strict flag

### DIFF
--- a/internal/commands/cnab.go
+++ b/internal/commands/cnab.go
@@ -369,7 +369,6 @@ func prepareCustomAction(actionName string, dockerCli command.Cli, appname strin
 	if err := mergeBundleParameters(installation,
 		withFileParameters(paramsOpts.parametersFiles),
 		withCommandLineParameters(paramsOpts.overrides),
-		withStrictMode(paramsOpts.strictMode),
 	); err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -118,7 +118,6 @@ func runInstall(dockerCli command.Cli, appname string, opts installOptions) erro
 		withCommandLineParameters(opts.overrides),
 		withOrchestratorParameters(opts.orchestrator, opts.kubeNamespace),
 		withSendRegistryAuth(opts.sendRegistryAuth),
-		withStrictMode(opts.strictMode),
 	); err != nil {
 		return err
 	}

--- a/internal/commands/parameters.go
+++ b/internal/commands/parameters.go
@@ -15,10 +15,9 @@ import (
 )
 
 type mergeBundleConfig struct {
-	bundle     *bundle.Bundle
-	params     map[string]string
-	strictMode bool
-	stderr     io.Writer
+	bundle *bundle.Bundle
+	params map[string]string
+	stderr io.Writer
 }
 
 type mergeBundleOpt func(c *mergeBundleConfig) error
@@ -78,12 +77,6 @@ func withErrorWriter(w io.Writer) mergeBundleOpt {
 	}
 }
 
-func withStrictMode(strict bool) mergeBundleOpt {
-	return func(c *mergeBundleConfig) error {
-		c.strictMode = strict
-		return nil
-	}
-}
 func mergeBundleParameters(installation *store.Installation, ops ...mergeBundleOpt) error {
 	bndl := installation.Bundle
 	if installation.Parameters == nil {
@@ -116,9 +109,6 @@ func matchAndMergeParametersDefinition(currentValues map[string]interface{}, cfg
 	for k, v := range cfg.params {
 		param, ok := cfg.bundle.Parameters[k]
 		if !ok {
-			if cfg.strictMode {
-				return nil, fmt.Errorf("parameter %q is not defined in the bundle", k)
-			}
 			fmt.Fprintf(cfg.stderr, "Warning: parameter %q is not defined in the bundle\n", k)
 			continue
 		}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -117,13 +117,11 @@ func prepareBundleStore() (store.BundleStore, error) {
 type parametersOptions struct {
 	parametersFiles []string
 	overrides       []string
-	strictMode      bool
 }
 
 func (o *parametersOptions) addFlags(flags *pflag.FlagSet) {
 	flags.StringArrayVar(&o.parametersFiles, "parameters-file", []string{}, "Override parameters file")
 	flags.StringArrayVarP(&o.overrides, "set", "s", []string{}, "Override parameter value")
-	flags.BoolVar(&o.strictMode, "strict", false, "Fail when a paramater is undefined instead of displaying a warning")
 }
 
 type credentialOptions struct {

--- a/internal/commands/upgrade.go
+++ b/internal/commands/upgrade.go
@@ -67,7 +67,6 @@ func runUpgrade(dockerCli command.Cli, installationName string, opts upgradeOpti
 		withFileParameters(opts.parametersFiles),
 		withCommandLineParameters(opts.overrides),
 		withSendRegistryAuth(opts.sendRegistryAuth),
-		withStrictMode(opts.strictMode),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Djordje Lukic <djordje.lukic@docker.com>

**- What I did**

Removed the strict flag

**- How to verify it**

Run `docker app install --help`, there shouldn't be any `--strict` flags

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/64961309-7cfa0e80-d895-11e9-9edd-aeeed5067683.png)

