### PR TITLE
change flag error message for docker-app root command

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -29,6 +29,20 @@ func TestExitErrorCode(t *testing.T) {
 		ExitCode: 1,
 		Err:      "\"unknown_command\" is not a docker app command\nSee 'docker app --help'",
 	})
+
+	cmd.Command = dockerCli.Command("app", "--unknown_flag")
+	output := icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+		ExitCode: 125,
+	}).Combined()
+	// Need to check the exact error output to be sure we don't have the usage message
+	assert.Equal(t, output, "unknown flag: --unknown_flag\nSee 'docker app --help'\n")
+
+	cmd.Command = dockerCli.Command("app", "install", "--unknown_flag")
+	output = icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+		ExitCode: 125,
+	}).Combined()
+	// Need to check the exact error output to be sure we don't have the usage message
+	assert.Equal(t, output, "unknown flag: --unknown_flag\nSee 'docker app install --help'\n")
 }
 
 func TestRender(t *testing.T) {


### PR DESCRIPTION
**- What I did**
Change the flag error message for the docker app root command

**- How I did it**
Set a custom FlagErrorFunction to the root command

**- How to verify it**

- run `docker app --unknown_flag` should return 
```
unknown flag: --unknown_flag
See 'docker app --help'
```
 `echo $?` should return an error status code equal to `125`

- run `docker app install --unknown_flag` should return 
```
unknown flag: --unknown_flag
See 'docker app install --help'
```
 `echo $?` should return an error status code equal to `125`

- run `docker app` should return the usage message

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/705411/66221470-53334b00-e6cf-11e9-8dc7-cc554ee345a5.png)
