### PR TITLE
Ignore unknown files on image ls

### DIFF
--- a/internal/store/bundle.go
+++ b/internal/store/bundle.go
@@ -75,7 +75,7 @@ func (b *bundleStore) List() ([]reference.Named, error) {
 		}
 
 		if !strings.HasSuffix(info.Name(), ".json") {
-			return fmt.Errorf("unknown file %q in bundle store", path)
+			return nil
 		}
 
 		ref, err := b.pathToReference(path)

--- a/internal/store/bundle_test.go
+++ b/internal/store/bundle_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -231,5 +232,15 @@ func TestList(t *testing.T) {
 		assert.Equal(t, len(bundles), 2)
 		assert.Equal(t, bundles[0].String(), "docker.io/my-repo/a-bundle:my-tag")
 		assert.Equal(t, bundles[1].String(), "docker.io/my-repo/b-bundle@sha256:"+testSha)
+	})
+
+	t.Run("Ignores unknown files in the bundle store", func(t *testing.T) {
+		p := path.Join(dockerConfigDir.Path(), AppConfigDirectory, BundleStoreDirectory)
+		//nolint:errcheck
+		os.OpenFile(path.Join(p, "filename"), os.O_CREATE, 06444)
+
+		bundles, err := bundleStore.List()
+		assert.NilError(t, err)
+		assert.Equal(t, len(bundles), 2)
 	})
 }


### PR DESCRIPTION
When a user opens the bundles directory with Finder it will add the junk
file .DS_Store, this makes docker app image ls fail.
With this change we silently ignore unknown files in the bundle store.

**- What I did**

Removed the check for .json files

**- How to verify it**

Open the bundle store in Finder (or add a file in the bundle store) and execute `docker app image ls`.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/65870213-f6a4f880-e37b-11e9-8ec4-bc34d98810a4.png)


