### PR TITLE
hide render command

### DIFF
--- a/e2e/testdata/plugin-usage-experimental.golden
+++ b/e2e/testdata/plugin-usage-experimental.golden
@@ -17,7 +17,6 @@ Commands:
   ls          List the installations and their last known installation result
   pull        Pull an application package from a registry
   push        Push an application package to a registry
-  render      Render the Compose file for an Application Package
   rm          Remove an application
   upgrade     Upgrade an installed application
   validate    Checks the rendered application is syntactically correct

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -17,7 +17,6 @@ Commands:
   ls          List the installations and their last known installation result
   pull        Pull an application package from a registry
   push        Push an application package to a registry
-  render      Render the Compose file for an Application Package
   rm          Remove an application
   upgrade     Upgrade an installed application
   validate    Checks the rendered application is syntactically correct

--- a/internal/commands/render.go
+++ b/internal/commands/render.go
@@ -26,6 +26,7 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 		Short:   "Render the Compose file for an Application Package",
 		Example: `$ docker app render myapp.dockerapp --set key=value`,
 		Args:    cli.RequiresMaxArgs(1),
+		Hidden:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRender(dockerCli, firstOrEmpty(args), opts)
 		},


### PR DESCRIPTION
**- What I did**
Hide `render` command

**- How I did it**
pass `hidden` flag to true in `render` command

**- How to verify it**

- `docker app --help` should not display `render` command
- `docker app render` should display `render` command help
- `docker app render` should behave as previously

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/705411/66137326-3595b100-e5fd-11e9-9d8a-c6d7c6636f9e.png)
