### PR TITLE
unknow command - use the same error format as the Docker CLI

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -27,7 +27,7 @@ func TestExitErrorCode(t *testing.T) {
 	cmd.Command = dockerCli.Command("app", "unknown_command")
 	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 		ExitCode: 1,
-		Out:      "\"unknown_command\" is not a docker app command",
+		Err:      "\"unknown_command\" is not a docker app command\nSee 'docker app --help'",
 	})
 }
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -38,16 +38,12 @@ func NewRootCmd(use string, dockerCli command.Cli) *cobra.Command {
 				return cmd.GenZshCompletion(dockerCli.Out())
 			default:
 				if completion != "" {
-					fmt.Printf("%q is not a supported shell", completion)
-					cmd.HelpFunc()(cmd, args)
-					os.Exit(1)
+					return fmt.Errorf("%q is not a supported shell\nSee 'docker app --help'", completion)
 				}
 			}
 
 			if len(args) != 0 {
-				fmt.Printf("%q is not a docker app command", args[0])
-				cmd.HelpFunc()(cmd, args)
-				os.Exit(1)
+				return fmt.Errorf("%q is not a docker app command\nSee 'docker app --help'", args[0])
 			}
 			cmd.HelpFunc()(cmd, args)
 			return nil


### PR DESCRIPTION
**- What I did**
Align Docker App error message to the Docker CLI when a command is unknown

**- How I did it**
Remove usage message of the error output

**- How to verify it**

- execute the command line docker app, check it displays the usage message & check the return code is 0 with echo $?
- execute the command line with an invalid command such as docker app unknown_command, check it doesn't display the usage message & check the return code is 1 with echo $?

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/705411/65768420-32984d80-e131-11e9-8ab5-3c88a68207cd.png)
