### PR TITLE
Remove completion flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,6 @@ A tool to build and manage Docker Applications.
 
 Commands:
   bundle      Create a CNAB invocation image and `bundle.json` for the application
-  completion  Generates completion scripts for the specified shell (bash or zsh)
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
   install     Install an application

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -136,7 +136,7 @@ func pushInvocationImage(dockerCli command.Cli, retag retagResult) error {
 func pushBundle(dockerCli command.Cli, opts pushOptions, bndl *bundle.Bundle, retag retagResult) error {
 	insecureRegistries, err := insecureRegistriesFromEngine(dockerCli)
 	if err != nil {
-		return errors.Wrap(err, "could not retrive insecure registries")
+		return errors.Wrap(err, "could not retrieve insecure registries")
 	}
 	resolver := remotes.CreateResolver(dockerCli.ConfigFile(), insecureRegistries...)
 	var display fixupDisplay = &plainDisplay{out: os.Stdout}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -17,7 +17,6 @@ import (
 )
 
 var (
-	completion  string
 	showVersion bool
 )
 
@@ -34,17 +33,6 @@ func NewRootCmd(use string, dockerCli command.Cli) *cobra.Command {
 				return nil
 			}
 
-			switch completion {
-			case "bash":
-				return cmd.GenBashCompletion(dockerCli.Out())
-			case "zsh":
-				return cmd.GenZshCompletion(dockerCli.Out())
-			default:
-				if completion != "" {
-					return fmt.Errorf("%q is not a supported shell\nSee 'docker app --help'", completion)
-				}
-			}
-
 			if len(args) != 0 {
 				return fmt.Errorf("%q is not a docker app command\nSee 'docker app --help'", args[0])
 			}
@@ -53,12 +41,6 @@ func NewRootCmd(use string, dockerCli command.Cli) *cobra.Command {
 		},
 	}
 	addCommands(cmd, dockerCli)
-
-	cmd.Flags().StringVar(&completion, "completion", "", "Generates completion scripts for the specified shell (bash or zsh)")
-	if err := cmd.Flags().MarkHidden("completion"); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to register command line options: %v", err.Error()) //nolint:errcheck
-		return nil
-	}
 
 	cmd.Flags().BoolVar(&showVersion, "version", false, "Print version information")
 	return cmd


### PR DESCRIPTION
**- What I did**
Remove completion flag

**- How I did it**
By removing the flag description in root command

**- How to verify it**
Run `docker app --completion zsh` and get the following error message
`unknown flag: --completion` followed by the usage message

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/705411/66133943-cf5a5f80-e5f7-11e9-84fa-e29eca494a44.png)
