### PR TITLE
Fix init help message.

### DIFF
--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -17,7 +17,7 @@ func initCmd(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "init APP_NAME [--compose-file COMPOSE_FILE] [OPTIONS]",
 		Short:   "Initialize Docker Application definition",
-		Long:    `Start building a Docker Application package. If there is a docker-compose.yml file in the current directory it will be copied and used.`,
+		Long:    `Start building a Docker Application package.`,
 		Example: `$ docker app init myapp`,
 		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
**- What I did**

Docker App doesn't take a docker-compose file implicitly any more.

**- How I did it**

Removed the incorrect statement in the help.

**- How to verify it**

Run `docker app init --help`.