### PR TITLE
Disable gomod when running fossa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ coverage: coverage-test-unit coverage-test-e2e ## run tests with coverage
 
 fossa-analyze:
 	docker run -i --rm -e FOSSA_API_KEY \
-		-e GO111MODULE=on \
+		-e GO111MODULE=off \
 		-v $(CURDIR)/$*:/go/src/github.com/docker/app \
 		-w /go/src/github.com/docker/app \
 		$(BUILD_ANALYZER) analyze $(FOSSA_OPTS) --branch $(BRANCH_NAME)


### PR DESCRIPTION
**- What I did**

Go is unable to convert our Gopkg.toml into a go mod so I put `GO111MODULE=off` 

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/66845716-d460cc80-ef70-11e9-9310-12320b1a0268.png)

