### PR TITLE
Add warnings for env_file entries not copied

### DIFF
--- a/e2e/testdata/init-output-warning-multiple-envfiles.golden
+++ b/e2e/testdata/init-output-warning-multiple-envfiles.golden
@@ -1,0 +1,3 @@
+WARNING: "env_file: myenv1.env" entry in service "nginx" has been translated to the "environment" section. Note that your environment files will not be copied!
+WARNING: "env_file: myenv2.env" entry in service "nginx" has been translated to the "environment" section. Note that your environment files will not be copied!
+Created "app-test.dockerapp"

--- a/e2e/testdata/init-output-warning-single-envfile.golden
+++ b/e2e/testdata/init-output-warning-single-envfile.golden
@@ -1,0 +1,2 @@
+WARNING: "env_file: myenv1.env" entry in service "nginx" has been translated to the "environment" section. Note that your environment files will not be copied!
+Created "app-test.dockerapp"


### PR DESCRIPTION
'env_file' entries now removed and we
warn the user that the its contents are merged
into the 'environment' section.

Signed-off-by: Ulysses Souza <ulysses.souza@docker.com>

**- What I did**

**- How I did it**
By using `Load` and `Render` method from the CLI in the `init` command to resolve the environment section

**- How to verify it**
Create `docker-compose.yml` by running:
```
cat << 'EOF' > docker-compose.yml
version: "3.7"

services:
  db:
    image: postgres:9.6
    env_file:
      - myvars.env
    environment:
      - ENVVAR=myenvvalue
EOF
```
Create `myvars.env` by running:
```
cat << 'EOF' > myvars.env
FOO=fooVal
BAR=barVal
EOF
```

Then init your docker app with:
```
$ docker app init --compose-file docker-compose.yml testapp
```
Check the WARNING message saying:
`WARNING: "env_file: myvars.env" entry in service "db" has been translated to the "environment" section. Note that your environment files will not be copied!`.

Note also that the contents of your env file is now merged into the "environment" section of the services. Also, the "env_file" section from the original `docker-compose.yml` was removed from the migrated file.

Check the resulting file with:
```
$ cat testapp.dockerapp/docker-compose.yml
```

It should look like:
```
version: "3.7"
services:
  db:
    environment:
      BAR: barVal
      ENVVAR: myenvvalue
      FOO: fooVal
    image: postgres:9.6
```


**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

