### PR TITLE
Add build parameters to docker app build command

### DIFF
--- a/e2e/testdata/build/single.dockerapp/docker-compose.yml
+++ b/e2e/testdata/build/single.dockerapp/docker-compose.yml
@@ -7,6 +7,9 @@ services:
   worker:
     build:
       context: ./worker
+      args:
+        - REPLACE_BY_BUILD_ARG=original
+        - STATIC_ARG=static
       dockerfile: Dockerfile.worker
   db:
     image: postgres:9.3

--- a/e2e/testdata/build/worker/Dockerfile.worker
+++ b/e2e/testdata/build/worker/Dockerfile.worker
@@ -1,1 +1,6 @@
 FROM scratch
+ARG REPLACE_BY_BUILD_ARG
+ARG STATIC_ARG
+LABEL com.docker.labelled.arg=$REPLACE_BY_BUILD_ARG
+LABEL com.docker.labelled.optional=$STATIC_ARG
+

--- a/internal/commands/build/compose.go
+++ b/internal/commands/build/compose.go
@@ -18,7 +18,7 @@ func parseCompose(app *types.App, contextPath string, options buildOptions) (map
 		return nil, err
 	}
 
-	services, err := load(parsed)
+	services, err := load(parsed, options.args)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse compose file: %s", err)
 	}


### PR DESCRIPTION
**- What I did**
Pass `--build-arg` parameter to buildx to build service images

**- How I did it**
Add a `--build-arg` flag
Check a build arg isn't defined twice
Replace build arg defined in compose file & pass the list of args to buildx for generating service images

**- How to verify it**
- Test main workflow
run `docker --debug app build e2e/testdata/build/ --build-arg REPLACE_BY_BUILD_ARG=plop`
check you see the following trace in the debug output in the `worker` section of the `com.docker.app.invocation-image`
```
"BuildArgs": {
  >          "REPLACE_BY_BUILD_ARG": "plop",
  >          "STATIC_ARG": "static"
  >       },
```
Find the `worker` image sha256 & then do a `docker image inspect` with the given sha & make sure to have 
```
"Labels": {
                "com.docker.labelled.arg": "plop",
                "com.docker.labelled.optional": "static"
            }
```

- Test error message

run `docker app build e2e/testdata/build/single.dockerapp --build-arg REPLACE_BY_BUILD_ARG=plop --build-arg REPLACE_BY_BUILD_ARG` and check you have the following error message `'--build-arg REPLACE_BY_BUILD_ARG' is defined twice`


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/705411/66934392-b069bd80-f03a-11e9-9176-4eae93be561d.png)

