### PR TITLE
Use -trimpath while building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 
 TEST_RESULTS_DIR = _build/test-results
 STATIC_FLAGS= CGO_ENABLED=0
-GO_BUILD = $(STATIC_FLAGS) go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
+GO_BUILD = $(STATIC_FLAGS) go build -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS) -trimpath
 GO_TEST = $(STATIC_FLAGS) go test -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 GO_TESTSUM = $(STATIC_FLAGS) gotestsum --junitfile $(TEST_RESULTS_DIR)/$(TEST_RESULTS_PREFIX)$(1) -- -tags=$(BUILDTAGS) -ldflags=$(LDFLAGS)
 


### PR DESCRIPTION
**- What I did**

Add the new `-trimpath` flag from go 1.13 which instructs the compiler to remove all file system paths from the compiled executable. With this we will see module paths in stack trace and not absolute paths. This also helps have reproducible builds (same executable bit-by-bit even if compiled on different machines).

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/66651033-55972700-ec32-11e9-9a30-8989e632d5c8.png)

