### PR TITLE
Add command to remove application images

### DIFF
--- a/e2e/images_test.go
+++ b/e2e/images_test.go
@@ -20,31 +20,58 @@ b-simple-app           latest simple
 `
 )
 
+func insertBundles(t *testing.T, cmd icmd.Cmd, dir *fs.Dir, info dindSwarmAndRegistryInfo) string {
+	// Push an application so that we can later pull it by digest
+	cmd.Command = dockerCli.Command("app", "push", "--tag", info.registryAddress+"/c-myapp", filepath.Join("testdata", "push-pull", "push-pull.dockerapp"))
+	r := icmd.RunCmd(cmd).Assert(t, icmd.Success)
+
+	// Get the digest from the output of the pull command
+	out := r.Stdout()
+	matches := reg.FindAllStringSubmatch(out, 1)
+	digest := matches[0][1]
+
+	// Pull the app by digest
+	cmd.Command = dockerCli.Command("app", "pull", info.registryAddress+"/c-myapp@"+digest)
+	icmd.RunCmd(cmd).Assert(t, icmd.Success)
+
+	cmd.Command = dockerCli.Command("app", "bundle", filepath.Join("testdata", "simple", "simple.dockerapp"), "--tag", "b-simple-app", "--output", dir.Join("simple-bundle.json"))
+	icmd.RunCmd(cmd).Assert(t, icmd.Success)
+	cmd.Command = dockerCli.Command("app", "bundle", filepath.Join("testdata", "simple", "simple.dockerapp"), "--tag", "a-simple-app", "--output", dir.Join("simple-bundle.json"))
+	icmd.RunCmd(cmd).Assert(t, icmd.Success)
+
+	return digest
+}
+
 func TestImageList(t *testing.T) {
 	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
 		cmd := info.configuredCmd
 		dir := fs.NewDir(t, "")
 		defer dir.Remove()
 
-		// Push an application so that we can later pull it by digest
-		cmd.Command = dockerCli.Command("app", "push", "--tag", info.registryAddress+"/c-myapp", filepath.Join("testdata", "push-pull", "push-pull.dockerapp"))
-		r := icmd.RunCmd(cmd).Assert(t, icmd.Success)
-
-		// Get the digest from the output of the pull command
-		out := r.Stdout()
-		matches := reg.FindAllStringSubmatch(out, 1)
-		digest := matches[0][1]
-
-		// Pull the app by digest
-		cmd.Command = dockerCli.Command("app", "pull", info.registryAddress+"/c-myapp@"+digest)
-		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-
-		cmd.Command = dockerCli.Command("app", "bundle", filepath.Join("testdata", "simple", "simple.dockerapp"), "--tag", "b-simple-app", "--output", dir.Join("simple-bundle.json"))
-		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		cmd.Command = dockerCli.Command("app", "bundle", filepath.Join("testdata", "simple", "simple.dockerapp"), "--tag", "a-simple-app", "--output", dir.Join("simple-bundle.json"))
-		icmd.RunCmd(cmd).Assert(t, icmd.Success)
+		insertBundles(t, cmd, dir, info)
 
 		expectedOutput := fmt.Sprintf(expected, info.registryAddress+"/c-myapp")
+		cmd.Command = dockerCli.Command("app", "image", "ls")
+		result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
+		assert.Equal(t, result.Stdout(), expectedOutput)
+	})
+}
+
+func TestImageRm(t *testing.T) {
+	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
+		cmd := info.configuredCmd
+		dir := fs.NewDir(t, "")
+		defer dir.Remove()
+
+		digest := insertBundles(t, cmd, dir, info)
+
+		cmd.Command = dockerCli.Command("app", "image", "rm", info.registryAddress+"/c-myapp@"+digest)
+		icmd.RunCmd(cmd).Assert(t, icmd.Success)
+
+		cmd.Command = dockerCli.Command("app", "image", "rm", "a-simple-app:latest", "b-simple-app:latest")
+		icmd.RunCmd(cmd).Assert(t, icmd.Success)
+
+		expectedOutput := "REPOSITORY TAG APP NAME\n"
 		cmd.Command = dockerCli.Command("app", "image", "ls")
 		result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
 		assert.Equal(t, result.Stdout(), expectedOutput)

--- a/internal/commands/image/command.go
+++ b/internal/commands/image/command.go
@@ -12,7 +12,10 @@ func Cmd(dockerCli command.Cli) *cobra.Command {
 		Use:   "image",
 	}
 
-	cmd.AddCommand(listCmd(dockerCli))
+	cmd.AddCommand(
+		listCmd(dockerCli),
+		rmCmd(),
+	)
 
 	return cmd
 }

--- a/internal/commands/image/rm.go
+++ b/internal/commands/image/rm.go
@@ -1,0 +1,58 @@
+package image
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/docker/app/internal/store"
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/distribution/reference"
+	"github.com/spf13/cobra"
+)
+
+func rmCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rm [APP_IMAGE] [APP_IMAGE...]",
+		Short: "Remove an application image",
+		Args:  cli.RequiresMinArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			appstore, err := store.NewApplicationStore(config.Dir())
+			if err != nil {
+				return err
+			}
+
+			bundleStore, err := appstore.BundleStore()
+			if err != nil {
+				return err
+			}
+
+			errs := []string{}
+			for _, arg := range args {
+				if err := runRm(bundleStore, arg); err != nil {
+					errs = append(errs, fmt.Sprintf("Error: %s", err))
+				}
+			}
+			if len(errs) > 0 {
+				return errors.New(strings.Join(errs, "\n"))
+			}
+			return nil
+		},
+	}
+}
+
+func runRm(bundleStore store.BundleStore, app string) error {
+	ref, err := reference.ParseNormalizedNamed(app)
+	if err != nil {
+		return err
+	}
+
+	err = bundleStore.Remove(ref)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Deleted: " + ref.String())
+	return nil
+}

--- a/internal/store/bundle.go
+++ b/internal/store/bundle.go
@@ -24,6 +24,7 @@ type BundleStore interface {
 	Store(ref reference.Named, bndle *bundle.Bundle) error
 	Read(ref reference.Named) (*bundle.Bundle, error)
 	List() ([]reference.Named, error)
+	Remove(ref reference.Named) error
 
 	LookupOrPullBundle(ref reference.Named, pullRef bool, config *configfile.ConfigFile, insecureRegistries []string) (*bundle.Bundle, error)
 }
@@ -95,6 +96,20 @@ func (b *bundleStore) List() ([]reference.Named, error) {
 	})
 
 	return references, nil
+}
+
+// Remove removes a bundle from the bundle store.
+func (b *bundleStore) Remove(ref reference.Named) error {
+	path, err := b.storePath(ref)
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return errors.New("no such image " + ref.String())
+	}
+
+	return os.Remove(path)
 }
 
 // LookupOrPullBundle will fetch the given bundle from the local

--- a/internal/store/bundle_test.go
+++ b/internal/store/bundle_test.go
@@ -233,3 +233,49 @@ func TestList(t *testing.T) {
 		assert.Equal(t, bundles[1].String(), "docker.io/my-repo/b-bundle@sha256:"+testSha)
 	})
 }
+
+func TestRemove(t *testing.T) {
+	dockerConfigDir := fs.NewDir(t, t.Name(), fs.WithMode(0755))
+	defer dockerConfigDir.Remove()
+	appstore, err := NewApplicationStore(dockerConfigDir.Path())
+	assert.NilError(t, err)
+	bundleStore, err := appstore.BundleStore()
+	assert.NilError(t, err)
+
+	refs := []reference.Named{
+		parseRefOrDie(t, "my-repo/a-bundle:my-tag"),
+		parseRefOrDie(t, "my-repo/b-bundle@sha256:"+testSha),
+	}
+
+	bndl := &bundle.Bundle{Name: "bundle-name"}
+	for _, ref := range refs {
+		err = bundleStore.Store(ref, bndl)
+		assert.NilError(t, err)
+	}
+
+	t.Run("error on unknown", func(t *testing.T) {
+		err := bundleStore.Remove(parseRefOrDie(t, "my-repo/some-bundle:1.0.0"))
+		assert.Equal(t, err.Error(), "no such image docker.io/my-repo/some-bundle:1.0.0")
+	})
+
+	t.Run("remove tagged and digested", func(t *testing.T) {
+		bundles, err := bundleStore.List()
+		assert.NilError(t, err)
+		assert.Equal(t, len(bundles), 2)
+
+		err = bundleStore.Remove(refs[0])
+
+		// Once removed there should be none left
+		assert.NilError(t, err)
+		bundles, err = bundleStore.List()
+		assert.NilError(t, err)
+		assert.Equal(t, len(bundles), 1)
+
+		err = bundleStore.Remove(refs[1])
+		assert.NilError(t, err)
+
+		bundles, err = bundleStore.List()
+		assert.NilError(t, err)
+		assert.Equal(t, len(bundles), 0)
+	})
+}


### PR DESCRIPTION
**- What I did**

Added a new comand to remove application images, example:

```bash
$ docker app image ls
REPOSITORY TAG   APP NAME
my-app     1.0.0 voting-app
my-app     1.0.1 voting-app

$ docker app image rm my-app:1.0.0 my-app:1.0.1 my-app:2.0.0
Deleted: docker.io/library/my-app:1.0.0
Deleted: docker.io/library/my-app:1.0.1
Error: no such image docker.io/library/my-app:2.0.0

$ docker app image ls
REPOSITORY TAG APP NAME
```

**- How I did it**

The `image rm` command only remove the bundle from the bundle store, container images are not touched

**- How to verify it**

Look at the e2e test to see sample usage.

**- Description for the changelog**
New subcommand `docker app image rm` to remove a docker application from the local bundle store.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/65779813-c1fd2b00-e148-11e9-81b1-c88c96a1e640.png)

