### PR TITLE
Rename "uninstall" to "remove/rm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Commands:
   push        Push an application package to a registry
   render      Render the Compose file for an Application Package
   status      Get the installation status of an application
-  uninstall   Uninstall an application
+  rm          Remove an application
   upgrade     Upgrade an installed application
   validate    Checks the rendered application is syntactically correct
   version     Print version information

--- a/e2e/cnab_test.go
+++ b/e2e/cnab_test.go
@@ -55,7 +55,7 @@ func TestCallCustomStatusAction(t *testing.T) {
 
 			// docker app uninstall
 			defer func() {
-				cmd.Command = dockerCli.Command("app", "uninstall", testCase.name)
+				cmd.Command = dockerCli.Command("app", "rm", testCase.name)
 				icmd.RunCmd(cmd).Assert(t, icmd.Success)
 			}()
 
@@ -79,7 +79,7 @@ func TestCnabParameters(t *testing.T) {
 
 	// docker app uninstall
 	defer func() {
-		cmd.Command = dockerCli.Command("app", "uninstall", "cnab-parameters")
+		cmd.Command = dockerCli.Command("app", "rm", "cnab-parameters")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 	}()
 

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -362,7 +362,7 @@ STATUS
 	icmd.RunCmd(cmd).Assert(t, icmd.Expected{ExitCode: 0, Out: "8081"})
 
 	// Uninstall the application
-	cmd.Command = dockerCli.Command("app", "uninstall", appName)
+	cmd.Command = dockerCli.Command("app", "rm", appName)
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 		[]string{
 			fmt.Sprintf("Removing service %s_api", appName),

--- a/e2e/pushpull_test.go
+++ b/e2e/pushpull_test.go
@@ -258,7 +258,7 @@ func TestPushInstallBundle(t *testing.T) {
 			assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref))
 
 			// ensure it doesn't confuse the next test
-			cmd.Command = dockerCli.Command("app", "uninstall", name)
+			cmd.Command = dockerCli.Command("app", "rm", name)
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 			cmd.Command = dockerCli.Command("service", "ls")

--- a/e2e/testdata/plugin-usage-experimental.golden
+++ b/e2e/testdata/plugin-usage-experimental.golden
@@ -12,8 +12,8 @@ Commands:
   pull        Pull an application package from a registry
   push        Push an application package to a registry
   render      Render the Compose file for an Application Package
+  rm          Remove an application
   status      Get the installation status of an application
-  uninstall   Uninstall an application
   upgrade     Upgrade an installed application
   validate    Checks the rendered application is syntactically correct
   version     Print version information

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -12,8 +12,8 @@ Commands:
   pull        Pull an application package from a registry
   push        Push an application package to a registry
   render      Render the Compose file for an Application Package
+  rm          Remove an application
   status      Get the installation status of an application
-  uninstall   Uninstall an application
   upgrade     Upgrade an installed application
   validate    Checks the rendered application is syntactically correct
   version     Print version information

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -20,9 +20,10 @@ func uninstallCmd(dockerCli command.Cli) *cobra.Command {
 	var opts uninstallOptions
 
 	cmd := &cobra.Command{
-		Use:     "uninstall INSTALLATION_NAME [--target-context TARGET_CONTEXT] [OPTIONS]",
-		Short:   "Uninstall an application",
-		Example: `$ docker app uninstall myinstallation --target-context=mycontext`,
+		Use:     "rm INSTALLATION_NAME [--target-context TARGET_CONTEXT] [OPTIONS]",
+		Short:   "Remove an application",
+		Aliases: []string{"remove"},
+		Example: `$ docker app rm myinstallation --target-context=mycontext`,
 		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUninstall(dockerCli, args[0], opts)


### PR DESCRIPTION
**- What I did**
Renamed `uninstall` into `rm` (alias `remove`)

**- How I did it**
Search and replace

**- How to verify it**
docker app --help
docker app rm foo

**- Description for the changelog**
"uninstall" command renamed to "rm" (alias remove)

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/65123274-273b7880-d9f3-11e9-81e4-67fe2d5b0300.png)

