### PR TITLE
Dockerfile.invocation-image: Fix for multi-arch

### DIFF
--- a/Dockerfile.invocation-image
+++ b/Dockerfile.invocation-image
@@ -1,8 +1,8 @@
 ARG ALPINE_VERSION=3.10.1
 
-FROM dockercore/golang-cross:1.12.9@sha256:3ea9dcef4dd2c46d80445c0b22d6177817f4cfce22c523cc12a5a1091cb37705 AS build
+FROM golang:1.13.0 AS build
 
-RUN apt-get install -y -q --no-install-recommends \
+RUN apt-get update -qq && apt-get install -y -q --no-install-recommends \
     coreutils \
     util-linux \
     uuid-runtime


### PR DESCRIPTION
The container used for compiling the application is only available on
amd64. This change uses a multi-arch golang container and also fixes
an issue where the apt cache can be out-of-date.

Fixes Bug #611
Verify by building on something like an rpi3.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
Reported-by: Andy Doan <andy@foundries.io>
