### PR TITLE
Add a json output as default for app inspect

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -170,9 +170,7 @@ func TestInspectApp(t *testing.T) {
 	cmd.Command = dockerCli.Command("app", "inspect", "simple-app:1.0.0")
 	cmd.Dir = dir.Path()
 	output := icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined()
-	fmt.Println(output)
 	golden.Assert(t, output, "app-inspect.golden")
-
 }
 
 func TestBundle(t *testing.T) {

--- a/e2e/pushpull_test.go
+++ b/e2e/pushpull_test.go
@@ -145,7 +145,7 @@ func TestPushInstall(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "push", "--tag", ref, filepath.Join("testdata", "push-pull", "push-pull.dockerapp"))
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-		cmd.Command = dockerCli.Command("app", "install", ref, "--name", t.Name())
+		cmd.Command = dockerCli.Command("app", "install", ref, "--pull", "--name", t.Name())
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 		cmd.Command = dockerCli.Command("service", "ls")
 		assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref))
@@ -203,7 +203,7 @@ func TestPushInstallBundle(t *testing.T) {
 			cmd.Command = dockerCli.Command("app", "push", "--tag", ref, bundleFile)
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-			cmd.Command = dockerCli.Command("app", "install", ref, "--name", name)
+			cmd.Command = dockerCli.Command("app", "install", ref, "--pull", "--name", name)
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 			cmd.Command = dockerCli.Command("service", "ls")
 			assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref))
@@ -223,7 +223,7 @@ func TestPushInstallBundle(t *testing.T) {
 			cmd.Command = dockerCli.Command("app", "push", "--tag", ref2, ref+":latest")
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-			cmd.Command = dockerCli.Command("app", "install", ref2, "--name", name)
+			cmd.Command = dockerCli.Command("app", "install", ref2, "--pull", "--name", name)
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 			cmd.Command = dockerCli.Command("service", "ls")
 			assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref2))
@@ -250,7 +250,7 @@ func TestPushInstallBundle(t *testing.T) {
 			// remove the bundle from the bundle store to be sure it won't be used instead of registry
 			cleanupIsolatedStore()
 			// install from the registry
-			cmd.Command = dockerCli.Command("app", "install", ref2, "--name", name)
+			cmd.Command = dockerCli.Command("app", "install", ref2, "--pull", "--name", name)
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 			cmd.Command = dockerCli.Command("service", "ls")
 			assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref))

--- a/e2e/testdata/app-inspect.golden
+++ b/e2e/testdata/app-inspect.golden
@@ -18,22 +18,17 @@
         {
             "Name": "api",
             "Image": "python:3.6",
-            "Replicas": 1,
-            "Mode": "",
-            "Ports": ""
+            "Replicas": 1
         },
         {
             "Name": "db",
             "Image": "postgres:9.3",
-            "Replicas": 1,
-            "Mode": "",
-            "Ports": ""
+            "Replicas": 1
         },
         {
             "Name": "web",
             "Image": "nginx:latest",
             "Replicas": 1,
-            "Mode": "",
             "Ports": "8082"
         }
     ],
@@ -44,11 +39,9 @@
     "Volumes": [
         "static"
     ],
-    "Secrets": [],
     "Parameters": {
         "api_host": "example.com",
         "static_subdir": "data/static",
         "web_port": "8082"
-    },
-    "Attachments": []
+    }
 }

--- a/e2e/testdata/app-inspect.golden
+++ b/e2e/testdata/app-inspect.golden
@@ -1,0 +1,54 @@
+{
+    "Metadata": {
+        "version": "1.1.0-beta1",
+        "name": "simple",
+        "description": "new fancy webapp with microservices",
+        "maintainers": [
+            {
+                "name": "John Developer",
+                "email": "john.dev@example.com"
+            },
+            {
+                "name": "Jane Developer",
+                "email": "jane.dev@example.com"
+            }
+        ]
+    },
+    "Services": [
+        {
+            "Name": "api",
+            "Image": "python:3.6",
+            "Replicas": 1,
+            "Mode": "",
+            "Ports": ""
+        },
+        {
+            "Name": "db",
+            "Image": "postgres:9.3",
+            "Replicas": 1,
+            "Mode": "",
+            "Ports": ""
+        },
+        {
+            "Name": "web",
+            "Image": "nginx:latest",
+            "Replicas": 1,
+            "Mode": "",
+            "Ports": "8082"
+        }
+    ],
+    "Networks": [
+        "back",
+        "front"
+    ],
+    "Volumes": [
+        "static"
+    ],
+    "Secrets": [],
+    "Parameters": {
+        "api_host": "example.com",
+        "static_subdir": "data/static",
+        "web_port": "8082"
+    },
+    "Attachments": []
+}

--- a/e2e/testdata/bundle-with-tag.json.golden
+++ b/e2e/testdata/bundle-with-tag.json.golden
@@ -52,6 +52,15 @@
 				"env": "docker_param1"
 			}
 		},
+		"com.docker.app.inspect-format": {
+			"definition": "com.docker.app.inspect-format",
+			"applyTo": [
+				"com.docker.app.inspect"
+			],
+			"destination": {
+				"env": "DOCKER_INSPECT_FORMAT"
+			}
+		},
 		"com.docker.app.kubernetes-namespace": {
 			"definition": "com.docker.app.kubernetes-namespace",
 			"applyTo": [
@@ -115,6 +124,16 @@
 	"definitions": {
 		"api_host": {
 			"default": "example.com",
+			"type": "string"
+		},
+		"com.docker.app.inspect-format": {
+			"default": "json",
+			"description": "Output format for the inspect command",
+			"enum": [
+				"json",
+				"pretty"
+			],
+			"title": "Inspect format",
 			"type": "string"
 		},
 		"com.docker.app.kubernetes-namespace": {

--- a/e2e/testdata/simple-bundle.json.golden
+++ b/e2e/testdata/simple-bundle.json.golden
@@ -52,6 +52,15 @@
 				"env": "docker_param1"
 			}
 		},
+		"com.docker.app.inspect-format": {
+			"definition": "com.docker.app.inspect-format",
+			"applyTo": [
+				"com.docker.app.inspect"
+			],
+			"destination": {
+				"env": "DOCKER_INSPECT_FORMAT"
+			}
+		},
 		"com.docker.app.kubernetes-namespace": {
 			"definition": "com.docker.app.kubernetes-namespace",
 			"applyTo": [
@@ -115,6 +124,16 @@
 	"definitions": {
 		"api_host": {
 			"default": "example.com",
+			"type": "string"
+		},
+		"com.docker.app.inspect-format": {
+			"default": "json",
+			"description": "Output format for the inspect command",
+			"enum": [
+				"json",
+				"pretty"
+			],
+			"title": "Inspect format",
 			"type": "string"
 		},
 		"com.docker.app.kubernetes-namespace": {

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
-	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -36,15 +35,7 @@ func runPull(dockerCli command.Cli, name string) error {
 		return err
 	}
 
-	ref, err := reference.ParseNormalizedNamed(name)
-	if err != nil {
-		return errors.Wrap(err, name)
-	}
-	insecureRegistries, err := insecureRegistriesFromEngine(dockerCli)
-	if err != nil {
-		return errors.Wrap(err, "could not retrieve insecure registries")
-	}
-	bndl, err := bundleStore.LookupOrPullBundle(reference.TagNameOnly(ref), true, dockerCli.ConfigFile(), insecureRegistries)
+	bndl, ref, err := getLocalBundle(dockerCli, bundleStore, name, true)
 	if err != nil {
 		return errors.Wrap(err, name)
 	}

--- a/internal/inspect/testdata/inspect-full-json.golden
+++ b/internal/inspect/testdata/inspect-full-json.golden
@@ -1,0 +1,51 @@
+{
+    "Metadata": {
+        "version": "0.1.0",
+        "name": "myapp",
+        "description": "some description",
+        "maintainers": [
+            {
+                "name": "dev",
+                "email": "dev@example.com"
+            }
+        ]
+    },
+    "Services": [
+        {
+            "Name": "web1",
+            "Image": "nginx:latest",
+            "Replicas": 2,
+            "Mode": "",
+            "Ports": "8080-8100"
+        },
+        {
+            "Name": "web2",
+            "Image": "nginx:latest",
+            "Replicas": 2,
+            "Mode": "",
+            "Ports": "9080-9100"
+        }
+    ],
+    "Networks": [
+        "my-network1",
+        "my-network2"
+    ],
+    "Volumes": [
+        "my-volume1",
+        "my-volume2"
+    ],
+    "Secrets": [
+        "my-secret1",
+        "my-secret2"
+    ],
+    "Parameters": {
+        "port": "8080",
+        "text": "hello"
+    },
+    "Attachments": [
+        {
+            "Path": "config.cfg",
+            "Size": 9
+        }
+    ]
+}

--- a/internal/inspect/testdata/inspect-full-json.golden
+++ b/internal/inspect/testdata/inspect-full-json.golden
@@ -15,14 +15,12 @@
             "Name": "web1",
             "Image": "nginx:latest",
             "Replicas": 2,
-            "Mode": "",
             "Ports": "8080-8100"
         },
         {
             "Name": "web2",
             "Image": "nginx:latest",
             "Replicas": 2,
-            "Mode": "",
             "Ports": "9080-9100"
         }
     ],

--- a/internal/inspect/testdata/inspect-no-description-json.golden
+++ b/internal/inspect/testdata/inspect-no-description-json.golden
@@ -8,11 +8,5 @@
                 "email": "dev@example.com"
             }
         ]
-    },
-    "Services": [],
-    "Networks": [],
-    "Volumes": [],
-    "Secrets": [],
-    "Parameters": {},
-    "Attachments": []
+    }
 }

--- a/internal/inspect/testdata/inspect-no-description-json.golden
+++ b/internal/inspect/testdata/inspect-no-description-json.golden
@@ -1,0 +1,18 @@
+{
+    "Metadata": {
+        "version": "0.1.0",
+        "name": "myapp",
+        "maintainers": [
+            {
+                "name": "dev",
+                "email": "dev@example.com"
+            }
+        ]
+    },
+    "Services": [],
+    "Networks": [],
+    "Volumes": [],
+    "Secrets": [],
+    "Parameters": {},
+    "Attachments": []
+}

--- a/internal/inspect/testdata/inspect-no-maintainers-json.golden
+++ b/internal/inspect/testdata/inspect-no-maintainers-json.golden
@@ -2,11 +2,5 @@
     "Metadata": {
         "version": "0.1.0",
         "name": "myapp"
-    },
-    "Services": [],
-    "Networks": [],
-    "Volumes": [],
-    "Secrets": [],
-    "Parameters": {},
-    "Attachments": []
+    }
 }

--- a/internal/inspect/testdata/inspect-no-maintainers-json.golden
+++ b/internal/inspect/testdata/inspect-no-maintainers-json.golden
@@ -1,0 +1,12 @@
+{
+    "Metadata": {
+        "version": "0.1.0",
+        "name": "myapp"
+    },
+    "Services": [],
+    "Networks": [],
+    "Volumes": [],
+    "Secrets": [],
+    "Parameters": {},
+    "Attachments": []
+}

--- a/internal/inspect/testdata/inspect-no-parameters-json.golden
+++ b/internal/inspect/testdata/inspect-no-parameters-json.golden
@@ -1,0 +1,19 @@
+{
+    "Metadata": {
+        "version": "0.1.0",
+        "name": "myapp",
+        "description": "some description",
+        "maintainers": [
+            {
+                "name": "dev",
+                "email": "dev@example.com"
+            }
+        ]
+    },
+    "Services": [],
+    "Networks": [],
+    "Volumes": [],
+    "Secrets": [],
+    "Parameters": {},
+    "Attachments": []
+}

--- a/internal/inspect/testdata/inspect-no-parameters-json.golden
+++ b/internal/inspect/testdata/inspect-no-parameters-json.golden
@@ -9,11 +9,5 @@
                 "email": "dev@example.com"
             }
         ]
-    },
-    "Services": [],
-    "Networks": [],
-    "Volumes": [],
-    "Secrets": [],
-    "Parameters": {},
-    "Attachments": []
+    }
 }

--- a/internal/inspect/testdata/inspect-overridden-json.golden
+++ b/internal/inspect/testdata/inspect-overridden-json.golden
@@ -1,0 +1,22 @@
+{
+    "Metadata": {
+        "version": "0.1.0",
+        "name": "myapp"
+    },
+    "Services": [
+        {
+            "Name": "web",
+            "Image": "nginx",
+            "Replicas": 1,
+            "Mode": "",
+            "Ports": "80"
+        }
+    ],
+    "Networks": [],
+    "Volumes": [],
+    "Secrets": [],
+    "Parameters": {
+        "web.port": "80"
+    },
+    "Attachments": []
+}

--- a/internal/inspect/testdata/inspect-overridden-json.golden
+++ b/internal/inspect/testdata/inspect-overridden-json.golden
@@ -8,15 +8,10 @@
             "Name": "web",
             "Image": "nginx",
             "Replicas": 1,
-            "Mode": "",
             "Ports": "80"
         }
     ],
-    "Networks": [],
-    "Volumes": [],
-    "Secrets": [],
     "Parameters": {
         "web.port": "80"
-    },
-    "Attachments": []
+    }
 }

--- a/internal/names.go
+++ b/internal/names.go
@@ -50,9 +50,9 @@ const (
 	ParameterOrchestratorName = Namespace + "orchestrator"
 	// ParameterKubernetesNamespaceName is the name of the parameter containing the kubernetes namespace
 	ParameterKubernetesNamespaceName = Namespace + "kubernetes-namespace"
-	// ParameterRenderFormatName is the name of the parameter containing the kubernetes namespace
+	// ParameterRenderFormatName is the name of the parameter containing the render format
 	ParameterRenderFormatName = Namespace + "render-format"
-	// ParameterRenderFormatName is the name of the parameter containing the kubernetes namespace
+	// ParameterInspectFormatName is the name of the parameter containing the inspect format
 	ParameterInspectFormatName = Namespace + "inspect-format"
 	// ParameterShareRegistryCredsName is the name of the parameter which indicates if credentials should be shared
 	ParameterShareRegistryCredsName = Namespace + "share-registry-creds"
@@ -66,7 +66,8 @@ const (
 	// DockerRenderFormatEnvVar is the environment variable set by the CNAB runtime to select
 	// the render output format.
 	DockerRenderFormatEnvVar = "DOCKER_RENDER_FORMAT"
-	// DockerInspectFormatEnvVar ...
+	// DockerInspectFormatEnvVar is the environment variable set by the CNAB runtime to select
+	// the inspect output format.
 	DockerInspectFormatEnvVar = "DOCKER_INSPECT_FORMAT"
 )
 

--- a/internal/names.go
+++ b/internal/names.go
@@ -52,6 +52,8 @@ const (
 	ParameterKubernetesNamespaceName = Namespace + "kubernetes-namespace"
 	// ParameterRenderFormatName is the name of the parameter containing the kubernetes namespace
 	ParameterRenderFormatName = Namespace + "render-format"
+	// ParameterRenderFormatName is the name of the parameter containing the kubernetes namespace
+	ParameterInspectFormatName = Namespace + "inspect-format"
 	// ParameterShareRegistryCredsName is the name of the parameter which indicates if credentials should be shared
 	ParameterShareRegistryCredsName = Namespace + "share-registry-creds"
 
@@ -64,6 +66,8 @@ const (
 	// DockerRenderFormatEnvVar is the environment variable set by the CNAB runtime to select
 	// the render output format.
 	DockerRenderFormatEnvVar = "DOCKER_RENDER_FORMAT"
+	// DockerInspectFormatEnvVar ...
+	DockerInspectFormatEnvVar = "DOCKER_INSPECT_FORMAT"
 )
 
 var (

--- a/internal/packager/cnab.go
+++ b/internal/packager/cnab.go
@@ -48,6 +48,16 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 			Title:       "Render format",
 			Description: "Output format for the render command",
 		},
+		internal.ParameterInspectFormatName: {
+			Type: "string",
+			Enum: []interface{}{
+				"json",
+				"pretty",
+			},
+			Default:     "json",
+			Title:       "Inspect format",
+			Description: "Output format for the inspect command",
+		},
 		internal.ParameterShareRegistryCredsName: {
 			Type:        "boolean",
 			Default:     false,
@@ -88,6 +98,15 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 				internal.ActionRenderName,
 			},
 			Definition: internal.ParameterRenderFormatName,
+		},
+		internal.ParameterInspectFormatName: {
+			Destination: &bundle.Location{
+				EnvironmentVariable: internal.DockerInspectFormatEnvVar,
+			},
+			ApplyTo: []string{
+				internal.ActionInspectName,
+			},
+			Definition: internal.ParameterInspectFormatName,
 		},
 		internal.ParameterShareRegistryCredsName: {
 			Destination: &bundle.Location{

--- a/internal/packager/testdata/bundle-json.golden
+++ b/internal/packager/testdata/bundle-json.golden
@@ -51,6 +51,15 @@
     "io.cnab.status": {}
   },
   "parameters": {
+    "com.docker.app.inspect-format": {
+      "definition": "com.docker.app.inspect-format",
+      "applyTo": [
+        "com.docker.app.inspect"
+      ],
+      "destination": {
+        "env": "DOCKER_INSPECT_FORMAT"
+      }
+    },
     "com.docker.app.kubernetes-namespace": {
       "definition": "com.docker.app.kubernetes-namespace",
       "applyTo": [
@@ -106,6 +115,16 @@
     }
   },
   "definitions": {
+    "com.docker.app.inspect-format": {
+      "default": "json",
+      "description": "Output format for the inspect command",
+      "enum": [
+        "json",
+        "pretty"
+      ],
+      "title": "Inspect format",
+      "type": "string"
+    },
     "com.docker.app.kubernetes-namespace": {
       "default": "",
       "description": "Namespace in which to deploy",

--- a/internal/store/bundle.go
+++ b/internal/store/bundle.go
@@ -119,12 +119,7 @@ func (b *bundleStore) Remove(ref reference.Named) error {
 func (b *bundleStore) LookupOrPullBundle(ref reference.Named, pullRef bool, config *configfile.ConfigFile, insecureRegistries []string) (*bundle.Bundle, error) {
 	if !pullRef {
 		bndl, err := b.Read(ref)
-		if err == nil {
-			return bndl, nil
-		}
-		if !os.IsNotExist(errors.Cause(err)) {
-			return nil, err
-		}
+		return bndl, errors.Wrapf(err, "bundle not found")
 	}
 	bndl, err := remotes.Pull(log.WithLogContext(context.Background()), reference.TagNameOnly(ref), remotes.CreateResolver(config, insecureRegistries...))
 	if err != nil {

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -34,6 +34,14 @@ func NewInstallation(name string, reference string) (*Installation, error) {
 	}, nil
 }
 
+// SetParameters sets the parameter value if the installation bundle has
+// a defined parameter with that name.
+func (i Installation) SetParameter(name string, value string) {
+	if _, ok := i.Bundle.Parameters[name]; ok {
+		i.Parameters[name] = value
+	}
+}
+
 var _ InstallationStore = &installationStore{}
 
 type installationStore struct {


### PR DESCRIPTION
**- What I did**

Made `docker app inspect` print a json by default, added a flag `--pretty` to print the old tabular inspect.

**- How I did it**

**- How to verify it**

* bundle an app : `docker app bundle ... --tag my-app:1.0.0`
* inspect the app: `docker app inspect my-app:1.0.0`

**- Description for the changelog**
Docker app inspect now prints a json by default. Only bundled or running apps can be inspected.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/66122200-64049380-e5df-11e9-9cb7-59c5e50e8a4e.png)

