### PR TITLE
Jenkinsfile: use --password-stdin

### DIFF
--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -68,7 +68,7 @@ pipeline {
                             dir('src/github.com/docker/app') {
                                 checkout scm
                                 ansiColor('xterm') {
-                                    sh "docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD"
+                                    sh 'echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USERNAME}" --password-stdin'
                                     sh "FOSSA_API_KEY=$FOSSA_API_KEY BRANCH_NAME='${BRANCH_NAME}' make fossa-analyze"
                                     sh "FOSSA_API_KEY=$FOSSA_API_KEY make fossa-test"
                                 }
@@ -284,7 +284,7 @@ pipeline {
             }
             steps{
                 echo "Pushing Base Invocation Image"
-                sh 'docker login --username "${DOCKERHUB_CREDS_USR}" --password "${DOCKERHUB_CREDS_PSW}"'
+                sh 'echo "${DOCKERHUB_CREDS_PSW}" | docker login --username "${DOCKERHUB_CREDS_USR}" --password-stdin'
                 dir('src/github.com/docker/app') {
                     checkout scm
                     dir('_build') {


### PR DESCRIPTION
before:

    docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD
    WARNING! Using --password via the CLI is insecure. Use --password-stdin.
    Login Succeeded

with this PR:

    echo $REGISTRY_PASSWORD | docker login -u "$REGISTRY_USERNAME" --password-stdin
    Login Succeeded

**- How to verify it**

Ehm, don't know; I don't think the Jenkinsfile change will run on this PR (because I'm not an owner in this repo)

**- A picture of a cute animal (not mandatory but encouraged)**


![monkey_phone](https://user-images.githubusercontent.com/1804568/65312521-f5611800-db92-11e9-8919-0b5d04914d69.jpg)
