### PR TITLE
Add the docker app version in the bundle

### DIFF
--- a/internal/names.go
+++ b/internal/names.go
@@ -69,6 +69,10 @@ const (
 	// DockerInspectFormatEnvVar is the environment variable set by the CNAB runtime to select
 	// the inspect output format.
 	DockerInspectFormatEnvVar = "DOCKER_INSPECT_FORMAT"
+
+	// CustomDockerAppName is the custom variable set by Docker App to
+	// save custom informations
+	CustomDockerAppName = "com.docker.app"
 )
 
 var (

--- a/internal/packager/cnab.go
+++ b/internal/packager/cnab.go
@@ -16,6 +16,13 @@ const (
 	CNABVersion1_0_0 = "v1.0.0-WD"
 )
 
+// DockerAppCustom contains extension custom data that docker app injects
+// in the bundle.
+type DockerAppCustom struct {
+	Version string          `json:"version,omitempty"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
 // ToCNAB creates a CNAB bundle from an app package
 func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) {
 	mapping := ExtractCNABParameterMapping(app.Parameters())
@@ -142,6 +149,11 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 
 	bndl := &bundle.Bundle{
 		SchemaVersion: CNABVersion1_0_0,
+		Custom: map[string]interface{}{
+			internal.CustomDockerAppName: DockerAppCustom{
+				Version: internal.Version,
+			},
+		},
 		Credentials: map[string]bundle.Credential{
 			internal.CredentialDockerContextName: {
 				Location: bundle.Location{

--- a/internal/packager/cnab_test.go
+++ b/internal/packager/cnab_test.go
@@ -2,12 +2,13 @@ package packager
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
-	"gotest.tools/golden"
-
+	"github.com/docker/app/internal"
 	"github.com/docker/app/types"
 	"gotest.tools/assert"
+	"gotest.tools/golden"
 )
 
 func TestToCNAB(t *testing.T) {
@@ -17,5 +18,7 @@ func TestToCNAB(t *testing.T) {
 	assert.NilError(t, err)
 	actualJSON, err := json.MarshalIndent(actual, "", "  ")
 	assert.NilError(t, err)
-	golden.Assert(t, string(actualJSON), "bundle-json.golden")
+	s := golden.Get(t, "bundle-json.golden")
+	expected := fmt.Sprintf(string(s), internal.Version)
+	assert.Equal(t, string(actualJSON), expected)
 }

--- a/internal/packager/testdata/bundle-json.golden
+++ b/internal/packager/testdata/bundle-json.golden
@@ -162,5 +162,10 @@
       "default": "foo",
       "type": "string"
     }
+  },
+  "custom": {
+    "com.docker.app": {
+      "version": "%s"
+    }
   }
 }


### PR DESCRIPTION
**- What I did**
Added the docker app version in the generated bundle. This will help us track what we can or not do with the bundle we are dealing with.

**- How to verify it**

* Build an application
* Look at the generated bundle (in the bundle store), it should containe the verison of docker app in `custom["com.docker.app.version"]`.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/66765198-acf3fc00-eeab-11e9-89fa-c06d358d5708.png)

