### PR TITLE
Inspect prints the metadata in yaml format

### DIFF
--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/app/internal"
 	"github.com/docker/app/render"
@@ -132,14 +134,9 @@ func printTable(out io.Writer, appInfo appInfo) error {
 
 func printMetadata(out io.Writer, app appInfo) {
 	meta := app.Metadata
-	fmt.Fprintln(out, meta.Name, meta.Version)
-	if maintainers := meta.Maintainers.String(); maintainers != "" {
-		fmt.Fprintln(out)
-		fmt.Fprintln(out, "Maintained by:", maintainers)
-	}
-	if meta.Description != "" {
-		fmt.Fprintln(out)
-		fmt.Fprintln(out, meta.Description)
+
+	if bytes, err := yaml.Marshal(meta); err == nil {
+		fmt.Fprintln(out, string(bytes))
 	}
 }
 

--- a/internal/inspect/testdata/inspect-full.golden
+++ b/internal/inspect/testdata/inspect-full.golden
@@ -1,8 +1,10 @@
-myapp 0.1.0
+version: 0.1.0
+name: myapp
+description: some description
+maintainers:
+- name: dev
+  email: dev@example.com
 
-Maintained by: dev <dev@example.com>
-
-some description
 
 Services (2) Replicas Ports     Image
 ------------ -------- -----     -----

--- a/internal/inspect/testdata/inspect-no-description.golden
+++ b/internal/inspect/testdata/inspect-no-description.golden
@@ -1,3 +1,7 @@
-myapp 0.1.0
+version: 0.1.0
+name: myapp
+description: ""
+maintainers:
+- name: dev
+  email: dev@example.com
 
-Maintained by: dev <dev@example.com>

--- a/internal/inspect/testdata/inspect-no-maintainers.golden
+++ b/internal/inspect/testdata/inspect-no-maintainers.golden
@@ -1,1 +1,5 @@
-myapp 0.1.0
+version: 0.1.0
+name: myapp
+description: ""
+maintainers: []
+

--- a/internal/inspect/testdata/inspect-no-parameters.golden
+++ b/internal/inspect/testdata/inspect-no-parameters.golden
@@ -1,5 +1,7 @@
-myapp 0.1.0
+version: 0.1.0
+name: myapp
+description: some description
+maintainers:
+- name: dev
+  email: dev@example.com
 
-Maintained by: dev <dev@example.com>
-
-some description

--- a/internal/inspect/testdata/inspect-overridden.golden
+++ b/internal/inspect/testdata/inspect-overridden.golden
@@ -1,4 +1,8 @@
-myapp 0.1.0
+version: 0.1.0
+name: myapp
+description: ""
+maintainers: []
+
 
 Service (1) Replicas Ports Image
 ----------- -------- ----- -----


### PR DESCRIPTION
**- What I did**

Made inspect print the application metadata in yaml format.

**- How to verify it**

Build a new application and then inspect it with `--pretty` format.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/66761509-7797e000-eea4-11e9-8316-dbfd4d7b2234.png)

