### PR TITLE
Add specific error message for image tag cmd

### DIFF
--- a/e2e/images_test.go
+++ b/e2e/images_test.go
@@ -141,6 +141,20 @@ a-simple-app:latest simple
 			Err:      `could not parse 'b@simple-app' as a valid reference: invalid reference format`,
 		})
 
+		// with unexisting source image
+		dockerAppImageTag("b-simple-app", "target")
+		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      `could not tag 'b-simple-app': no such application image`,
+		})
+
+		// with unexisting source tag
+		dockerAppImageTag("a-simple-app:not-a-tag", "target")
+		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      `could not tag 'a-simple-app:not-a-tag': no such application image`,
+		})
+
 		// tag image with only names
 		dockerAppImageTag("a-simple-app", "b-simple-app")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)

--- a/internal/commands/image/tag.go
+++ b/internal/commands/image/tag.go
@@ -49,7 +49,11 @@ func readBundle(name string, bundleStore store.BundleStore) (*bundle.Bundle, err
 		return nil, err
 	}
 
-	return bundleStore.Read(cnabRef)
+	bundle, err := bundleStore.Read(cnabRef)
+	if err != nil {
+		return nil, fmt.Errorf("could not tag '%s': no such application image", name)
+	}
+	return bundle, nil
 }
 
 func storeBundle(bundle *bundle.Bundle, name string, bundleStore store.BundleStore) error {


### PR DESCRIPTION
**- What I did**

Improve the UX by displaying a better error message when trying to tag an
image/tag that doesn't exist.

**- How I did it**

Wrap the `bundleStore` access to output a dedicated error message.

**- How to verify it**

`docker app image tag image_that_doesnt_exist test`

`docker app image tag image_that_exists:not-a-tag test`