### PR TITLE
Remove `--insecure-registries` flag

### DIFF
--- a/e2e/images_test.go
+++ b/e2e/images_test.go
@@ -27,7 +27,7 @@ func TestImageList(t *testing.T) {
 		defer dir.Remove()
 
 		// Push an application so that we can later pull it by digest
-		cmd.Command = dockerCli.Command("app", "push", "--tag", info.registryAddress+"/c-myapp", "--insecure-registries="+info.registryAddress, filepath.Join("testdata", "push-pull", "push-pull.dockerapp"))
+		cmd.Command = dockerCli.Command("app", "push", "--tag", info.registryAddress+"/c-myapp", filepath.Join("testdata", "push-pull", "push-pull.dockerapp"))
 		r := icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 		// Get the digest from the output of the pull command
@@ -36,7 +36,7 @@ func TestImageList(t *testing.T) {
 		digest := matches[0][1]
 
 		// Pull the app by digest
-		cmd.Command = dockerCli.Command("app", "pull", "--insecure-registries="+info.registryAddress, info.registryAddress+"/c-myapp@"+digest)
+		cmd.Command = dockerCli.Command("app", "pull", info.registryAddress+"/c-myapp@"+digest)
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 		cmd.Command = dockerCli.Command("app", "bundle", filepath.Join("testdata", "simple", "simple.dockerapp"), "--tag", "b-simple-app", "--output", dir.Join("simple-bundle.json"))

--- a/internal/commands/inspect.go
+++ b/internal/commands/inspect.go
@@ -11,7 +11,6 @@ import (
 
 type inspectOptions struct {
 	parametersOptions
-	registryOptions
 	pullOptions
 }
 
@@ -27,14 +26,13 @@ func inspectCmd(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())
-	opts.registryOptions.addFlags(cmd.Flags())
 	opts.pullOptions.addFlags(cmd.Flags())
 	return cmd
 }
 
 func runInspect(dockerCli command.Cli, appname string, opts inspectOptions) error {
 	defer muteDockerCli(dockerCli)()
-	action, installation, errBuf, err := prepareCustomAction(internal.ActionInspectName, dockerCli, appname, nil, opts.registryOptions, opts.pullOptions, opts.parametersOptions)
+	action, installation, errBuf, err := prepareCustomAction(internal.ActionInspectName, dockerCli, appname, nil, opts.pullOptions, opts.parametersOptions)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -16,7 +16,6 @@ import (
 type installOptions struct {
 	parametersOptions
 	credentialOptions
-	registryOptions
 	pullOptions
 	orchestrator  string
 	kubeNamespace string
@@ -59,7 +58,6 @@ func installCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
-	opts.registryOptions.addFlags(cmd.Flags())
 	opts.pullOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.orchestrator, "orchestrator", "", "Orchestrator to install on (swarm, kubernetes)")
 	cmd.Flags().StringVar(&opts.kubeNamespace, "namespace", "default", "Kubernetes namespace to install into")
@@ -81,7 +79,7 @@ func runInstall(dockerCli command.Cli, appname string, opts installOptions) erro
 		return err
 	}
 
-	bndl, ref, err := resolveBundle(dockerCli, bundleStore, appname, opts.pull, opts.insecureRegistries)
+	bndl, ref, err := resolveBundle(dockerCli, bundleStore, appname, opts.pull)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -14,21 +14,19 @@ import (
 )
 
 func pullCmd(dockerCli command.Cli) *cobra.Command {
-	var opts registryOptions
 	cmd := &cobra.Command{
 		Use:     "pull NAME:TAG [OPTIONS]",
 		Short:   "Pull an application package from a registry",
 		Example: `$ docker app pull docker/app-example:0.1.0`,
 		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPull(dockerCli, args[0], opts)
+			return runPull(dockerCli, args[0])
 		},
 	}
-	opts.addFlags(cmd.Flags())
 	return cmd
 }
 
-func runPull(dockerCli command.Cli, name string, opts registryOptions) error {
+func runPull(dockerCli command.Cli, name string) error {
 	appstore, err := store.NewApplicationStore(config.Dir())
 	if err != nil {
 		return err
@@ -42,7 +40,11 @@ func runPull(dockerCli command.Cli, name string, opts registryOptions) error {
 	if err != nil {
 		return errors.Wrap(err, name)
 	}
-	bndl, err := bundleStore.LookupOrPullBundle(reference.TagNameOnly(ref), true, dockerCli.ConfigFile(), opts.insecureRegistries)
+	insecureRegistries, err := insecureRegistriesFromEngine(dockerCli)
+	if err != nil {
+		return errors.Wrap(err, "could not retrieve insecure registries")
+	}
+	bndl, err := bundleStore.LookupOrPullBundle(reference.TagNameOnly(ref), true, dockerCli.ConfigFile(), insecureRegistries)
 	if err != nil {
 		return errors.Wrap(err, name)
 	}

--- a/internal/commands/render.go
+++ b/internal/commands/render.go
@@ -13,7 +13,6 @@ import (
 
 type renderOptions struct {
 	parametersOptions
-	registryOptions
 	pullOptions
 
 	formatDriver string
@@ -32,7 +31,6 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())
-	opts.registryOptions.addFlags(cmd.Flags())
 	opts.pullOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVarP(&opts.renderOutput, "output", "o", "-", "Output file")
 	cmd.Flags().StringVar(&opts.formatDriver, "formatter", "yaml", "Configure the output format (yaml|json)")
@@ -53,7 +51,7 @@ func runRender(dockerCli command.Cli, appname string, opts renderOptions) error 
 		w = f
 	}
 
-	action, installation, errBuf, err := prepareCustomAction(internal.ActionRenderName, dockerCli, appname, w, opts.registryOptions, opts.pullOptions, opts.parametersOptions)
+	action, installation, errBuf, err := prepareCustomAction(internal.ActionRenderName, dockerCli, appname, w, opts.pullOptions, opts.parametersOptions)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/upgrade.go
+++ b/internal/commands/upgrade.go
@@ -13,7 +13,6 @@ import (
 type upgradeOptions struct {
 	parametersOptions
 	credentialOptions
-	registryOptions
 	pullOptions
 	bundleOrDockerApp string
 }
@@ -31,7 +30,6 @@ func upgradeCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
-	opts.registryOptions.addFlags(cmd.Flags())
 	opts.pullOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.bundleOrDockerApp, "app-name", "", "Override the installation with another Application Package")
 
@@ -57,7 +55,7 @@ func runUpgrade(dockerCli command.Cli, installationName string, opts upgradeOpti
 	}
 
 	if opts.bundleOrDockerApp != "" {
-		b, _, err := resolveBundle(dockerCli, bundleStore, opts.bundleOrDockerApp, opts.pull, opts.insecureRegistries)
+		b, _, err := resolveBundle(dockerCli, bundleStore, opts.bundleOrDockerApp, opts.pull)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION




Signed-off-by: Yves Brissaud <yves.brissaud@docker.com>

**- What I did**

The `--insecure-registries` flag is removed to have a consistent UX with
Docker CLI.

**- How I did it**

Instead of this flag, the list of insecure registries is retrieved from
the engine. See https://docs.docker.com/registry/insecure/ to configure
your engine to allow communication to an insecure registry.

See [the engine API](https://docs.docker.com/engine/api/v1.40/#operation/SystemInfo) and `RegistryConfig.IndexConfigs` fields.

**- How to verify it**

1. run an insecure registry:

    `docker run --rm -p 5000:5000 registry:2`

2. create an app

    `docker app init test-insecure`

3. push the app against the insecure registry

    `docker app push --tag 127.0.0.1:5000/test-insecure:0.1 test-insecure.dockerapp`

    It should fail with an error about HTTP (insecure) response to a HTTPS (secure) client:

    > http: server gave HTTP response to HTTPS client

4. update your daemon configuration to add the local registry as insecure (apply and restart the daemon, restart the stopped registry)

    ```
    "insecure-registries": [
      "127.0.0.1:5000"
    ]
    ```

5. push again the app

    > Successfully pushed bundle to 127.0.0.1:5000/test-insecure:0.1.

**- Description for the changelog**

Remove `--insecure-registries` flag and rely on the daemon to retrieve the list of insecure registries.
