### PR TITLE
Send slack message for failed master builds

### DIFF
--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -288,6 +288,16 @@ pipeline {
             }
         }
     }
+    post {
+        failure {
+            script {
+                if (env.BRANCH_NAME == 'master') {
+                    slackSend channel: '#app-def-team', color: 'danger',
+                              message: "Build #${env.BUILD_NUMBER} failed: ${env.BUILD_URL}"
+                }
+            }
+        }
+    }
 }
 
 def release(repo) {


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a post step to send a Slack message when a build in master branch failed.

**- How I did it**

**- How to verify it**
Run in internal CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

