### PR TITLE
Bump vendored docker/cli

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -226,7 +226,7 @@
   version = "v0.3.2-beta1"
 
 [[projects]]
-  digest = "1:5f5253dd1a588922925933e105c1de2d1a221cf0aa42d5c08549a12d93493024"
+  digest = "1:bc88d135d4f5d9a0968a213b3b2d786d1e216b9f10c30720f4d0d4976346732b"
   name = "github.com/docker/cli"
   packages = [
     "cli",
@@ -281,7 +281,7 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "83751b978155dc889c35e0e49654f76e7cf8d951"
+  revision = "d83cd90464377d4164c8f70248d064b979e5ca98"
 
 [[projects]]
   digest = "1:47edc537d608c0ad4ef8e9cebfec7c74ccc0986af115ff53ea26b18b4605a878"
@@ -340,7 +340,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:83ede099909456cf1f5d6de21e5108b1ea593d5d33859799bfa7d8e575281a3c"
+  digest = "1:315760c1c8784622f910cee4dbf9e9e670188f8b13971d839bca75b926fe52dd"
   name = "github.com/docker/docker"
   packages = [
     "api",
@@ -1041,12 +1041,12 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:62a00229c3bc24945de91bc7050e8bc8d19fce15e6fdc29760c8d2fff4790d74"
+  digest = "1:c0ce856ee6874fc944d5ee7ceb6c374321e027287c73a33b4c5fad666aedb3ea"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "c86e64ed9581b7588e736f0c3e6ecc02cc22996e"
-  source = "https://github.com/simonferquel/yaml"
+  revision = "bb4e33bf68bf89cad44d386192cbed201f35b241"
+  version = "v2.2.3"
 
 [[projects]]
   digest = "1:9d7d5988129436e49ee34d17bf0229065f9c45e6fc85cad160464bd488dcacca"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,7 @@ required = ["github.com/wadey/gocovmerge"]
 
 [[override]]
   name = "github.com/docker/cli"
-  revision = "83751b978155dc889c35e0e49654f76e7cf8d951"
+  revision = "d83cd90464377d4164c8f70248d064b979e5ca98"
 
 [[override]]
   name = "github.com/deislabs/cnab-go"
@@ -95,13 +95,6 @@ required = ["github.com/wadey/gocovmerge"]
 [[override]]
   name = "k8s.io/client-go"
   revision = "kubernetes-1.14.1"
-
-# This is using a fork waiting for go-yaml/yaml#375 to be merged
-# This PR allows to set a max decoded value, thus not being exposed to yaml bombs
-[[override]]
-  name = "gopkg.in/yaml.v2"
-  source = "https://github.com/simonferquel/yaml"
-  revision = "c86e64ed9581b7588e736f0c3e6ecc02cc22996e"
 
 [[override]]
   name = "github.com/opencontainers/runtime-spec"

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -7,16 +7,12 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const (
-	maxDecodedValues = 1000000
-)
-
 // Unmarshal decodes the first document found within the in byte slice
 // and assigns decoded values into the out value.
 //
 // See gopkg.in/yaml.v2 documentation
 func Unmarshal(in []byte, out interface{}) error {
-	d := yaml.NewDecoder(bytes.NewBuffer(in), yaml.WithLimitDecodedValuesCount(maxDecodedValues))
+	d := yaml.NewDecoder(bytes.NewBuffer(in))
 	err := d.Decode(out)
 	if err == io.EOF {
 		return nil
@@ -37,5 +33,5 @@ func Marshal(in interface{}) ([]byte, error) {
 //
 // See gopkg.in/yaml.v2 documentation
 func NewDecoder(r io.Reader) *yaml.Decoder {
-	return yaml.NewDecoder(r, yaml.WithLimitDecodedValuesCount(maxDecodedValues))
+	return yaml.NewDecoder(r)
 }

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -21,7 +21,7 @@ h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
 i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]`)
 	d := NewDecoder(bytes.NewBuffer(data))
 	err := d.Decode(&v)
-	assert.ErrorContains(t, err, "yaml: exceeded max number of decoded values (1000000)")
+	assert.ErrorContains(t, err, "yaml: document contains excessive aliasing")
 }
 
 func TestUnmarshalYamlBomb(t *testing.T) {
@@ -37,5 +37,5 @@ g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
 h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
 i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]`)
 	err := Unmarshal(data, &v)
-	assert.ErrorContains(t, err, "yaml: exceeded max number of decoded values (1000000)")
+	assert.ErrorContains(t, err, "yaml: document contains excessive aliasing")
 }

--- a/vendor/github.com/docker/cli/cli/config/config.go
+++ b/vendor/github.com/docker/cli/cli/config/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/cli/config/types"
-	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
 )
 
@@ -28,7 +27,10 @@ var (
 
 func init() {
 	if configDir == "" {
-		configDir = filepath.Join(homedir.Get(), configFileDir)
+		homedir, err := os.UserHomeDir()
+		if err == nil {
+			configDir = filepath.Join(homedir, configFileDir)
+		}
 	}
 }
 
@@ -106,7 +108,11 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 	}
 
 	// Can't find latest config file so check for the old one
-	confFile := filepath.Join(homedir.Get(), oldConfigfile)
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return configFile, errors.Wrap(err, oldConfigfile)
+	}
+	confFile := filepath.Join(homedir, oldConfigfile)
 	if _, err := os.Stat(confFile); err != nil {
 		return configFile, nil //missing file is not an error
 	}

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -81,7 +81,7 @@ func resolvableTag(tag string) bool {
 	return false
 }
 
-var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
+var yamlStyleFloat = regexp.MustCompile(`^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$`)
 
 func resolve(tag string, in string) (rtag string, out interface{}) {
 	if !resolvableTag(tag) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This allows us to rely on the upstream `yaml.v2` library as it includes a mitigation for malicious YAML files.

Related issue: https://github.com/kubernetes/kubernetes/issues/83253

**- How I did it**
* Bump `docker/cli` in `Gopkg.toml`
* Run `make vendor`

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

