### PR TITLE
Align docker app with `docker run` UX

### DIFF
--- a/e2e/cnab_test.go
+++ b/e2e/cnab_test.go
@@ -50,7 +50,7 @@ func TestCallCustomStatusAction(t *testing.T) {
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 			// docker app install
-			cmd.Command = dockerCli.Command("app", "install", path.Join(testDir, "bundle.json"), "--name", testCase.name)
+			cmd.Command = dockerCli.Command("app", "run", path.Join(testDir, "bundle.json"), "--name", testCase.name)
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 			// docker app uninstall
@@ -78,7 +78,7 @@ func TestCnabParameters(t *testing.T) {
 	}()
 
 	// docker app install
-	cmd.Command = dockerCli.Command("app", "install", path.Join(testDir, "bundle.json"), "--name", "cnab-parameters",
+	cmd.Command = dockerCli.Command("app", "run", path.Join(testDir, "bundle.json"), "--name", "cnab-parameters",
 		"--set", "boolParam=true",
 		"--set", "stringParam=value",
 		"--set", "intParam=42",

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -198,7 +198,7 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 	initializeDockerAppEnvironment(t, &cmd, tmpDir, swarm, useBindMount)
 
 	// Install an illformed Docker Application Package
-	cmd.Command = dockerCli.Command("app", "install", "testdata/simple/simple.dockerapp", "--set", "web_port=-1", "--name", appName)
+	cmd.Command = dockerCli.Command("app", "run", "testdata/simple/simple.dockerapp", "--set", "web_port=-1", "--name", appName)
 	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 		ExitCode: 1,
 		Err:      "error decoding 'Ports': Invalid hostPort: -1",
@@ -220,7 +220,7 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 	})
 
 	// Install a Docker Application Package with an existing failed installation is fine
-	cmd.Command = dockerCli.Command("app", "install", "testdata/simple/simple.dockerapp", "--name", appName)
+	cmd.Command = dockerCli.Command("app", "run", "testdata/simple/simple.dockerapp", "--name", appName)
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 		[]string{
 			fmt.Sprintf("WARNING: installing over previously failed installation %q", appName),
@@ -240,7 +240,7 @@ func testDockerAppLifecycle(t *testing.T, useBindMount bool) {
 		})
 
 	// Installing again the same application is forbidden
-	cmd.Command = dockerCli.Command("app", "install", "testdata/simple/simple.dockerapp", "--name", appName)
+	cmd.Command = dockerCli.Command("app", "run", "testdata/simple/simple.dockerapp", "--name", appName)
 	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 		ExitCode: 1,
 		Err:      fmt.Sprintf("Installation %q already exists, use 'docker app upgrade' instead", appName),
@@ -307,7 +307,7 @@ func TestCredentials(t *testing.T) {
 
 	t.Run("missing", func(t *testing.T) {
 		cmd.Command = dockerCli.Command(
-			"app", "install",
+			"app", "run",
 			"--credential", "secret1=foo",
 			// secret2 deliberately omitted.
 			"--credential", "secret3=baz",
@@ -322,7 +322,7 @@ func TestCredentials(t *testing.T) {
 
 	t.Run("full", func(t *testing.T) {
 		cmd.Command = dockerCli.Command(
-			"app", "install",
+			"app", "run",
 			"--credential", "secret1=foo",
 			"--credential", "secret2=bar",
 			"--credential", "secret3=baz",
@@ -334,7 +334,7 @@ func TestCredentials(t *testing.T) {
 
 	t.Run("mixed-credstore", func(t *testing.T) {
 		cmd.Command = dockerCli.Command(
-			"app", "install",
+			"app", "run",
 			"--credential-set", "test-creds",
 			"--credential", "secret3=xyzzy",
 			"--name", "mixed-credstore", bundle,
@@ -345,7 +345,7 @@ func TestCredentials(t *testing.T) {
 
 	t.Run("mixed-local-cred", func(t *testing.T) {
 		cmd.Command = dockerCli.Command(
-			"app", "install",
+			"app", "run",
 			"--credential-set", tmpDir.Join("local", "test-creds.yaml"),
 			"--credential", "secret3=xyzzy",
 			"--name", "mixed-local-cred", bundle,
@@ -356,7 +356,7 @@ func TestCredentials(t *testing.T) {
 
 	t.Run("overload", func(t *testing.T) {
 		cmd.Command = dockerCli.Command(
-			"app", "install",
+			"app", "run",
 			"--credential-set", "test-creds",
 			"--credential", "secret1=overload",
 			"--credential", "secret3=xyzzy",

--- a/e2e/pushpull_test.go
+++ b/e2e/pushpull_test.go
@@ -144,7 +144,7 @@ func TestPushInstall(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "push", "--tag", ref, filepath.Join("testdata", "push-pull", "push-pull.dockerapp"))
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-		cmd.Command = dockerCli.Command("app", "install", ref, "--name", t.Name())
+		cmd.Command = dockerCli.Command("app", "run", ref, "--name", t.Name())
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 		cmd.Command = dockerCli.Command("service", "ls")
 		assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref))
@@ -165,7 +165,7 @@ func TestPushPullInstall(t *testing.T) {
 		info.stopRegistry()
 
 		// install from local store
-		cmd.Command = dockerCli.Command("app", "install", ref+tag, "--name", t.Name())
+		cmd.Command = dockerCli.Command("app", "run", ref+tag, "--name", t.Name())
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 		cmd.Command = dockerCli.Command("service", "ls")
 		assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref))
@@ -178,7 +178,7 @@ func TestPushPullInstall(t *testing.T) {
 			})
 
 		// install should fail (registry is stopped)
-		cmd.Command = dockerCli.Command("app", "install", "unknown")
+		cmd.Command = dockerCli.Command("app", "run", "unknown")
 		//nolint: lll
 		expected := `Unable to find application image "unknown:latest" locally
 Unable to find application "unknown": failed to resolve bundle manifest "docker.io/library/unknown:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed`
@@ -204,7 +204,7 @@ func TestPushInstallBundle(t *testing.T) {
 			cmd.Command = dockerCli.Command("app", "push", "--tag", ref, "a-simple-app:1.0.0")
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-			cmd.Command = dockerCli.Command("app", "install", ref, "--name", name)
+			cmd.Command = dockerCli.Command("app", "run", ref, "--name", name)
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 			cmd.Command = dockerCli.Command("service", "ls")
 			assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref))
@@ -224,7 +224,7 @@ func TestPushInstallBundle(t *testing.T) {
 			cmd.Command = dockerCli.Command("app", "push", "--tag", ref2, ref+":latest")
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-			cmd.Command = dockerCli.Command("app", "install", ref2, "--name", name)
+			cmd.Command = dockerCli.Command("app", "run", ref2, "--name", name)
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 			cmd.Command = dockerCli.Command("service", "ls")
 			assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref2))
@@ -251,7 +251,7 @@ func TestPushInstallBundle(t *testing.T) {
 			// remove the bundle from the bundle store to be sure it won't be used instead of registry
 			cleanupIsolatedStore()
 			// install from the registry
-			cmd.Command = dockerCli.Command("app", "install", ref2, "--name", name)
+			cmd.Command = dockerCli.Command("app", "run", ref2, "--name", name)
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 			cmd.Command = dockerCli.Command("service", "ls")
 			assert.Check(t, cmp.Contains(icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(), ref))

--- a/e2e/testdata/plugin-usage-experimental.golden
+++ b/e2e/testdata/plugin-usage-experimental.golden
@@ -13,11 +13,11 @@ Commands:
   build       Build service images for the application
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
-  install     Install an application
   ls          List the installations and their last known installation result
   pull        Pull an application package from a registry
   push        Push an application package to a registry
   rm          Remove an application
+  run         Run an application
   upgrade     Upgrade an installed application
   validate    Checks the rendered application is syntactically correct
 

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -13,11 +13,11 @@ Commands:
   build       Build service images for the application
   init        Initialize Docker Application definition
   inspect     Shows metadata, parameters and a summary of the Compose file for a given application
-  install     Install an application
   ls          List the installations and their last known installation result
   pull        Pull an application package from a registry
   push        Push an application package to a registry
   rm          Remove an application
+  run         Run an application
   upgrade     Upgrade an installed application
   validate    Checks the rendered application is syntactically correct
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -49,7 +49,7 @@ func NewRootCmd(use string, dockerCli command.Cli) *cobra.Command {
 
 func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 	cmd.AddCommand(
-		installCmd(dockerCli),
+		runCmd(dockerCli),
 		upgradeCmd(dockerCli),
 		removeCmd(dockerCli),
 		listCmd(dockerCli),

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -33,14 +33,9 @@ const (
 	nameKindReference
 )
 
-const longDescription = `Run an application.
-By default, the application definition in the current directory will be ran. The APP_NAME can also be:
-- a path to a Docker Application definition (.dockerapp) or a CNAB bundle.json
-- a registry Application Package reference`
+const longDescription = `Run an application based on a docker app image.`
 
-const example = `$ docker app run myapp.dockerapp --name myinstallation --target-context=mycontext
-$ docker app run myrepo/myapp:mytag --name myinstallation --target-context=mycontext
-$ docker app run bundle.json --name myinstallation --credential-set=mycredentials.yml`
+const example = `$ docker app run myrepo/myapp:mytag --name myinstallation --target-context=mycontext`
 
 func runCmd(dockerCli command.Cli) *cobra.Command {
 	var opts runOptions

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type installOptions struct {
+type runOptions struct {
 	parametersOptions
 	credentialOptions
 	orchestrator  string
@@ -33,28 +33,27 @@ const (
 	nameKindReference
 )
 
-const longDescription = `Install an application.
-By default, the application definition in the current directory will be
-installed. The APP_NAME can also be:
+const longDescription = `Run an application.
+By default, the application definition in the current directory will be ran. The APP_NAME can also be:
 - a path to a Docker Application definition (.dockerapp) or a CNAB bundle.json
 - a registry Application Package reference`
 
-const example = `$ docker app install myapp.dockerapp --name myinstallation --target-context=mycontext
-$ docker app install myrepo/myapp:mytag --name myinstallation --target-context=mycontext
-$ docker app install bundle.json --name myinstallation --credential-set=mycredentials.yml`
+const example = `$ docker app run myapp.dockerapp --name myinstallation --target-context=mycontext
+$ docker app run myrepo/myapp:mytag --name myinstallation --target-context=mycontext
+$ docker app run bundle.json --name myinstallation --credential-set=mycredentials.yml`
 
-func installCmd(dockerCli command.Cli) *cobra.Command {
-	var opts installOptions
+func runCmd(dockerCli command.Cli) *cobra.Command {
+	var opts runOptions
 
 	cmd := &cobra.Command{
-		Use:     "install [APP_NAME] [--name INSTALLATION_NAME] [--target-context TARGET_CONTEXT] [OPTIONS]",
+		Use:     "run [APP_NAME] [--name INSTALLATION_NAME] [--target-context TARGET_CONTEXT] [OPTIONS]",
 		Aliases: []string{"deploy"},
-		Short:   "Install an application",
+		Short:   "Run an application",
 		Long:    longDescription,
 		Example: example,
 		Args:    cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInstall(dockerCli, firstOrEmpty(args), opts)
+			return runRun(dockerCli, firstOrEmpty(args), opts)
 		},
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())
@@ -66,7 +65,7 @@ func installCmd(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runInstall(dockerCli command.Cli, appname string, opts installOptions) error {
+func runRun(dockerCli command.Cli, appname string, opts runOptions) error {
 	opts.SetDefaultTargetContext(dockerCli)
 
 	bind, err := requiredBindMount(opts.targetContext, opts.orchestrator, dockerCli.ContextStore())

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -35,20 +35,20 @@ const (
 
 const longDescription = `Run an application based on a docker app image.`
 
-const example = `$ docker app run myrepo/myapp:mytag --name myinstallation --target-context=mycontext`
+const example = `$ docker app run --name myinstallation --target-context=mycontext myrepo/myapp:mytag`
 
 func runCmd(dockerCli command.Cli) *cobra.Command {
 	var opts runOptions
 
 	cmd := &cobra.Command{
-		Use:     "run [APP_NAME] [--name INSTALLATION_NAME] [--target-context TARGET_CONTEXT] [OPTIONS]",
+		Use:     "run [OPTIONS] [APP_IMAGE]",
 		Aliases: []string{"deploy"},
 		Short:   "Run an application",
 		Long:    longDescription,
 		Example: example,
-		Args:    cli.RequiresMaxArgs(1),
+		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRun(dockerCli, firstOrEmpty(args), opts)
+			return runRun(dockerCli, args[0], opts)
 		},
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())


### PR DESCRIPTION
**- What I did**
Renamed `install/deploy` command to "run" to align with `docker run` UX

**- How I did it**
refactor > rename

**- How to verify it**
docker app --help
docker app run myapp

**- Description for the changelog**
`deploy` command has been renamed `run` to align with `docker run` UX

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/66633772-e0186000-ec0b-11e9-849b-2508ec33e3ad.png)

