### PR TITLE
Ensure invocation image has been build before running make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ GO_BUILD = $(STATIC_FLAGS) go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 GO_TEST = $(STATIC_FLAGS) go test -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 GO_TESTSUM = $(STATIC_FLAGS) gotestsum --junitfile $(TEST_RESULTS_DIR)/$(TEST_RESULTS_PREFIX)$(1) -- -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 
-all: bin/$(BIN_NAME) test
+all: bin/$(BIN_NAME) build-invocation-image test
 
 check_go_env:
 	@test $$(go list) = "$(PKG_NAME)" || \
@@ -71,6 +71,12 @@ bin/$(BIN_NAME)-%.exe bin/$(BIN_NAME)-%: cmd/$(BIN_NAME) check_go_env
 
 bin/%: cmd/% check_go_env
 	$(GO_BUILD) -o $@$(EXEC_EXT) ./$<
+
+build-invocation-image: ## build invocation image if not present (internal usage, not diplayed in help)
+	@echo "Build invocation image if needed"
+	$(if $(shell docker images -q docker/cnab-app-base:$(TAG)),, \
+		$(MAKE) -f ./docker.Makefile invocation-image \
+	)
 
 check: lint test
 


### PR DESCRIPTION
As a potential contributor of Docker App
I want to run `make` or `make all` on docker-app source code without having errors during the end-to-end tests phase

**- What I did**
Add a build of the invocation image if needed
**- How I did it**
Check if the image is already present & if not build it
**- How to verify it**

- remove all the docker/cnab-app-base images 
- run a `make` command
- check the image is building before executing tests
- re-run a `make` command 
- check the image isn't build again


**- A picture of a cute animal (not mandatory but encouraged)**

![bear](https://user-images.githubusercontent.com/705411/65463038-46a12e00-de57-11e9-839b-bc162bfd1419.jpeg)
