### PR TITLE
image rm small fixes

### DIFF
--- a/e2e/images_test.go
+++ b/e2e/images_test.go
@@ -66,10 +66,23 @@ func TestImageRm(t *testing.T) {
 		digest := insertBundles(t, cmd, dir, info)
 
 		cmd.Command = dockerCli.Command("app", "image", "rm", info.registryAddress+"/c-myapp@"+digest)
-		icmd.RunCmd(cmd).Assert(t, icmd.Success)
+		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+			ExitCode: 0,
+			Out:      "Deleted: " + info.registryAddress + "/c-myapp@" + digest,
+		})
 
-		cmd.Command = dockerCli.Command("app", "image", "rm", "a-simple-app:latest", "b-simple-app:latest")
-		icmd.RunCmd(cmd).Assert(t, icmd.Success)
+		cmd.Command = dockerCli.Command("app", "image", "rm", "a-simple-app", "b-simple-app:latest")
+		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+			ExitCode: 0,
+			Out: `Deleted: a-simple-app:latest
+Deleted: b-simple-app:latest`,
+		})
+
+		cmd.Command = dockerCli.Command("app", "image", "rm", "b-simple-app")
+		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      `Error: no such image b-simple-app:latest`,
+		})
 
 		expectedOutput := "REPOSITORY TAG APP NAME\n"
 		cmd.Command = dockerCli.Command("app", "image", "ls")

--- a/internal/commands/image/rm.go
+++ b/internal/commands/image/rm.go
@@ -17,6 +17,9 @@ func rmCmd() *cobra.Command {
 		Use:   "rm [APP_IMAGE] [APP_IMAGE...]",
 		Short: "Remove an application image",
 		Args:  cli.RequiresMinArgs(1),
+		Example: `$ docker app image rm myapp
+$ docker app image rm myapp:1.0.0
+$ docker app image rm docker.io/library/myapp@sha256:beef...`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appstore, err := store.NewApplicationStore(config.Dir())
 			if err != nil {
@@ -48,11 +51,11 @@ func runRm(bundleStore store.BundleStore, app string) error {
 		return err
 	}
 
-	err = bundleStore.Remove(ref)
-	if err != nil {
+	tagged := reference.TagNameOnly(ref)
+	if err := bundleStore.Remove(tagged); err != nil {
 		return err
 	}
 
-	fmt.Println("Deleted: " + ref.String())
+	fmt.Println("Deleted: " + reference.FamiliarString(tagged))
 	return nil
 }

--- a/internal/store/bundle.go
+++ b/internal/store/bundle.go
@@ -106,7 +106,7 @@ func (b *bundleStore) Remove(ref reference.Named) error {
 	}
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return errors.New("no such image " + ref.String())
+		return errors.New("no such image " + reference.FamiliarString(ref))
 	}
 
 	return os.Remove(path)

--- a/internal/store/bundle_test.go
+++ b/internal/store/bundle_test.go
@@ -266,7 +266,7 @@ func TestRemove(t *testing.T) {
 
 	t.Run("error on unknown", func(t *testing.T) {
 		err := bundleStore.Remove(parseRefOrDie(t, "my-repo/some-bundle:1.0.0"))
-		assert.Equal(t, err.Error(), "no such image docker.io/my-repo/some-bundle:1.0.0")
+		assert.Equal(t, err.Error(), "no such image my-repo/some-bundle:1.0.0")
 	})
 
 	t.Run("remove tagged and digested", func(t *testing.T) {


### PR DESCRIPTION
**- What I did**

* added example usages for image rm
* made the output nicer for the user (no domain for the reference, only repo:tag)
* image rm adds the `latest` tag if none given

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/65951409-506ef680-e440-11e9-9e33-e53525df6877.png)

