### PR TITLE
Rename --kubernetes-namespace flag to --namespace

### DIFF
--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -62,7 +62,7 @@ func installCmd(dockerCli command.Cli) *cobra.Command {
 	opts.registryOptions.addFlags(cmd.Flags())
 	opts.pullOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.orchestrator, "orchestrator", "", "Orchestrator to install on (swarm, kubernetes)")
-	cmd.Flags().StringVar(&opts.kubeNamespace, "kubernetes-namespace", "default", "Kubernetes namespace to install into")
+	cmd.Flags().StringVar(&opts.kubeNamespace, "namespace", "default", "Kubernetes namespace to install into")
 	cmd.Flags().StringVar(&opts.stackName, "name", "", "Installation name (defaults to application name)")
 
 	return cmd


### PR DESCRIPTION
**- What I did**
Rename --kubernetes-namespace flag to --namespace

**- How to verify it**
`docker app install --help` command should contain
```
      --namespace string              Kubernetes namespace to install into (default "default")
```

**- A picture of a cute animal (not mandatory but encouraged)**
![alt_367624_1_2x](https://user-images.githubusercontent.com/470082/65032014-9d33d700-d942-11e9-9c22-e0acc870a22c.jpg)

