### PR TITLE
Better app install error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ Removing network hello_default
 
 ## Installation
 
-**Note**: Docker app is a _command line_ plugin (not be confused with docker _engine_ plugins), extending the `docker` command with `app` sub-commands. 
-It requires [Docker CLI](https://download.docker.com) 19.03.0 or later with experimental features enabled. 
-Either set environment variable `DOCKER_CLI_EXPERIMENTAL=enabled` 
+**Note**: Docker app is a _command line_ plugin (not be confused with docker _engine_ plugins), extending the `docker` command with `app` sub-commands.
+It requires [Docker CLI](https://download.docker.com) 19.03.0 or later with experimental features enabled.
+Either set environment variable `DOCKER_CLI_EXPERIMENTAL=enabled`
 or update your [docker CLI configuration](https://docs.docker.com/engine/reference/commandline/cli/#experimental-features).
 
 **Note**: Docker-app can't be installed using the `docker plugin install` command (yet)
@@ -307,10 +307,7 @@ $ docker app inspect myhubuser/myimage
 
 The first time a command is executed against a given image name the bundle is
 pulled from the registry and put in the local bundle store. You can pre-populate
-this store by running `docker app pull myhubuser/myimage:latest`. All commands
-manipulating a package also accept a `--pull` flag to force pulling the bundle
-from the registry, even if it is present in the local store. This can be useful
-when you are repeatedly pushing a bundle on the same tag.
+this store by running `docker app pull myhubuser/myimage:latest`.
 
 ### Multi-arch applications
 

--- a/internal/commands/image/tag_test.go
+++ b/internal/commands/image/tag_test.go
@@ -7,7 +7,6 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/deislabs/cnab-go/bundle"
-	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/distribution/reference"
 )
 
@@ -42,10 +41,6 @@ func (b *bundleStoreStub) List() ([]reference.Named, error) {
 
 func (b *bundleStoreStub) Remove(ref reference.Named) error {
 	return nil
-}
-
-func (b *bundleStoreStub) LookupOrPullBundle(ref reference.Named, pullRef bool, config *configfile.ConfigFile, insecureRegistries []string) (*bundle.Bundle, error) {
-	return nil, nil
 }
 
 var mockedBundleStore = &bundleStoreStub{}

--- a/internal/commands/inspect.go
+++ b/internal/commands/inspect.go
@@ -43,7 +43,7 @@ func runInspect(dockerCli command.Cli, appname string, opts inspectOptions) erro
 	if err != nil {
 		return err
 	}
-	bndl, ref, err := getLocalBundle(dockerCli, bundleStore, appname, false)
+	bndl, ref, err := getBundle(dockerCli, bundleStore, appname)
 
 	if err != nil {
 		return err

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
+	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -34,8 +35,13 @@ func runPull(dockerCli command.Cli, name string) error {
 	if err != nil {
 		return err
 	}
+	ref, err := reference.ParseNormalizedNamed(name)
+	if err != nil {
+		return errors.Wrap(err, name)
+	}
+	tagRef := reference.TagNameOnly(ref)
 
-	bndl, ref, err := getLocalBundle(dockerCli, bundleStore, name, true)
+	bndl, err := pullBundle(dockerCli, bundleStore, tagRef)
 	if err != nil {
 		return errors.Wrap(err, name)
 	}

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -102,7 +102,7 @@ func resolveReferenceAndBundle(dockerCli command.Cli, name string) (*bundle.Bund
 		return nil, "", err
 	}
 
-	bndl, ref, err := resolveBundle(dockerCli, bundleStore, name, false)
+	bndl, ref, err := resolveBundle(dockerCli, bundleStore, name)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/commands/render.go
+++ b/internal/commands/render.go
@@ -13,8 +13,6 @@ import (
 
 type renderOptions struct {
 	parametersOptions
-	pullOptions
-
 	formatDriver string
 	renderOutput string
 }
@@ -32,7 +30,6 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())
-	opts.pullOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVarP(&opts.renderOutput, "output", "o", "-", "Output file")
 	cmd.Flags().StringVar(&opts.formatDriver, "formatter", "yaml", "Configure the output format (yaml|json)")
 
@@ -52,7 +49,7 @@ func runRender(dockerCli command.Cli, appname string, opts renderOptions) error 
 		w = f
 	}
 
-	action, installation, errBuf, err := prepareCustomAction(internal.ActionRenderName, dockerCli, appname, w, opts.pullOptions, opts.parametersOptions)
+	action, installation, errBuf, err := prepareCustomAction(internal.ActionRenderName, dockerCli, appname, w, opts.parametersOptions)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -149,14 +149,6 @@ func (o *credentialOptions) CredentialSetOpts(dockerCli command.Cli, credentialS
 	}
 }
 
-type pullOptions struct {
-	pull bool
-}
-
-func (o *pullOptions) addFlags(flags *pflag.FlagSet) {
-	flags.BoolVar(&o.pull, "pull", false, "Pull the bundle")
-}
-
 // insecureRegistriesFromEngine reads the registry configuration from the daemon and returns
 // a list of all insecure ones.
 func insecureRegistriesFromEngine(dockerCli command.Cli) ([]string, error) {

--- a/internal/commands/upgrade.go
+++ b/internal/commands/upgrade.go
@@ -13,7 +13,6 @@ import (
 type upgradeOptions struct {
 	parametersOptions
 	credentialOptions
-	pullOptions
 	bundleOrDockerApp string
 }
 
@@ -30,7 +29,6 @@ func upgradeCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
-	opts.pullOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.bundleOrDockerApp, "app-name", "", "Override the installation with another Application Package")
 
 	return cmd
@@ -55,7 +53,7 @@ func runUpgrade(dockerCli command.Cli, installationName string, opts upgradeOpti
 	}
 
 	if opts.bundleOrDockerApp != "" {
-		b, _, err := resolveBundle(dockerCli, bundleStore, opts.bundleOrDockerApp, opts.pull)
+		b, _, err := resolveBundle(dockerCli, bundleStore, opts.bundleOrDockerApp)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**- What I did**

Made the output of `docker app install` be uniform with the `docker run` command.
Removed the `--pull` flag, we align with what the cli is doing: searching locally first, then pulling if not found. The user needs to explicitly pull an app image if they want to install the latest version.

**- How I did it**

Removed a bunch of code

**- How to verify it**

Run:

```
docker app install unknown
```

You should see the output :
```
Unable to find application image "docker.io/library/unknown" locally
Unable to find application "unknown": failed to resolve bundle manifest "docker.io/library/unknown:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```

**- Description for the changelog**
`docker app install` no longer has the `--pull` flag, an application already present locally should be pulled explicitly to update it.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/66320643-823ffb80-e91f-11e9-9693-70390c79b84f.png)
