### PR TITLE
Rename command `list` with `ls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Commands:
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
   install     Install an application
-  list        List the installations and their last known installation result
+  ls          List the installations and their last known installation result
   pull        Pull an application package from a registry
   push        Push an application package to a registry
   render      Render the Compose file for an Application Package

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -274,7 +274,7 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 	})
 
 	// List the installation and check the failed status
-	cmd.Command = dockerCli.Command("app", "list")
+	cmd.Command = dockerCli.Command("app", "ls")
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 		[]string{
 			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
@@ -334,7 +334,7 @@ STATUS
 		})
 
 	// List the installed application
-	cmd.Command = dockerCli.Command("app", "list")
+	cmd.Command = dockerCli.Command("app", "ls")
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 		[]string{
 			`INSTALLATION\s+APPLICATION\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,

--- a/e2e/pushpull_test.go
+++ b/e2e/pushpull_test.go
@@ -221,7 +221,7 @@ func TestPushPullInstall(t *testing.T) {
 		assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref))
 
 		// listing the installed application shows the pulled application reference
-		cmd.Command = dockerCli.Command("app", "list")
+		cmd.Command = dockerCli.Command("app", "ls")
 		checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 			[]string{
 				fmt.Sprintf(`%s\s+push-pull \(1.1.0-beta1\)\s+install\s+success\s+.+second[s]?\sago\s+.+second[s]?\sago\s+%s`, t.Name(), ref+tag),

--- a/e2e/testdata/plugin-usage-experimental.golden
+++ b/e2e/testdata/plugin-usage-experimental.golden
@@ -11,7 +11,7 @@ Commands:
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
   install     Install an application
-  list        List the installations and their last known installation result
+  ls          List the installations and their last known installation result
   pull        Pull an application package from a registry
   push        Push an application package to a registry
   render      Render the Compose file for an Application Package

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -11,7 +11,7 @@ Commands:
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
   install     Install an application
-  list        List the installations and their last known installation result
+  ls          List the installations and their last known installation result
   pull        Pull an application package from a registry
   push        Push an application package to a registry
   render      Render the Compose file for an Application Package

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -43,9 +43,9 @@ func listCmd(dockerCli command.Cli) *cobra.Command {
 	var opts listOptions
 
 	cmd := &cobra.Command{
-		Use:     "list [OPTIONS]",
+		Use:     "ls [OPTIONS]",
 		Short:   "List the installations and their last known installation result",
-		Aliases: []string{"ls"},
+		Aliases: []string{"list"},
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(dockerCli, opts)


### PR DESCRIPTION
**- What I did**
Rename command `list` with `ls`

**- How I did it**
Rename command `list` with `ls` and added an alias to `list`

**- How to verify it**
`docker app ls`
`docker app list`
`docker app --help`

**- Description for the changelog**
Rename command `list` with `ls`

**- A picture of a cute animal (not mandatory but encouraged)**
![baby-goat-pajama-party-strawberry](https://user-images.githubusercontent.com/373485/65521123-fecae700-dee8-11e9-90b5-96fe3a0eb4cf.jpg)

