### PR TITLE
Remove target-context flags

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -637,6 +637,14 @@
   version = "v1.0"
 
 [[projects]]
+  digest = "1:c145f317274ab1a430e40f427402ca812219dbd4fa548a60fe1e09820c51d8cd"
+  name = "github.com/jackpal/gateway"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "10816db7ab2f4b71e71dba9420bfa67d5be27b33"
+  source = "github.com/ndeloof/gateway"
+
+[[projects]]
   digest = "1:fbfb539de947ebc48768d413ee811e3ff34d32636ff0965a517e7786e559f66b"
   name = "github.com/jaguilar/vt100"
   packages = ["."]
@@ -1457,6 +1465,7 @@
     "github.com/docker/docker/registry",
     "github.com/docker/go-units",
     "github.com/imdario/mergo",
+    "github.com/jackpal/gateway",
     "github.com/moby/buildkit/client",
     "github.com/moby/buildkit/session",
     "github.com/moby/buildkit/session/auth/authprovider",
@@ -1478,7 +1487,6 @@
     "gotest.tools/icmd",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/util/net",
     "k8s.io/client-go/kubernetes/typed/core/v1",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1478,6 +1478,7 @@
     "gotest.tools/icmd",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/util/net",
     "k8s.io/client-go/kubernetes/typed/core/v1",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -121,6 +121,12 @@ required = ["github.com/wadey/gocovmerge"]
   name = "github.com/wadey/gocovmerge"
   branch = "master"
 
+[[constraint]]
+  # see https://github.com/jackpal/gateway/pull/21
+  source = "github.com/ndeloof/gateway"
+  name = "github.com/jackpal/gateway"
+  revision = "10816db7ab2f4b71e71dba9420bfa67d5be27b33"
+
 [prune]
   non-go = true
   unused-packages = true

--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ $ docker app inspect myrepo/hello:0.1.0
 **Note**: Commands like `install`, `upgrade`, `render`, etc. can also be used
 directly on Application Packages that are in a registry.
 
+You can specify the Docker endpoint where an application is installed using a
+context and the `--context` option. If you do not specify one, it will	
+use the currently active context.
+
+Whenever you define such a context, the installer image will run in the `default`
+context (i.e. on local host). You can use the `--installer-context` to target
+another context to run the installer image.
+
 More examples are available in the [examples](examples) directory.
 
 ## CNAB

--- a/README.md
+++ b/README.md
@@ -188,23 +188,6 @@ $ docker app inspect myrepo/hello:0.1.0
 **Note**: Commands like `install`, `upgrade`, `render`, etc. can also be used
 directly on Application Packages that are in a registry.
 
-You can specify the Docker endpoint where an application is installed using a
-context and the `--target-context` option. If you do not specify one, it will
-use the currently active context.
-
-```console
-$ docker context create remote --description "remote cluster" --docker host=tcp://<remote-ip>:<remote-port>
-Successfully created context "remote"
-
-$ docker context ls
-NAME                DESCRIPTION                               DOCKER ENDPOINT               KUBERNETES ENDPOINT                ORCHESTRATOR
-default *           Current DOCKER_HOST based configuration   unix:///var/run/docker.sock   https://localhost:6443 (default)   swarm
-remote              remote cluster                            tcp://<remote-ip>:<remote-port>
-
-$ docker app install myrepo/hello:0.1.0 --target-context remote
-...
-```
-
 More examples are available in the [examples](examples) directory.
 
 ## CNAB

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -65,12 +65,16 @@ func testRenderApp(appPath string, env ...string) func(*testing.T) {
 		cmd.Env = append(cmd.Env, env...)
 		t.Run("stdout", func(t *testing.T) {
 			result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
-			assert.Assert(t, is.Equal(readFile(t, filepath.Join(appPath, "expected.txt")), result.Stdout()), "rendering mismatch")
+			expected := readFile(t, filepath.Join(appPath, "expected.txt"))
+			actual := result.Stdout()
+			assert.Assert(t, is.Equal(expected, actual), "rendering mismatch")
 		})
 		t.Run("file", func(t *testing.T) {
 			cmd.Command = append(cmd.Command, "--output="+dir.Join("actual.yaml"))
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
-			assert.Assert(t, is.Equal(readFile(t, filepath.Join(appPath, "expected.txt")), readFile(t, dir.Join("actual.yaml"))), "rendering mismatch")
+			expected := readFile(t, filepath.Join(appPath, "expected.txt"))
+			actual := readFile(t, dir.Join("actual.yaml"))
+			assert.Assert(t, is.Equal(expected, actual), "rendering mismatch")
 		})
 	}
 }
@@ -233,100 +237,86 @@ func TestRunWithLabels(t *testing.T) {
 }
 
 func TestDockerAppLifecycle(t *testing.T) {
-	t.Run("withBindMounts", func(t *testing.T) {
-		testDockerAppLifecycle(t, true)
-	})
-	t.Run("withoutBindMounts", func(t *testing.T) {
-		testDockerAppLifecycle(t, false)
-	})
-}
+	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
+		cmd := info.configuredCmd
+		appName := strings.ToLower(strings.Replace(t.Name(), "/", "_", 1))
+		tmpDir := fs.NewDir(t, appName)
+		defer tmpDir.Remove()
 
-func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
-	cmd, cleanup := dockerCli.createTestCmd()
-	defer cleanup()
-	appName := strings.ToLower(strings.Replace(t.Name(), "/", "_", 1))
-	tmpDir := fs.NewDir(t, appName)
-	defer tmpDir.Remove()
-	// Running a swarm using docker in docker to install the application
-	// and run the invocation image
-	swarm := NewContainer("docker:19.03.3-dind", 2375)
-	swarm.Start(t, "-e", "DOCKER_TLS_CERTDIR=")
-	defer swarm.Stop(t)
-	initializeDockerAppEnvironment(t, &cmd, tmpDir, swarm, useBindMount)
+		cmd.Command = dockerCli.Command("app", "build", "--tag", appName, "testdata/simple")
+		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-	cmd.Command = dockerCli.Command("app", "build", "--tag", appName, "testdata/simple")
-	icmd.RunCmd(cmd).Assert(t, icmd.Success)
-
-	// Install an illformed Docker Application Package
-	cmd.Command = dockerCli.Command("app", "run", appName, "--set", "web_port=-1", "--name", appName)
-	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
-		ExitCode: 1,
-		Err:      "error decoding 'Ports': Invalid hostPort: -1",
-	})
-
-	// List the installation and check the failed status
-	cmd.Command = dockerCli.Command("app", "ls")
-	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
-		[]string{
-			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
-			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+failure\s+.+second[s]?\sago\s+.+second[s]?\sago\s+`, appName),
+		// Install an illformed Docker Application Package
+		cmd.Command = dockerCli.Command("app", "run", appName, "--set", "web_port=-1", "--name", appName)
+		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      "error decoding 'Ports': Invalid hostPort: -1",
 		})
 
-	// Upgrading a failed installation is not allowed
-	cmd.Command = dockerCli.Command("app", "update", appName)
-	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
-		ExitCode: 1,
-		Err:      fmt.Sprintf("Running App %q cannot be updated, please use 'docker app run' instead", appName),
+		// List the installation and check the failed status
+		cmd.Command = dockerCli.Command("app", "ls")
+		checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
+			[]string{
+				`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
+				fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+failure\s+.+second[s]?\sago\s+.+second[s]?\sago\s+`, appName),
+			})
+
+		// Upgrading a failed installation is not allowed
+		cmd.Command = dockerCli.Command("app", "update", appName)
+		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      fmt.Sprintf("Running App %q cannot be updated, please use 'docker app run' instead", appName),
+		})
+
+		// Install a Docker Application Package with an existing failed installation is fine
+		cmd.Command = dockerCli.Command("app", "run", appName, "--name", appName)
+		checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
+			[]string{
+				fmt.Sprintf("WARNING: installing over previously failed installation %q", appName),
+				fmt.Sprintf("Creating network %s_back", appName),
+				fmt.Sprintf("Creating network %s_front", appName),
+				fmt.Sprintf("Creating service %s_db", appName),
+				fmt.Sprintf("Creating service %s_api", appName),
+				fmt.Sprintf("Creating service %s_web", appName),
+			})
+		assertAppLabels(t, &cmd, appName, "db")
+
+		// List the installed application
+		cmd.Command = dockerCli.Command("app", "ls")
+		checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
+			[]string{
+				`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
+				fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+success\s+.+second[s]?\sago\s+.+second[s]?\sago\s+`, appName),
+			})
+
+		// Installing again the same application is forbidden
+		cmd.Command = dockerCli.Command("app", "run", appName, "--name", appName)
+		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      fmt.Sprintf("Installation %q already exists, use 'docker app update' instead", appName),
+		})
+
+		// Update the application, changing the port
+		cmd.Command = dockerCli.Command("app", "update", appName, "--set", "web_port=8081")
+		checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
+			[]string{
+				fmt.Sprintf("Updating service %s_db", appName),
+				fmt.Sprintf("Updating service %s_api", appName),
+				fmt.Sprintf("Updating service %s_web", appName),
+			})
+		assertAppLabels(t, &cmd, appName, "db")
+
+		// Uninstall the application
+		cmd.Command = dockerCli.Command("app", "rm", appName)
+		checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
+			[]string{
+				fmt.Sprintf("Removing service %s_api", appName),
+				fmt.Sprintf("Removing service %s_db", appName),
+				fmt.Sprintf("Removing service %s_web", appName),
+				fmt.Sprintf("Removing network %s_front", appName),
+				fmt.Sprintf("Removing network %s_back", appName),
+			})
 	})
-
-	// Install a Docker Application Package with an existing failed installation is fine
-	cmd.Command = dockerCli.Command("app", "run", appName, "--name", appName)
-	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
-		[]string{
-			fmt.Sprintf("WARNING: installing over previously failed installation %q", appName),
-			fmt.Sprintf("Creating network %s_back", appName),
-			fmt.Sprintf("Creating network %s_front", appName),
-			fmt.Sprintf("Creating service %s_db", appName),
-			fmt.Sprintf("Creating service %s_api", appName),
-			fmt.Sprintf("Creating service %s_web", appName),
-		})
-	assertAppLabels(t, &cmd, appName, "db")
-
-	// List the installed application
-	cmd.Command = dockerCli.Command("app", "ls")
-	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
-		[]string{
-			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
-			fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+success\s+.+second[s]?\sago\s+.+second[s]?\sago\s+`, appName),
-		})
-
-	// Installing again the same application is forbidden
-	cmd.Command = dockerCli.Command("app", "run", appName, "--name", appName)
-	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
-		ExitCode: 1,
-		Err:      fmt.Sprintf("Installation %q already exists, use 'docker app update' instead", appName),
-	})
-
-	// Update the application, changing the port
-	cmd.Command = dockerCli.Command("app", "update", appName, "--set", "web_port=8081")
-	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
-		[]string{
-			fmt.Sprintf("Updating service %s_db", appName),
-			fmt.Sprintf("Updating service %s_api", appName),
-			fmt.Sprintf("Updating service %s_web", appName),
-		})
-	assertAppLabels(t, &cmd, appName, "db")
-
-	// Uninstall the application
-	cmd.Command = dockerCli.Command("app", "rm", appName)
-	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
-		[]string{
-			fmt.Sprintf("Removing service %s_api", appName),
-			fmt.Sprintf("Removing service %s_db", appName),
-			fmt.Sprintf("Removing service %s_web", appName),
-			fmt.Sprintf("Removing network %s_front", appName),
-			fmt.Sprintf("Removing network %s_back", appName),
-		})
 }
 
 func TestCredentials(t *testing.T) {
@@ -417,7 +407,8 @@ func TestCredentials(t *testing.T) {
 			"--cnab-bundle-json", bundle,
 		)
 		result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		golden.Assert(t, result.Stdout(), "credential-install-mixed-local-cred.golden")
+		stdout := result.Stdout()
+		golden.Assert(t, stdout, "credential-install-mixed-local-cred.golden")
 	})
 
 	t.Run("overload", func(t *testing.T) {
@@ -435,41 +426,6 @@ func TestCredentials(t *testing.T) {
 		})
 		golden.Assert(t, result.Stderr(), "credential-install-overload.golden")
 	})
-}
-
-func initializeDockerAppEnvironment(t *testing.T, cmd *icmd.Cmd, tmpDir *fs.Dir, swarm *Container, useBindMount bool) {
-	cmd.Env = append(cmd.Env, "DOCKER_TARGET_CONTEXT=swarm-target-context")
-
-	// The dind doesn't have the cnab-app-base image so we save it in order to load it later
-	icmd.RunCommand(dockerCli.path, "save", fmt.Sprintf("docker/cnab-app-base:%s", internal.Version), "--output", tmpDir.Join("cnab-app-base.tar.gz")).Assert(t, icmd.Success)
-
-	// We  need two contexts:
-	// - one for `docker` so that it connects to the dind swarm created before
-	// - the target context for the invocation image to install within the swarm
-	cmd.Command = dockerCli.Command("context", "create", "swarm-context", "--docker", fmt.Sprintf(`"host=tcp://%s"`, swarm.GetAddress(t)), "--default-stack-orchestrator", "swarm")
-	icmd.RunCmd(*cmd).Assert(t, icmd.Success)
-
-	// When creating a context on a Windows host we cannot use
-	// the unix socket but it's needed inside the invocation image.
-	// The workaround is to create a context with an empty host.
-	// This host will default to the unix socket inside the
-	// invocation image
-	host := "host="
-	if !useBindMount {
-		host += fmt.Sprintf("tcp://%s", swarm.GetPrivateAddress(t))
-	}
-
-	cmd.Command = dockerCli.Command("context", "create", "swarm-target-context", "--docker", host, "--default-stack-orchestrator", "swarm")
-	icmd.RunCmd(*cmd).Assert(t, icmd.Success)
-
-	// Initialize the swarm
-	cmd.Env = append(cmd.Env, "DOCKER_CONTEXT=swarm-context")
-	cmd.Command = dockerCli.Command("swarm", "init")
-	icmd.RunCmd(*cmd).Assert(t, icmd.Success)
-
-	// Load the needed base cnab image into the swarm docker engine
-	cmd.Command = dockerCli.Command("load", "--input", tmpDir.Join("cnab-app-base.tar.gz"))
-	icmd.RunCmd(*cmd).Assert(t, icmd.Success)
 }
 
 func assertAppLabels(t *testing.T, cmd *icmd.Cmd, appName, containerName string) {

--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"strconv"
 	"strings"
 	"testing"
@@ -27,63 +28,54 @@ func runWithDindSwarmAndRegistry(t *testing.T, todo func(dindSwarmAndRegistryInf
 	cmd, cleanup := dockerCli.createTestCmd()
 	defer cleanup()
 
-	registryPort := findAvailablePort()
 	tmpDir := fs.NewDir(t, t.Name())
 	defer tmpDir.Remove()
-
-	cmd.Env = append(cmd.Env, "DOCKER_TARGET_CONTEXT=swarm-target-context")
 
 	// The dind doesn't have the cnab-app-base image so we save it in order to load it later
 	saveCmd := icmd.Cmd{Command: dockerCli.Command("save", fmt.Sprintf("docker/cnab-app-base:%s", internal.Version), "-o", tmpDir.Join("cnab-app-base.tar.gz"))}
 	icmd.RunCmd(saveCmd).Assert(t, icmd.Success)
 
+	// Busybox is used in a few e2e test, let's pre-load it
+	cmd.Command = dockerCli.Command("pull", "busybox:1.30.1")
+	icmd.RunCmd(cmd).Assert(t, icmd.Success)
+	saveCmd = icmd.Cmd{Command: dockerCli.Command("save", "busybox:1.30.1", "-o", tmpDir.Join("busybox.tar.gz"))}
+	icmd.RunCmd(saveCmd).Assert(t, icmd.Success)
+
 	// we have a difficult constraint here:
 	// - the registry must be reachable from the client side (for cnab-to-oci, which does not use the docker daemon to access the registry)
 	// - the registry must be reachable from the dind daemon on the same address/port
-	// Solution found is: fix the port of the registry to be the same internally and externally
-	// and run the dind container in the same network namespace: this way 127.0.0.1:<registry-port> both resolves to the registry from the client and from dind
+	// - the installer image need to target the same docker context (dind) as the client, while running on default (or another) context, which means we can't use 'localhost'
+	// Solution found is: use host external IP (not loopback) so accessing from within installer container will reach the right container
 
-	swarm := NewContainer("docker:19.03.3-dind", 2375, "--insecure-registry", fmt.Sprintf("127.0.0.1:%d", registryPort))
-	swarm.Start(t, "--expose", strconv.FormatInt(int64(registryPort), 10),
-		"-p", fmt.Sprintf("%d:%d", registryPort, registryPort),
-		"-p", "2375",
-		"-e", "DOCKER_TLS_CERTDIR=") // Disable certificate generate on DinD startup
-	defer swarm.Stop(t)
-
-	registry := NewContainer("registry:2", registryPort)
-	registry.StartWithContainerNetwork(t, swarm, "-e", "REGISTRY_VALIDATION_MANIFESTS_URLS_ALLOW=[^http]",
-		"-e", fmt.Sprintf("REGISTRY_HTTP_ADDR=0.0.0.0:%d", registryPort))
+	registry := NewContainer("registry:2", 5000)
+	registry.Start(t, "-e", "REGISTRY_VALIDATION_MANIFESTS_URLS_ALLOW=[^http]",
+		"-e", "REGISTRY_HTTP_ADDR=0.0.0.0:5000")
 	defer registry.StopNoFail()
+	registryAddress := registry.GetAddress(t)
 
-	// We  need two contexts:
-	// - one for `docker` so that it connects to the dind swarm created before
-	// - the target context for the invocation image to install within the swarm
-	cmd.Command = dockerCli.Command("context", "create", "swarm-context", "--docker", fmt.Sprintf(`"host=tcp://%s"`, swarm.GetAddress(t)), "--default-stack-orchestrator", "swarm")
+	swarm := NewContainer("docker:19.03.3-dind", 2375, "--insecure-registry", registryAddress)
+	swarm.Start(t, "-e", "DOCKER_TLS_CERTDIR=") // Disable certificate generate on DinD startup
+	defer swarm.Stop(t)
+	swarmAddress := swarm.GetAddress(t)
+
+	cmd.Command = dockerCli.Command("context", "create", "swarm-context", "--docker", fmt.Sprintf(`"host=tcp://%s"`, swarmAddress), "--default-stack-orchestrator", "swarm")
 	icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-	// When creating a context on a Windows host we cannot use
-	// the unix socket but it's needed inside the invocation image.
-	// The workaround is to create a context with an empty host.
-	// This host will default to the unix socket inside the
-	// invocation image
-	cmd.Command = dockerCli.Command("context", "create", "swarm-target-context", "--docker", "host=", "--default-stack-orchestrator", "swarm")
-	icmd.RunCmd(cmd).Assert(t, icmd.Success)
-
+	cmd.Env = append(cmd.Env, "DOCKER_CONTEXT=swarm-context", "DOCKER_INSTALLER_CONTEXT=swarm-context")
 	// Initialize the swarm
-	cmd.Env = append(cmd.Env, "DOCKER_CONTEXT=swarm-context")
 	cmd.Command = dockerCli.Command("swarm", "init")
 	icmd.RunCmd(cmd).Assert(t, icmd.Success)
 	// Load the needed base cnab image into the swarm docker engine
 	cmd.Command = dockerCli.Command("load", "-i", tmpDir.Join("cnab-app-base.tar.gz"))
 	icmd.RunCmd(cmd).Assert(t, icmd.Success)
-
-	cmd.Command = dockerCli.Command("pull", "busybox:1.30.1")
+	// Pre-load busybox image used by a few e2e tests
+	cmd.Command = dockerCli.Command("load", "-i", tmpDir.Join("busybox.tar.gz"))
 	icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 	info := dindSwarmAndRegistryInfo{
 		configuredCmd:   cmd,
-		registryAddress: registry.GetAddress(t),
-		swarmAddress:    swarm.GetAddress(t),
+		registryAddress: registryAddress,
+		swarmAddress:    swarmAddress,
 		stopRegistry:    registry.StopNoFail,
 		registryLogs:    registry.Logs(t),
 	}
@@ -147,23 +139,32 @@ func (c *Container) GetAddress(t *testing.T) string {
 	if c.address != "" {
 		return c.address
 	}
-	container := c.parentContainer
-	if container == "" {
-		container = c.container
-	}
-	result := icmd.RunCommand(dockerCli.path, "port", container, strconv.Itoa(c.privatePort)).Assert(t, icmd.Success)
-	c.address = fmt.Sprintf("127.0.0.1:%v", strings.Trim(strings.Split(result.Stdout(), ":")[1], " \r\n"))
+	ip := c.getIP(t)
+	port := c.getPort(t)
+	c.address = fmt.Sprintf("%s:%v", ip, port)
 	return c.address
 }
 
-// GetPrivateAddress returns the host:port this container listens on
-func (c *Container) GetPrivateAddress(t *testing.T) string {
-	container := c.parentContainer
-	if container == "" {
-		container = c.container
+func (c *Container) getPort(t *testing.T) string {
+	result := icmd.RunCommand(dockerCli.path, "port", c.container, strconv.Itoa(c.privatePort)).Assert(t, icmd.Success)
+	port := strings.Trim(strings.Split(result.Stdout(), ":")[1], " \r\n")
+	return port
+}
+
+func (c *Container) getIP(t *testing.T) string {
+	ip := "127.0.0.1"
+	// This won't work, but we can't guarantee computer has another IP
+	addrs, err := net.InterfaceAddrs()
+	assert.NilError(t, err)
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				ip = ipnet.IP.String()
+				break
+			}
+		}
 	}
-	result := icmd.RunCommand(dockerCli.path, "inspect", container, "-f", "{{.NetworkSettings.IPAddress}}").Assert(t, icmd.Success)
-	return fmt.Sprintf("%s:%d", strings.TrimSpace(result.Stdout()), c.privatePort)
+	return ip
 }
 
 func (c *Container) Logs(t *testing.T) func() string {

--- a/e2e/images_test.go
+++ b/e2e/images_test.go
@@ -72,7 +72,7 @@ my.registry:5000/c-myapp latest [a-f0-9]{12} push-pull
 func TestImageListQuiet(t *testing.T) {
 	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
 		cmd := info.configuredCmd
-		insertBundles(t, cmd, info)
+		insertBundles(t, cmd)
 		verifyImageIDListOutput(t, cmd, 3, 2)
 	})
 }
@@ -80,14 +80,13 @@ func TestImageListQuiet(t *testing.T) {
 func TestImageListDigests(t *testing.T) {
 	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
 		cmd := info.configuredCmd
-		insertBundles(t, cmd, info)
-		expected := `REPOSITORY             TAG    DIGEST APP IMAGE ID APP NAME
-%s latest <none> [a-f0-9]{12} push-pull
-a-simple-app           latest <none> [a-f0-9]{12} simple
-b-simple-app           latest <none> [a-f0-9]{12} simple
+		insertBundles(t, cmd)
+		expected := `REPOSITORY               TAG    DIGEST APP IMAGE ID APP NAME
+a-simple-app             latest <none> [a-f0-9]{12} simple
+b-simple-app             latest <none> [a-f0-9]{12} simple
+my.registry:5000/c-myapp latest <none> [a-f0-9]{12} push-pull
 `
-		expectedOutput := fmt.Sprintf(expected, info.registryAddress+"/c-myapp")
-		expectImageListDigestsOutput(t, cmd, expectedOutput)
+		expectImageListDigestsOutput(t, cmd, expected)
 	})
 }
 

--- a/e2e/pushpull_test.go
+++ b/e2e/pushpull_test.go
@@ -4,13 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
-	"net"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/docker/cnab-to-oci/converter"
 	"github.com/docker/distribution/manifest/manifestlist"
@@ -258,25 +255,6 @@ func TestPushInstallBundle(t *testing.T) {
 			assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref))
 		})
 	})
-}
-
-func findAvailablePort() int {
-	rand.Seed(time.Now().UnixNano())
-	for {
-		candidate := (rand.Int() % 2000) + 5000
-		if isPortAvailable(candidate) {
-			return candidate
-		}
-	}
-}
-
-func isPortAvailable(port int) bool {
-	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-	if err != nil {
-		return false
-	}
-	defer l.Close()
-	return true
 }
 
 func httpGet(url string, headers map[string]string, obj interface{}) error {

--- a/internal/cliopts/installerContext.go
+++ b/internal/cliopts/installerContext.go
@@ -1,0 +1,56 @@
+package cliopts
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/flags"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+)
+
+type InstallerContextOptions struct {
+	installerContext string
+}
+
+func (o *InstallerContextOptions) AddFlags(flags *pflag.FlagSet) {
+	defaultContext, ok := os.LookupEnv("DOCKER_INSTALLER_CONTEXT")
+	if !ok {
+		defaultContext = "default"
+	}
+	flags.StringVar(&o.installerContext, "installer-context", defaultContext, "Context on which the installer image is ran")
+}
+
+func (o *InstallerContextOptions) SetInstallerContext(dockerCli command.Cli) (command.Cli, error) {
+	if o.installerContext != dockerCli.CurrentContext() {
+		if _, err := dockerCli.ContextStore().GetMetadata(o.installerContext); err != nil {
+			return nil, errors.Wrapf(err, "Unknown docker context %s", o.installerContext)
+		}
+		fmt.Fprintf(dockerCli.Out(), "Using context %q to run installer image", o.installerContext)
+		cli, err := command.NewDockerCli()
+		if err != nil {
+			return nil, err
+		}
+		opts := flags.ClientOptions{
+			Common: &flags.CommonOptions{
+				Context:  o.installerContext,
+				LogLevel: logrus.GetLevel().String(),
+			},
+			ConfigDir: config.Dir(),
+		}
+		if err = cli.Apply(
+			command.WithInputStream(dockerCli.In()),
+			command.WithOutputStream(dockerCli.Out()),
+			command.WithErrorStream(dockerCli.Err())); err != nil {
+			return nil, err
+		}
+		if err = cli.Initialize(&opts); err != nil {
+			return nil, err
+		}
+		return cli, nil
+	}
+	return dockerCli, nil
+}

--- a/internal/cnab/cnab.go
+++ b/internal/cnab/cnab.go
@@ -128,7 +128,6 @@ func PullBundle(dockerCli command.Cli, bundleStore appstore.BundleStore, tagRef 
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve insecure registries: %v", err)
 	}
-
 	bndl, err := remotes.Pull(log.WithLogContext(context.Background()), reference.TagNameOnly(tagRef), remotes.CreateResolver(dockerCli.ConfigFile(), insecureRegistries...))
 	if err != nil {
 		return nil, err

--- a/internal/cnab/driver.go
+++ b/internal/cnab/driver.go
@@ -25,13 +25,13 @@ type BindMount struct {
 
 const defaultSocketPath string = "/var/run/docker.sock"
 
-func RequiredClaimBindMount(c claim.Claim, targetContextName string, dockerCli command.Cli) (BindMount, error) {
+func RequiredClaimBindMount(c claim.Claim, dockerCli command.Cli) (BindMount, error) {
 	var specifiedOrchestrator string
 	if rawOrchestrator, ok := c.Parameters[internal.ParameterOrchestratorName]; ok {
 		specifiedOrchestrator = rawOrchestrator.(string)
 	}
 
-	return RequiredBindMount(targetContextName, specifiedOrchestrator, dockerCli.ContextStore())
+	return RequiredBindMount(dockerCli.CurrentContext(), specifiedOrchestrator, dockerCli.ContextStore())
 }
 
 // RequiredBindMount Returns the path required to bind mount when running

--- a/internal/commands/credentials.go
+++ b/internal/commands/credentials.go
@@ -136,6 +136,8 @@ func prepareCredentialSet(b *bundle.Bundle, opts ...credentialSetOpt) (map[strin
 
 	_, requiresDockerContext := b.Credentials[internal.CredentialDockerContextName]
 	_, hasDockerContext := creds[internal.CredentialDockerContextName]
+
+	// FIXME not sure what this mean if we don't have --target-context
 	if requiresDockerContext && !hasDockerContext {
 		return nil, errors.New("no target context specified. Use --target-context= or DOCKER_TARGET_CONTEXT= to define it")
 	}

--- a/internal/commands/credentials.go
+++ b/internal/commands/credentials.go
@@ -133,14 +133,5 @@ func prepareCredentialSet(b *bundle.Bundle, opts ...credentialSetOpt) (map[strin
 			return nil, err
 		}
 	}
-
-	_, requiresDockerContext := b.Credentials[internal.CredentialDockerContextName]
-	_, hasDockerContext := creds[internal.CredentialDockerContextName]
-
-	// FIXME not sure what this mean if we don't have --target-context
-	if requiresDockerContext && !hasDockerContext {
-		return nil, errors.New("no target context specified. Use --target-context= or DOCKER_TARGET_CONTEXT= to define it")
-	}
-
 	return creds, nil
 }

--- a/internal/commands/image/render.go
+++ b/internal/commands/image/render.go
@@ -6,11 +6,10 @@ import (
 	"io"
 	"os"
 
-	"github.com/docker/app/internal/cliopts"
-
 	"github.com/deislabs/cnab-go/action"
 	"github.com/docker/app/internal"
 	bdl "github.com/docker/app/internal/bundle"
+	"github.com/docker/app/internal/cliopts"
 	"github.com/docker/app/internal/cnab"
 	appstore "github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli"
@@ -22,7 +21,7 @@ import (
 
 type renderOptions struct {
 	cliopts.ParametersOptions
-	installerContextOptions
+	cliopts.InstallerContextOptions
 	formatDriver string
 	renderOutput string
 }
@@ -40,7 +39,7 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 	opts.ParametersOptions.AddFlags(cmd.Flags())
-	opts.installerContextOptions.addFlags(cmd.Flags())
+	opts.InstallerContextOptions.AddFlags(cmd.Flags())
 	cmd.Flags().StringVarP(&opts.renderOutput, "output", "o", "-", "Output file")
 	cmd.Flags().StringVar(&opts.formatDriver, "formatter", "yaml", "Configure the output format (yaml|json)")
 
@@ -98,7 +97,7 @@ func prepareCustomAction(actionName string, dockerCli command.Cli, appname strin
 		return nil, nil, nil, err
 	}
 
-	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions, stdout)
+	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, opts.InstallerContextOptions, stdout)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/commands/image/render.go
+++ b/internal/commands/image/render.go
@@ -40,6 +40,7 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 	opts.ParametersOptions.AddFlags(cmd.Flags())
+	opts.installerContextOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVarP(&opts.renderOutput, "output", "o", "-", "Output file")
 	cmd.Flags().StringVar(&opts.formatDriver, "formatter", "yaml", "Configure the output format (yaml|json)")
 
@@ -65,7 +66,7 @@ func runRender(dockerCli command.Cli, appname string, opts renderOptions) error 
 	}
 	installation.Parameters[internal.ParameterRenderFormatName] = opts.formatDriver
 
-	if err := action.Run(&installation.Claim, nil, nil); err != nil {
+	if err := action.Run(&installation.Claim, nil, w); err != nil {
 		return fmt.Errorf("render failed: %s\n%s", err, errBuf)
 	}
 	return nil
@@ -97,7 +98,7 @@ func prepareCustomAction(actionName string, dockerCli command.Cli, appname strin
 		return nil, nil, nil, err
 	}
 
-	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions)
+	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions, stdout)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -51,7 +51,6 @@ func listCmd(dockerCli command.Cli) *cobra.Command {
 			return runList(dockerCli, opts)
 		},
 	}
-	cmd.Flags().StringVar(&opts.targetContext, "target-context", "", "List running Apps on this context")
 
 	return cmd
 }

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -16,9 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type listOptions struct {
-}
-
 var (
 	listColumns = []struct {
 		header string
@@ -39,22 +36,20 @@ var (
 )
 
 func listCmd(dockerCli command.Cli) *cobra.Command {
-	var opts listOptions
-
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS]",
 		Short:   "List running Apps",
 		Aliases: []string{"list"},
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(dockerCli, opts)
+			return runList(dockerCli)
 		},
 	}
 
 	return cmd
 }
 
-func runList(dockerCli command.Cli, opts listOptions) error {
+func runList(dockerCli command.Cli) error {
 	installations, err := getInstallations(dockerCli.CurrentContext(), config.Dir())
 	if err != nil {
 		return err

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -17,7 +17,6 @@ import (
 )
 
 type listOptions struct {
-	targetContextOptions
 }
 
 var (
@@ -56,8 +55,7 @@ func listCmd(dockerCli command.Cli) *cobra.Command {
 }
 
 func runList(dockerCli command.Cli, opts listOptions) error {
-	opts.SetDefaultTargetContext(dockerCli)
-	installations, err := getInstallations(opts.targetContext, config.Dir())
+	installations, err := getInstallations(dockerCli.CurrentContext(), config.Dir())
 	if err != nil {
 		return err
 	}

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/docker/app/internal/cnab"
+
+	"github.com/docker/app/internal/cliopts"
+
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/docker/cli/cli"
@@ -13,7 +17,7 @@ import (
 
 type removeOptions struct {
 	credentialOptions
-	installerContextOptions
+	cliopts.InstallerContextOptions
 	force bool
 }
 
@@ -31,7 +35,7 @@ func removeCmd(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 	opts.credentialOptions.addFlags(cmd.Flags())
-	opts.installerContextOptions.addFlags(cmd.Flags())
+	opts.InstallerContextOptions.AddFlags(cmd.Flags())
 	cmd.Flags().BoolVar(&opts.force, "force", false, "Force the removal of a running App")
 
 	return cmd
@@ -61,7 +65,7 @@ func runRemove(dockerCli command.Cli, installationName string, opts removeOption
 			fmt.Fprintf(os.Stderr, "deletion forced for running App %q\n", installationName)
 		}()
 	}
-	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions, os.Stdout)
+	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, opts.InstallerContextOptions, os.Stdout)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -30,7 +30,8 @@ func removeCmd(dockerCli command.Cli) *cobra.Command {
 			return runRemove(dockerCli, args[0], opts)
 		},
 	}
-	opts.addFlags(cmd.Flags())
+	opts.credentialOptions.addFlags(cmd.Flags())
+	opts.installerContextOptions.addFlags(cmd.Flags())
 	cmd.Flags().BoolVar(&opts.force, "force", false, "Force the removal of a running App")
 
 	return cmd
@@ -60,7 +61,7 @@ func runRemove(dockerCli command.Cli, installationName string, opts removeOption
 			fmt.Fprintf(os.Stderr, "deletion forced for running App %q\n", installationName)
 		}()
 	}
-	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions)
+	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions, os.Stdout)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -140,7 +140,6 @@ type credentialOptions struct {
 }
 
 func (o *credentialOptions) addFlags(flags *pflag.FlagSet) {
-	flags.StringVar(&o.targetContext, "target-context", "", "Context on which the application is installed (default: <current-context>)")
 	flags.StringArrayVar(&o.credentialsets, "credential-set", []string{}, "Use a YAML file containing a credential set or a credential set present in the credential store")
 	flags.StringArrayVar(&o.credentials, "credential", nil, "Add a single credential, additive ontop of any --credential-set used")
 	flags.BoolVar(&o.sendRegistryAuth, "with-registry-auth", false, "Sends registry auth")

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -63,6 +63,7 @@ func runCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	opts.ParametersOptions.AddFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
+	opts.installerContextOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.orchestrator, "orchestrator", "", "Orchestrator to install on (swarm, kubernetes)")
 	cmd.Flags().StringVar(&opts.kubeNamespace, "namespace", "default", "Kubernetes namespace to install into")
 	cmd.Flags().StringVar(&opts.stackName, "name", "", "Assign a name to the installation")
@@ -123,7 +124,7 @@ func runBundle(dockerCli command.Cli, bndl *bundle.Bundle, opts runOptions, ref 
 		return err
 	}
 
-	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions)
+	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions, os.Stdout)
 	if err != nil {
 		return err
 	}
@@ -163,6 +164,6 @@ func runBundle(dockerCli command.Cli, bndl *bundle.Bundle, opts runOptions, ref 
 		return err2
 	}
 
-	fmt.Fprintf(dockerCli.Out(), "App %q running on context %q\n", installationName, dockerCli.CurrentContext())
+	fmt.Fprintf(os.Stdout, "App %q running on context %q\n", installationName, dockerCli.CurrentContext())
 	return nil
 }

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -23,7 +23,7 @@ import (
 type runOptions struct {
 	cliopts.ParametersOptions
 	credentialOptions
-	installerContextOptions
+	cliopts.InstallerContextOptions
 	orchestrator  string
 	kubeNamespace string
 	stackName     string
@@ -63,7 +63,7 @@ func runCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	opts.ParametersOptions.AddFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
-	opts.installerContextOptions.addFlags(cmd.Flags())
+	opts.InstallerContextOptions.AddFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.orchestrator, "orchestrator", "", "Orchestrator to install on (swarm, kubernetes)")
 	cmd.Flags().StringVar(&opts.kubeNamespace, "namespace", "default", "Kubernetes namespace to install into")
 	cmd.Flags().StringVar(&opts.stackName, "name", "", "Assign a name to the installation")
@@ -109,7 +109,7 @@ func runBundle(dockerCli command.Cli, bndl *bundle.Bundle, opts runOptions, ref 
 	logrus.Debugf(`Looking for a previous installation "%q"`, installationName)
 	if installation, err := installationStore.Read(installationName); err == nil {
 		// A failed installation can be overridden, but with a warning
-		if isInstallationFailed(installation) {
+		if IsInstallationFailed(installation) {
 			fmt.Fprintf(dockerCli.Err(), "WARNING: installing over previously failed installation %q\n", installationName)
 		} else {
 			// Return an error in case of successful installation, or even failed upgrade, which means
@@ -124,7 +124,7 @@ func runBundle(dockerCli command.Cli, bndl *bundle.Bundle, opts runOptions, ref 
 		return err
 	}
 
-	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions, os.Stdout)
+	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, opts.InstallerContextOptions, os.Stdout)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -33,6 +33,7 @@ func updateCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	opts.ParametersOptions.AddFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
+	opts.installerContextOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.bundleOrDockerApp, "image", "", "Override the running App with another App image")
 
 	return cmd
@@ -70,7 +71,7 @@ func runUpdate(dockerCli command.Cli, installationName string, opts updateOption
 		return err
 	}
 
-	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions)
+	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions, os.Stdout)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -16,7 +16,7 @@ import (
 type updateOptions struct {
 	cliopts.ParametersOptions
 	credentialOptions
-	installerContextOptions
+	cliopts.InstallerContextOptions
 	bundleOrDockerApp string
 }
 
@@ -33,7 +33,7 @@ func updateCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	opts.ParametersOptions.AddFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
-	opts.installerContextOptions.addFlags(cmd.Flags())
+	opts.InstallerContextOptions.AddFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.bundleOrDockerApp, "image", "", "Override the running App with another App image")
 
 	return cmd
@@ -52,7 +52,7 @@ func runUpdate(dockerCli command.Cli, installationName string, opts updateOption
 		return err
 	}
 
-	if isInstallationFailed(installation) {
+	if IsInstallationFailed(installation) {
 		return fmt.Errorf("Running App %q cannot be updated, please use 'docker app run' instead", installationName)
 	}
 
@@ -71,7 +71,7 @@ func runUpdate(dockerCli command.Cli, installationName string, opts updateOption
 		return err
 	}
 
-	driverImpl, errBuf, err := setupDriver(installation, dockerCli, opts.installerContextOptions, os.Stdout)
+	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, opts.InstallerContextOptions, os.Stdout)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/jackpal/gateway/LICENSE
+++ b/vendor/github.com/jackpal/gateway/LICENSE
@@ -1,0 +1,27 @@
+// Copyright (c) 2010 Jack Palevich. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/jackpal/gateway/gateway_common.go
+++ b/vendor/github.com/jackpal/gateway/gateway_common.go
@@ -1,0 +1,160 @@
+package gateway
+
+import (
+	"errors"
+	"net"
+	"strings"
+)
+
+var errNoGateway = errors.New("no gateway found")
+
+func parseWindowsRoutePrint(output []byte) (net.IP, error) {
+	// Windows route output format is always like this:
+	// ===========================================================================
+	// Interface List
+	// 8 ...00 12 3f a7 17 ba ...... Intel(R) PRO/100 VE Network Connection
+	// 1 ........................... Software Loopback Interface 1
+	// ===========================================================================
+	// IPv4 Route Table
+	// ===========================================================================
+	// Active Routes:
+	// Network Destination        Netmask          Gateway       Interface  Metric
+	//           0.0.0.0          0.0.0.0      192.168.1.1    192.168.1.100     20
+	// ===========================================================================
+	//
+	// Windows commands are localized, so we can't just look for "Active Routes:" string
+	// I'm trying to pick the active route,
+	// then jump 2 lines and pick the third IP
+	// Not using regex because output is quite standard from Windows XP to 8 (NEEDS TESTING)
+	lines := strings.Split(string(output), "\n")
+	sep := 0
+	for idx, line := range lines {
+		if sep == 3 {
+			// We just entered the 2nd section containing "Active Routes:"
+			if len(lines) <= idx+2 {
+				return nil, errNoGateway
+			}
+
+			fields := strings.Fields(lines[idx+2])
+			if len(fields) < 3 {
+				return nil, errNoGateway
+			}
+
+			ip := net.ParseIP(fields[2])
+			if ip != nil {
+				return ip, nil
+			}
+		}
+		if strings.HasPrefix(line, "=======") {
+			sep++
+			continue
+		}
+	}
+	return nil, errNoGateway
+}
+
+func parseLinuxIPRouteShow(output []byte) (net.IP, error) {
+	// Linux '/usr/bin/ip route show' format looks like this:
+	// default via 192.168.178.1 dev wlp3s0  metric 303
+	// 192.168.178.0/24 dev wlp3s0  proto kernel  scope link  src 192.168.178.76  metric 303
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[0] == "default" {
+			ip := net.ParseIP(fields[2])
+			if ip != nil {
+				return ip, nil
+			}
+		}
+	}
+
+	return nil, errNoGateway
+}
+
+func parseLinuxIPRouteGet(output []byte) (net.IP, error) {
+	// Linux '/usr/bin/ip route get 8.8.8.8' format looks like this:
+	// 8.8.8.8 via 10.0.1.1 dev eth0  src 10.0.1.36  uid 2000
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == "via" {
+			ip := net.ParseIP(fields[2])
+			if ip != nil {
+				return ip, nil
+			}
+		}
+	}
+
+	return nil, errNoGateway
+}
+
+func parseLinuxRoute(output []byte) (net.IP, error) {
+	// Linux route out format is always like this:
+	// Kernel IP routing table
+	// Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
+	// 0.0.0.0         192.168.1.1     0.0.0.0         UG    0      0        0 eth0
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "0.0.0.0" {
+			ip := net.ParseIP(fields[1])
+			if ip != nil {
+				return ip, nil
+			}
+		}
+	}
+
+	return nil, errNoGateway
+}
+
+func parseDarwinRouteGet(output []byte) (net.IP, error) {
+	// Darwin route out format is always like this:
+	//    route to: default
+	// destination: default
+	//        mask: default
+	//     gateway: 192.168.1.1
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "gateway:" {
+			ip := net.ParseIP(fields[1])
+			if ip != nil {
+				return ip, nil
+			}
+		}
+	}
+
+	return nil, errNoGateway
+}
+
+func parseBSDSolarisNetstat(output []byte) (net.IP, error) {
+	// netstat -rn produces the following on FreeBSD:
+	// Routing tables
+	//
+	// Internet:
+	// Destination        Gateway            Flags      Netif Expire
+	// default            10.88.88.2         UGS         em0
+	// 10.88.88.0/24      link#1             U           em0
+	// 10.88.88.148       link#1             UHS         lo0
+	// 127.0.0.1          link#2             UH          lo0
+	//
+	// Internet6:
+	// Destination                       Gateway                       Flags      Netif Expire
+	// ::/96                             ::1                           UGRS        lo0
+	// ::1                               link#2                        UH          lo0
+	// ::ffff:0.0.0.0/96                 ::1                           UGRS        lo0
+	// fe80::/10                         ::1                           UGRS        lo0
+	// ...
+	outputLines := strings.Split(string(output), "\n")
+	for _, line := range outputLines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "default" {
+			ip := net.ParseIP(fields[1])
+			if ip != nil {
+				return ip, nil
+			}
+		}
+	}
+
+	return nil, errNoGateway
+}

--- a/vendor/github.com/jackpal/gateway/gateway_darwin.go
+++ b/vendor/github.com/jackpal/gateway/gateway_darwin.go
@@ -1,0 +1,16 @@
+package gateway
+
+import (
+	"net"
+	"os/exec"
+)
+
+func DiscoverGateway() (net.IP, error) {
+	routeCmd := exec.Command("/sbin/route", "-n", "get", "0.0.0.0")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseDarwinRouteGet(output)
+}

--- a/vendor/github.com/jackpal/gateway/gateway_freebsd.go
+++ b/vendor/github.com/jackpal/gateway/gateway_freebsd.go
@@ -1,0 +1,16 @@
+package gateway
+
+import (
+	"net"
+	"os/exec"
+)
+
+func DiscoverGateway() (ip net.IP, err error) {
+	routeCmd := exec.Command("netstat", "-rn")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseBSDSolarisNetstat(output)
+}

--- a/vendor/github.com/jackpal/gateway/gateway_linux.go
+++ b/vendor/github.com/jackpal/gateway/gateway_linux.go
@@ -1,0 +1,47 @@
+package gateway
+
+import (
+	"net"
+	"os/exec"
+)
+
+func DiscoverGateway() (ip net.IP, err error) {
+	ip, err = discoverGatewayUsingRoute()
+	if err != nil {
+		ip, err = discoverGatewayUsingIpRouteShow()
+	}
+	if err != nil {
+		ip, err = discoverGatewayUsingIpRouteGet()
+	}
+	return
+}
+
+func discoverGatewayUsingIpRouteShow() (net.IP, error) {
+	routeCmd := exec.Command("ip", "route", "show")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseLinuxIPRouteShow(output)
+}
+
+func discoverGatewayUsingIpRouteGet() (net.IP, error) {
+	routeCmd := exec.Command("ip", "route", "get", "8.8.8.8")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseLinuxIPRouteGet(output)
+}
+
+func discoverGatewayUsingRoute() (net.IP, error) {
+	routeCmd := exec.Command("route", "-n")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseLinuxRoute(output)
+}

--- a/vendor/github.com/jackpal/gateway/gateway_solaris.go
+++ b/vendor/github.com/jackpal/gateway/gateway_solaris.go
@@ -1,0 +1,16 @@
+package gateway
+
+import (
+	"net"
+	"os/exec"
+)
+
+func DiscoverGateway() (ip net.IP, err error) {
+	routeCmd := exec.Command("netstat", "-rn")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseBSDSolarisNetstat(output)
+}

--- a/vendor/github.com/jackpal/gateway/gateway_unimplemented.go
+++ b/vendor/github.com/jackpal/gateway/gateway_unimplemented.go
@@ -1,0 +1,14 @@
+// +build !darwin,!linux,!windows,!solaris,!freebsd
+
+package gateway
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+)
+
+func DiscoverGateway() (ip net.IP, err error) {
+	err = fmt.Errorf("DiscoverGateway not implemented for OS %s", runtime.GOOS)
+	return
+}

--- a/vendor/github.com/jackpal/gateway/gateway_windows.go
+++ b/vendor/github.com/jackpal/gateway/gateway_windows.go
@@ -1,0 +1,18 @@
+package gateway
+
+import (
+	"net"
+	"os/exec"
+	"syscall"
+)
+
+func DiscoverGateway() (ip net.IP, err error) {
+	routeCmd := exec.Command("route", "print", "0.0.0.0")
+	routeCmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseWindowsRoutePrint(output)
+}


### PR DESCRIPTION
As a user of the Docker App CLI tool
So that I have a consistent user experience with the Docker CLI
I want the target context flag removed

**- What I did**
Remove all the `--target-context` and references to it in the README.md

**- How I did it**
- removed all the `--target-context` and references to it in the README.md
- app is installed in context pointed by docker CLI
- installer image runs in `default` context by defaut until overriden by `--installer-context`

**- How to verify it**
Check the commands to see that the flags are not there anymore

**- Description for the changelog**
Remove target-context flags

**- A picture of a cute animal (not mandatory but encouraged)**
![2baby-goats](https://user-images.githubusercontent.com/373485/64964144-c731be80-d89a-11e9-8753-adedfacd51b1.jpg)
