### PR TITLE
[rfd] Use dockerCli.Out() / Err()

### DIFF
--- a/internal/commands/bundle.go
+++ b/internal/commands/bundle.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/app/internal/packager"
@@ -71,11 +70,11 @@ func runBundle(dockerCli command.Cli, appName string, opts bundleOptions) error 
 		_, err = dockerCli.Out().Write(bundleBytes)
 		return err
 	}
-	fmt.Fprintf(os.Stdout, "Invocation image %q successfully built\n", bundle.InvocationImages[0].Image)
+	fmt.Fprintf(dockerCli.Out(), "Invocation image %q successfully built\n", bundle.InvocationImages[0].Image)
 	if err := ioutil.WriteFile(opts.out, bundleBytes, 0644); err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stdout, "Bundle saved to %s\n", opts.out)
+	fmt.Fprintf(dockerCli.Out(), "Bundle saved to %s\n", opts.out)
 	return nil
 }
 

--- a/internal/commands/image/command.go
+++ b/internal/commands/image/command.go
@@ -14,7 +14,7 @@ func Cmd(dockerCli command.Cli) *cobra.Command {
 
 	cmd.AddCommand(
 		listCmd(dockerCli),
-		rmCmd(),
+		rmCmd(dockerCli),
 		tagCmd(),
 	)
 

--- a/internal/commands/image/rm.go
+++ b/internal/commands/image/rm.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/distribution/reference"
 	"github.com/spf13/cobra"
 )
 
-func rmCmd() *cobra.Command {
+func rmCmd(dockerCli command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Short:   "Remove an application image",
 		Use:     "rm [APP_IMAGE] [APP_IMAGE...]",
@@ -34,7 +35,7 @@ $ docker app image rm docker.io/library/myapp@sha256:beef...`,
 
 			errs := []string{}
 			for _, arg := range args {
-				if err := runRm(bundleStore, arg); err != nil {
+				if err := runRm(dockerCli, bundleStore, arg); err != nil {
 					errs = append(errs, fmt.Sprintf("Error: %s", err))
 				}
 			}
@@ -46,7 +47,7 @@ $ docker app image rm docker.io/library/myapp@sha256:beef...`,
 	}
 }
 
-func runRm(bundleStore store.BundleStore, app string) error {
+func runRm(dockerCli command.Cli, bundleStore store.BundleStore, app string) error {
 	ref, err := reference.ParseNormalizedNamed(app)
 	if err != nil {
 		return err
@@ -57,6 +58,6 @@ func runRm(bundleStore store.BundleStore, app string) error {
 		return err
 	}
 
-	fmt.Println("Deleted: " + reference.FamiliarString(tagged))
+	_, _ = fmt.Fprintln(dockerCli.Out(), "Deleted:", reference.FamiliarString(tagged))
 	return nil
 }

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/credentials"
@@ -95,7 +94,7 @@ func runInstall(dockerCli command.Cli, appname string, opts installOptions) erro
 	if installation, err := installationStore.Read(installationName); err == nil {
 		// A failed installation can be overridden, but with a warning
 		if isInstallationFailed(installation) {
-			fmt.Fprintf(os.Stderr, "WARNING: installing over previously failed installation %q\n", installationName)
+			fmt.Fprintf(dockerCli.Err(), "WARNING: installing over previously failed installation %q\n", installationName)
 		} else {
 			// Return an error in case of successful installation, or even failed upgrade, which means
 			// their was already a successful installation.
@@ -131,7 +130,7 @@ func runInstall(dockerCli command.Cli, appname string, opts installOptions) erro
 	inst := &action.Install{
 		Driver: driverImpl,
 	}
-	err = inst.Run(&installation.Claim, creds, os.Stdout)
+	err = inst.Run(&installation.Claim, creds, dockerCli.Out())
 	// Even if the installation failed, the installation is persisted with its failure status,
 	// so any installation needs a clean uninstallation.
 	err2 := installationStore.Store(installation)
@@ -142,6 +141,6 @@ func runInstall(dockerCli command.Cli, appname string, opts installOptions) erro
 		return err2
 	}
 
-	fmt.Fprintf(os.Stdout, "Application %q installed on context %q\n", installationName, opts.targetContext)
+	fmt.Fprintf(dockerCli.Out(), "Application %q installed on context %q\n", installationName, opts.targetContext)
 	return nil
 }

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli"
@@ -49,7 +48,7 @@ func runPull(dockerCli command.Cli, name string) error {
 		return errors.Wrap(err, name)
 	}
 
-	fmt.Fprintf(os.Stdout, "Successfully pulled %q (%s) from %s\n", bndl.Name, bndl.Version, ref.String())
+	fmt.Fprintf(dockerCli.Out(), "Successfully pulled %q (%s) from %s\n", bndl.Name, bndl.Version, ref.String())
 
 	return nil
 }

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -159,7 +159,7 @@ func pushBundle(dockerCli command.Cli, opts pushOptions, bndl *bundle.Bundle, re
 	if err != nil {
 		return errors.Wrapf(err, "pushing to %q", retag.cnabRef)
 	}
-	fmt.Fprintf(os.Stdout, "Successfully pushed bundle to %s. Digest is %s.\n", retag.cnabRef.String(), descriptor.Digest)
+	fmt.Fprintf(dockerCli.Out(), "Successfully pushed bundle to %s. Digest is %s.\n", retag.cnabRef.String(), descriptor.Digest)
 	return nil
 }
 

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/credentials"
@@ -54,10 +53,10 @@ func runRemove(dockerCli command.Cli, installationName string, opts removeOption
 				return
 			}
 			if err := installationStore.Delete(installationName); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to force deletion of installation %q: %s\n", installationName, err)
+				fmt.Fprintf(dockerCli.Err(), "failed to force deletion of installation %q: %s\n", installationName, err)
 				return
 			}
-			fmt.Fprintf(os.Stderr, "deletion forced for installation %q\n", installationName)
+			fmt.Fprintf(dockerCli.Err(), "deletion forced for installation %q\n", installationName)
 		}()
 	}
 	bind, err := requiredClaimBindMount(installation.Claim, opts.targetContext, dockerCli)
@@ -75,7 +74,7 @@ func runRemove(dockerCli command.Cli, installationName string, opts removeOption
 	uninst := &action.Uninstall{
 		Driver: driverImpl,
 	}
-	if err := uninst.Run(&installation.Claim, creds, os.Stdout); err != nil {
+	if err := uninst.Run(&installation.Claim, creds, dockerCli.Out()); err != nil {
 		if err2 := installationStore.Store(installation); err2 != nil {
 			return fmt.Errorf("%s while %s", err2, errBuf)
 		}
@@ -84,6 +83,6 @@ func runRemove(dockerCli command.Cli, installationName string, opts removeOption
 	if err := installationStore.Delete(installationName); err != nil {
 		return fmt.Errorf("Failed to delete installation %q from the installation store: %s", installationName, err)
 	}
-	fmt.Fprintf(os.Stdout, "Application %q uninstalled on context %q\n", installationName, opts.targetContext)
+	fmt.Fprintf(dockerCli.Out(), "Application %q uninstalled on context %q\n", installationName, opts.targetContext)
 	return nil
 }

--- a/internal/commands/render.go
+++ b/internal/commands/render.go
@@ -42,14 +42,16 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 func runRender(dockerCli command.Cli, appname string, opts renderOptions) error {
 	defer muteDockerCli(dockerCli)()
 
-	var w io.Writer = os.Stdout
-	if opts.renderOutput != "-" {
+	var w io.Writer
+	if opts.renderOutput == "-" {
 		f, err := os.Create(opts.renderOutput)
 		if err != nil {
 			return err
 		}
 		defer f.Close()
 		w = f
+	} else {
+		w = dockerCli.Out()
 	}
 
 	action, installation, errBuf, err := prepareCustomAction(internal.ActionRenderName, dockerCli, appname, w, opts.pullOptions, opts.parametersOptions)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/commands/image"
@@ -29,7 +28,7 @@ func NewRootCmd(use string, dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{"experimentalCLI": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if showVersion {
-				fmt.Fprintln(os.Stdout, internal.FullVersion()) //nolint:errcheck
+				fmt.Fprintln(dockerCli.Out(), internal.FullVersion()) //nolint:errcheck
 				return nil
 			}
 
@@ -55,7 +54,7 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		initCmd(dockerCli),
 		inspectCmd(dockerCli),
 		renderCmd(dockerCli),
-		validateCmd(),
+		validateCmd(dockerCli),
 		bundleCmd(dockerCli),
 		pushCmd(dockerCli),
 		pullCmd(dockerCli),

--- a/internal/commands/upgrade.go
+++ b/internal/commands/upgrade.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/credentials"
@@ -84,7 +83,7 @@ func runUpgrade(dockerCli command.Cli, installationName string, opts upgradeOpti
 	u := &action.Upgrade{
 		Driver: driverImpl,
 	}
-	err = u.Run(&installation.Claim, creds, os.Stdout)
+	err = u.Run(&installation.Claim, creds, dockerCli.Out())
 	err2 := installationStore.Store(installation)
 	if err != nil {
 		return fmt.Errorf("Upgrade failed: %s\n%s", err, errBuf)
@@ -92,6 +91,6 @@ func runUpgrade(dockerCli command.Cli, installationName string, opts upgradeOpti
 	if err2 != nil {
 		return err2
 	}
-	fmt.Fprintf(os.Stdout, "Application %q upgraded on context %q\n", installationName, opts.targetContext)
+	fmt.Fprintf(dockerCli.Out(), "Application %q upgraded on context %q\n", installationName, opts.targetContext)
 	return nil
 }

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -2,12 +2,12 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/render"
 	"github.com/docker/app/types"
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
 	cliopts "github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +16,7 @@ type validateOptions struct {
 	parametersOptions
 }
 
-func validateCmd() *cobra.Command {
+func validateCmd(dockerCli command.Cli) *cobra.Command {
 	var opts validateOptions
 	cmd := &cobra.Command{
 		Use:   "validate [APP_NAME] [--set KEY=VALUE ...] [--parameters-file PARAMETERS_FILE]",
@@ -35,7 +35,7 @@ func validateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stdout, "Validated %q\n", app.Path)
+			fmt.Fprintf(dockerCli.Out(), "Validated %q\n", app.Path)
 			return nil
 		},
 	}


### PR DESCRIPTION
Quick 5-minute write-up;

This should likely not make a difference for most situations, but try to keep a single source of truth where to print output


There's still some occurences of `os.Stdout` to detect if a terminal is attached, so perhaps we need a central solution for that