### PR TITLE
Also tag invocation image `unknown` so we can run e2e tests in Goland

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -140,7 +140,7 @@ specification/bindata.go: specification/schemas/*.json build_dev_image
 schemas: specification/bindata.go ## generate specification/bindata.go from json schemas
 
 invocation-image:
-	docker build -f Dockerfile.invocation-image $(BUILD_ARGS) --target=invocation -t $(CNAB_BASE_INVOCATION_IMAGE_NAME) .
+	docker build -f Dockerfile.invocation-image $(BUILD_ARGS) --target=invocation -t $(CNAB_BASE_INVOCATION_IMAGE_NAME) -t docker/cnab-app-base:unknown .
 
 save-invocation-image-tag:
 	docker tag $(CNAB_BASE_INVOCATION_IMAGE_NAME) docker/cnab-app-base:$(INVOCATION_IMAGE_TAG)


### PR DESCRIPTION
**- What I did**
So I can run e2e tests from Golang I have to change `version.go` to point to current git commit (this is handled by Makefile for classic build, but no within IDE)
And then I already created PRs with this change committed a few time - too much times actually
I changed the build so it also tag the invocation image as `unknown`, so e2e test can run from Goland without Makefile hacks, without impacting the standard build

**- How I did it**
invocation image is tagged both with git status and as `unknown`

**- How to verify it**
Use Goland :P

**- Description for the changelog**
_

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/66995540-7c8ca780-f0cf-11e9-8d9f-1199ce79a912.png)

