### PR TITLE
added app labels to container metadata

### DIFF
--- a/cmd/cnab-run/install.go
+++ b/cmd/cnab-run/install.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/cli/cli/command/stack"
 	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/cli/cli/command/stack/swarm"
+	composetypes "github.com/docker/cli/cli/compose/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
@@ -50,6 +51,7 @@ func installAction(instanceName string) error {
 	if err != nil {
 		return err
 	}
+	addAppLabels(rendered, instanceName)
 	if err := os.Chdir(app.Path); err != nil {
 		return err
 	}
@@ -83,4 +85,15 @@ func getBundleImageMap() (map[string]bundle.Image, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+func addAppLabels(rendered *composetypes.Config, instanceName string) {
+	for i, service := range rendered.Services {
+		if service.Labels == nil {
+			service.Labels = map[string]string{}
+		}
+		service.Labels[internal.LabelAppNamespace] = instanceName
+		service.Labels[internal.LabelAppVersion] = internal.Version
+		rendered.Services[i] = service
+	}
 }

--- a/internal/names.go
+++ b/internal/names.go
@@ -73,6 +73,11 @@ const (
 	// CustomDockerAppName is the custom variable set by Docker App to
 	// save custom informations
 	CustomDockerAppName = "com.docker.app"
+
+	// LabelAppNamespace is the label used to track app resources
+	LabelAppNamespace = Namespace + "namespace"
+	// LabelAppVersion is the label used to identify what version of docker app was used to create the app
+	LabelAppVersion = Namespace + "version"
 )
 
 var (


### PR DESCRIPTION
**- What I did**

Added 2 labels to the containers when they are deployed by docker app:

- com.docker.app.namespace: same as the com.docker.stack.namespace
- com.docker.app.version: version of docker app used for the deploy

These have been added so that Docker Desktop can differentiate between docker app deployments vs docker stack services.

**- How I did it**

Added the labels to the services in the invocation image `install` command (both `install` and `upgrade` in `docker app`) before calling `RunDeploy` on the orchestrator.

**- How to verify it**

Assertions for the labels have been added to the e2e tests. To verify manually:

- Run a `docker app install` and then `inspect` the running containers. They should have the labels as described above.
- Run a `docker app upgrade` on the installed app and then `inspect` the running containers. They should have the labels as described above.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added com.docker.app.namespace and com.docker.app.version labels to containers created by docker app.

**- A picture of a cute animal (not mandatory but encouraged)**

![_108799047_harry-walker_oh-my_00000657](https://user-images.githubusercontent.com/22098752/66644998-3ee4d600-ec1a-11e9-884b-f7a9491741b7.jpg)


