### PR TITLE
Add -q flag for image ls command

### DIFF
--- a/internal/commands/image/list_test.go
+++ b/internal/commands/image/list_test.go
@@ -1,0 +1,79 @@
+package image
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/docker/app/internal/store"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/distribution/reference"
+)
+
+type mockRef string
+
+func (ref mockRef) String() string {
+	return string(ref)
+}
+
+type bundleStoreStubForListCmd struct {
+	refMap map[reference.Reference]*bundle.Bundle
+	// in order to keep the reference in the same order between tests
+	refList []reference.Reference
+}
+
+func (b *bundleStoreStubForListCmd) Store(ref reference.Reference, bndle *bundle.Bundle) (reference.Reference, error) {
+	b.refMap[ref] = bndle
+	b.refList = append(b.refList, ref)
+	return ref, nil
+}
+
+func (b *bundleStoreStubForListCmd) Read(ref reference.Reference) (*bundle.Bundle, error) {
+	bndl, ok := b.refMap[ref]
+	if ok {
+		return bndl, nil
+	}
+	return nil, fmt.Errorf("Bundle not found")
+}
+
+func (b *bundleStoreStubForListCmd) List() ([]reference.Reference, error) {
+	return b.refList, nil
+}
+
+func (b *bundleStoreStubForListCmd) Remove(ref reference.Reference) error {
+	return nil
+}
+
+func TestListWithQuietFlag(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	dockerCli, err := command.NewDockerCli(command.WithOutputStream(w))
+	assert.NilError(t, err)
+	bundleStore := &bundleStoreStubForListCmd{
+		refMap:  make(map[reference.Reference]*bundle.Bundle),
+		refList: []reference.Reference{},
+	}
+	ref1, err := store.FromString("a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087")
+	assert.NilError(t, err)
+	ref2, err := reference.Parse("foo/bar:1.0")
+	assert.NilError(t, err)
+	_, err = bundleStore.Store(ref1, &bundle.Bundle{})
+	assert.NilError(t, err)
+	_, err = bundleStore.Store(ref2, &bundle.Bundle{
+		Version:       "1.0.0",
+		SchemaVersion: "1.0.0",
+		Name:          "Foo App",
+	})
+	assert.NilError(t, err)
+	err = runList(dockerCli, imageListOption{quiet: true}, bundleStore)
+	assert.NilError(t, err)
+	expectedOutput := `a855ac937f2e
+9aae408ee04f
+`
+	w.Flush()
+	assert.Equal(t, buf.String(), expectedOutput)
+}

--- a/internal/store/digest.go
+++ b/internal/store/digest.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"regexp"
 
+	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/distribution/reference"
 	"github.com/opencontainers/go-digest"
 )
@@ -25,6 +26,11 @@ func FromString(s string) (ID, error) {
 		return ID{}, fmt.Errorf("could not parse '%s' as a valid reference", s)
 	}
 	return ID{s}, nil
+}
+
+func FromBundle(bndle *bundle.Bundle) (ID, error) {
+	digest, err := ComputeDigest(bndle)
+	return ID{digest.Encoded()}, err
 }
 
 // ID is an unique identifier for docker app image bundle, implementing reference.Reference


### PR DESCRIPTION
**- What I did**
This PR add the flag `-q` to the `docker app image ls` command. When this flag is set to true only the app image id are printed.

**- How to verify it**
Run `docker app image ls -q`. The output must look like:
```
$ docker app image ls -q
bfd17c107aad
1fa73eccfc5c
bfd17c107aad
bfd17c107aad
916c80e7ab93
```

A E2E test covering this command has been added

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/470082/66903286-7c72a600-f002-11e9-9131-c032cf9f4822.png)

