### PR TITLE
Better error messages when using unsupported compose file syntax

### DIFF
--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -136,7 +136,7 @@ func pushInvocationImage(dockerCli command.Cli, retag retagResult) error {
 func pushBundle(dockerCli command.Cli, opts pushOptions, bndl *bundle.Bundle, retag retagResult) error {
 	insecureRegistries, err := insecureRegistriesFromEngine(dockerCli)
 	if err != nil {
-		return errors.Wrap(err, "could not retrive insecure registries")
+		return errors.Wrap(err, "could not retrieve insecure registries")
 	}
 	resolver := remotes.CreateResolver(dockerCli.ConfigFile(), insecureRegistries...)
 	var display fixupDisplay = &plainDisplay{out: os.Stdout}

--- a/render/render.go
+++ b/render/render.go
@@ -77,11 +77,11 @@ func substituteParams(allParameters map[string]string, composeContent string) (s
 		}
 		//fail on default values enclosed within {}
 		if fail := groups["defvals"]; fail != "" {
-			return "", errors.Errorf("The default value syntax of compose file is not supported in Docker App. "+
+			return "", errors.Errorf("The default value syntax of Compose files is not supported in Docker App. "+
 				"The characters ':' and '-' are not allowed in parameter names. Invalid parameter: %s.", match[0])
 		}
 		if fail := groups["errormsg"]; fail != "" {
-			return "", errors.Errorf("The custom error message syntax of compose file is not supported in Docker App. "+
+			return "", errors.Errorf("The custom error message syntax of Compose files is not supported in Docker App. "+
 				"The characters ':' and '?' are not allowed in parameter names. Invalid parameter: %s.", match[0])
 		}
 		if skip := groups["skip"]; skip != "" {

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -83,7 +83,7 @@ services:
 	userParameters := map[string]string{
 		"front.port": "4242",
 	}
-	checkRenderError(t, userParameters, composeFile, "The default value syntax of compose file is not supported in Docker App. "+
+	checkRenderError(t, userParameters, composeFile, "The default value syntax of Compose files is not supported in Docker App. "+
 		"The characters ':' and '-' are not allowed in parameter names. Invalid parameter: ${front.port:-9090}.")
 
 	composeFile = `
@@ -93,7 +93,7 @@ services:
 	ports:
 		- "${front.port-9090}:80"
 	`
-	checkRenderError(t, userParameters, composeFile, "The default value syntax of compose file is not supported in Docker App. "+
+	checkRenderError(t, userParameters, composeFile, "The default value syntax of Compose files is not supported in Docker App. "+
 		"The characters ':' and '-' are not allowed in parameter names. Invalid parameter: ${front.port-9090}.")
 	composeFile = `
 version: "3.6"
@@ -102,7 +102,7 @@ services:
 	ports:
 		- "${front.port:?Error}:80"
 	`
-	checkRenderError(t, userParameters, composeFile, "The custom error message syntax of compose file is not supported in Docker App. "+
+	checkRenderError(t, userParameters, composeFile, "The custom error message syntax of Compose files is not supported in Docker App. "+
 		"The characters ':' and '?' are not allowed in parameter names. Invalid parameter: ${front.port:?Error}.")
 
 	composeFile = `
@@ -112,7 +112,7 @@ services:
 	ports:
 		- "${front.port?Error:unset variable}:80"
 	`
-	checkRenderError(t, userParameters, composeFile, "The custom error message syntax of compose file is not supported in Docker App. "+
+	checkRenderError(t, userParameters, composeFile, "The custom error message syntax of Compose files is not supported in Docker App. "+
 		"The characters ':' and '?' are not allowed in parameter names. Invalid parameter: ${front.port?Error:unset variable}.")
 
 }

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -83,7 +83,8 @@ services:
 	userParameters := map[string]string{
 		"front.port": "4242",
 	}
-	checkRenderError(t, userParameters, composeFile, "Parameters must not have default values set in compose file. Invalid parameter: ${front.port:-9090}.")
+	checkRenderError(t, userParameters, composeFile, "The default value syntax of compose file is not supported in Docker App. "+
+		"The characters ':' and '-' are not allowed in parameter names. Invalid parameter: ${front.port:-9090}.")
 
 	composeFile = `
 version: "3.6"
@@ -92,7 +93,8 @@ services:
 	ports:
 		- "${front.port-9090}:80"
 	`
-	checkRenderError(t, userParameters, composeFile, "Parameters must not have default values set in compose file. Invalid parameter: ${front.port-9090}.")
+	checkRenderError(t, userParameters, composeFile, "The default value syntax of compose file is not supported in Docker App. "+
+		"The characters ':' and '-' are not allowed in parameter names. Invalid parameter: ${front.port-9090}.")
 	composeFile = `
 version: "3.6"
 services:
@@ -100,7 +102,8 @@ services:
 	ports:
 		- "${front.port:?Error}:80"
 	`
-	checkRenderError(t, userParameters, composeFile, "Parameters must not have default values set in compose file. Invalid parameter: ${front.port:?Error}.")
+	checkRenderError(t, userParameters, composeFile, "The custom error message syntax of compose file is not supported in Docker App. "+
+		"The characters ':' and '?' are not allowed in parameter names. Invalid parameter: ${front.port:?Error}.")
 
 	composeFile = `
 version: "3.6"
@@ -109,7 +112,8 @@ services:
 	ports:
 		- "${front.port?Error:unset variable}:80"
 	`
-	checkRenderError(t, userParameters, composeFile, "Parameters must not have default values set in compose file. Invalid parameter: ${front.port?Error:unset variable}.")
+	checkRenderError(t, userParameters, composeFile, "The custom error message syntax of compose file is not supported in Docker App. "+
+		"The characters ':' and '?' are not allowed in parameter names. Invalid parameter: ${front.port?Error:unset variable}.")
 
 }
 func TestSubstituteMixedParams(t *testing.T) {


### PR DESCRIPTION
**- What I did**
Docker App prints a more specific error messages when the template uses one of these compose file syntax
- ${VARIABLE:-default}
- ${VARIABLE-default} 
- ${VARIABLE:?err} 
- ${VARIABLE?err}

**- A picture of a cute animal (not mandatory but encouraged)**
![Hawaiian_bobtail_squid04 img_assist_custom](https://user-images.githubusercontent.com/470082/65892091-fe799280-e3a5-11e9-9803-adc97baf6bd1.jpg)

