### PR TITLE
Ux init

### DIFF
--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -11,19 +11,17 @@ import (
 
 var (
 	initComposeFile string
-	initDescription string
-	initMaintainers []string
 )
 
 func initCmd(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "init APP_NAME [--compose-file COMPOSE_FILE] [--description DESCRIPTION] [--maintainer NAME:EMAIL ...] [OPTIONS]",
+		Use:     "init APP_NAME [--compose-file COMPOSE_FILE] [OPTIONS]",
 		Short:   "Initialize Docker Application definition",
 		Long:    `Start building a Docker Application package. If there is a docker-compose.yml file in the current directory it will be copied and used.`,
-		Example: `$ docker app init myapp --description "a useful description"`,
+		Example: `$ docker app init myapp`,
 		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			created, err := packager.Init(args[0], initComposeFile, initDescription, initMaintainers)
+			created, err := packager.Init(args[0], initComposeFile)
 			if err != nil {
 				return err
 			}
@@ -32,7 +30,5 @@ func initCmd(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&initComposeFile, "compose-file", "", "Compose file to use as application base (optional)")
-	cmd.Flags().StringVar(&initDescription, "description", "", "Human readable description of your application (optional)")
-	cmd.Flags().StringArrayVar(&initMaintainers, "maintainer", []string{}, "Name and email address of person responsible for the application (name:email) (optional)")
 	return cmd
 }

--- a/internal/packager/init.go
+++ b/internal/packager/init.go
@@ -46,11 +46,6 @@ func Init(name string, composeFile string) (string, error) {
 	}
 
 	if composeFile == "" {
-		if _, err := os.Stat(internal.ComposeFileName); err == nil {
-			composeFile = internal.ComposeFileName
-		}
-	}
-	if composeFile == "" {
 		err = initFromScratch(name)
 	} else {
 		err = initFromComposeFile(name, composeFile)


### PR DESCRIPTION
**- What I did**

Made UX changes to the `init` subcommand:

* removed the maintainer flag
* removed the description flag
* removed implicit compose file search

**- How I did it**

Removed a bunch of code.

**- How to verify it**

Run `docker app init --help`, the flags `description` and `maintainer` should no longer be there.

**- Description for the changelog**
Docker App doesn't implicitly select a docker-compose.yml file on init.
The flags `--description` and `--maintainer` heve been removed.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/65513981-adb4f600-dedc-11e9-9675-3ae2ce7ac126.png)

