### PR TITLE
Set build arg values in docker.Makefile

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -14,7 +14,7 @@ E2E_CROSS_CTNR_NAME := $(BIN_NAME)-e2e-cross-$(TAG)
 COV_CTNR_NAME := $(BIN_NAME)-cov-$(TAG)
 SCHEMAS_CTNR_NAME := $(BIN_NAME)-schemas-$(TAG)
 
-BUILD_ARGS=--build-arg=EXPERIMENTAL --build-arg=TAG --build-arg=COMMIT --build-arg=ALPINE_VERSION --build-arg=GOPROXY
+BUILD_ARGS=--build-arg EXPERIMENTAL=$(EXPERIMENTAL) --build-arg TAG=$(TAG) --build-arg COMMIT=$(COMMIT) --build-arg ALPINE_VERSION=$(ALPINE_VERSION) --build-arg GOPROXY=$(GOPROXY)
 
 PKG_PATH := /go/src/$(PKG_NAME)
 


### PR DESCRIPTION
**- What I did**

Sets the values of the --build-args passed through to docker build from vars.mk when using make  with docker.Makefile. This will correctly set the TAG so that the binary versions are set as when using the standard Makefile directly.

**- How I did it**

Constructed `BUILD_ARGS` using variables from `vars.mk`

**- How to verify it**

Run `make -f docker.Makefile cross` and ensure that the `app --version` command of the resulting binaries print a version (e.g. `v0.6.0-516-g6a9e04b5c5-dirty`) rather than `unknown`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Sets build args when building with docker.Makefile 
