### PR TITLE
Return exit code 1 & usage message when an unknown command is passed …

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -20,6 +20,17 @@ import (
 	"gotest.tools/icmd"
 )
 
+func TestExitErrorCode(t *testing.T) {
+	cmd, cleanup := dockerCli.createTestCmd()
+	defer cleanup()
+
+	cmd.Command = dockerCli.Command("app", "unknown_command")
+	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+		ExitCode: 1,
+		Out:      "\"unknown_command\" is not a docker app command",
+	})
+}
+
 func TestRender(t *testing.T) {
 	appsPath := filepath.Join("testdata", "render")
 	apps, err := ioutil.ReadDir(appsPath)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/docker/app/internal"
-
 	"github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
@@ -37,12 +36,21 @@ func NewRootCmd(use string, dockerCli command.Cli) *cobra.Command {
 				return cmd.GenBashCompletion(dockerCli.Out())
 			case "zsh":
 				return cmd.GenZshCompletion(dockerCli.Out())
-			case "":
-				// Actually unset
-				return nil
 			default:
-				return fmt.Errorf("%q is not a supported shell", completion)
+				if completion != "" {
+					fmt.Printf("%q is not a supported shell", completion)
+					cmd.HelpFunc()(cmd, args)
+					os.Exit(1)
+				}
 			}
+
+			if len(args) != 0 {
+				fmt.Printf("%q is not a docker app command", args[0])
+				cmd.HelpFunc()(cmd, args)
+				os.Exit(1)
+			}
+			cmd.HelpFunc()(cmd, args)
+			return nil
 		},
 	}
 	addCommands(cmd, dockerCli)


### PR DESCRIPTION
**- What I did**
Return the usage message and 1 as return code when a bad command is passed to the CLI

**- How I did it**
remove the empty case on completion switch
call to the command help function
return a error with this format `"unknown command: %s", strings.Join(args," ")`

**- How to verify it**
- execute the command line `docker app`, check it displays the usage message & check the return code is 0 with `echo $?`
- execute the command line with an invalid command such as `docker app unknown_command`, check it displays the usage message & check the return code is 1 with `echo $?` 

**- A picture of a cute animal (not mandatory but encouraged)**
![bear2](https://user-images.githubusercontent.com/705411/65517935-c7a60700-dee3-11e9-9ad2-38d57b2ab1a7.jpeg)

