### PR TITLE
Make image inspect more in line with other tables

### DIFF
--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -92,35 +92,35 @@ func printTable(out io.Writer, appInfo appInfo) error {
 		for _, service := range appInfo.Services {
 			fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", service.Name, service.Replicas, service.Ports, service.Image)
 		}
-	}, "Service", "Replicas", "Ports", "Image")
+	}, "SERVICE", "REPLICAS", "PORTS", "IMAGE")
 
 	// Add Network section
 	printSection(out, len(appInfo.Networks), func(w io.Writer) {
 		for _, name := range appInfo.Networks {
 			fmt.Fprintln(w, name)
 		}
-	}, "Network")
+	}, "NETWORK")
 
 	// Add Volume section
 	printSection(out, len(appInfo.Volumes), func(w io.Writer) {
 		for _, name := range appInfo.Volumes {
 			fmt.Fprintln(w, name)
 		}
-	}, "Volume")
+	}, "VOLUME")
 
 	// Add Secret section
 	printSection(out, len(appInfo.Secrets), func(w io.Writer) {
 		for _, name := range appInfo.Secrets {
 			fmt.Fprintln(w, name)
 		}
-	}, "Secret")
+	}, "SECRET")
 
 	// Add Parameter section
 	printSection(out, len(appInfo.parametersKeys), func(w io.Writer) {
 		for _, k := range appInfo.parametersKeys {
 			fmt.Fprintf(w, "%s\t%s\n", k, appInfo.Parameters[k])
 		}
-	}, "Parameter", "Value")
+	}, "PARAMETER", "VALUE")
 
 	// Add Attachments section
 	printSection(out, len(appInfo.Attachments), func(w io.Writer) {
@@ -128,7 +128,7 @@ func printTable(out io.Writer, appInfo appInfo) error {
 			sizeString := units.HumanSize(float64(attachment.Size))
 			fmt.Fprintf(w, "%s\t%s\n", attachment.Path, sizeString)
 		}
-	}, "Attachment", "Size")
+	}, "ATTACHMENT", "SIZE")
 	return nil
 }
 
@@ -146,23 +146,9 @@ func printSection(out io.Writer, len int, printer func(io.Writer), headers ...st
 	}
 	fmt.Fprintln(out)
 	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
-	var plural string
-	if len > 1 {
-		plural = "s"
-	}
-	headers[0] = fmt.Sprintf("%s%s (%d)", headers[0], plural, len)
-	printHeaders(w, headers...)
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
 	printer(w)
 	w.Flush()
-}
-
-func printHeaders(w io.Writer, headers ...string) {
-	fmt.Fprintln(w, strings.Join(headers, "\t"))
-	dashes := make([]string, len(headers))
-	for i, h := range headers {
-		dashes[i] = strings.Repeat("-", len(h))
-	}
-	fmt.Fprintln(w, strings.Join(dashes, "\t"))
 }
 
 func getAppInfo(app *types.App, config *composetypes.Config, argParameters map[string]string) (appInfo, error) {

--- a/internal/inspect/testdata/inspect-full.golden
+++ b/internal/inspect/testdata/inspect-full.golden
@@ -6,31 +6,25 @@ maintainers:
   email: dev@example.com
 
 
-Services (2) Replicas Ports     Image
------------- -------- -----     -----
-web1         2        8080-8100 nginx:latest
-web2         2        9080-9100 nginx:latest
+SERVICE REPLICAS PORTS     IMAGE
+web1    2        8080-8100 nginx:latest
+web2    2        9080-9100 nginx:latest
 
-Networks (2)
-------------
+NETWORK
 my-network1
 my-network2
 
-Volumes (2)
------------
+VOLUME
 my-volume1
 my-volume2
 
-Secrets (2)
------------
+SECRET
 my-secret1
 my-secret2
 
-Parameters (2) Value
--------------- -----
-port           8080
-text           hello
+PARAMETER VALUE
+port      8080
+text      hello
 
-Attachment (1) Size
--------------- ----
-config.cfg     9B
+ATTACHMENT SIZE
+config.cfg 9B

--- a/internal/inspect/testdata/inspect-overridden.golden
+++ b/internal/inspect/testdata/inspect-overridden.golden
@@ -4,10 +4,8 @@ description: ""
 maintainers: []
 
 
-Service (1) Replicas Ports Image
------------ -------- ----- -----
-web         1        80    nginx
+SERVICE REPLICAS PORTS IMAGE
+web     1        80    nginx
 
-Parameter (1) Value
-------------- -----
-web.port      80
+PARAMETER VALUE
+web.port  80


### PR DESCRIPTION
**- What I did**

Changed the output of `docker app image inspect` to be more in line with other tables the cli has:
```
version: 0.1.0
name: voting-app
description: Dogs or cats?
maintainers:
- name: user
  email: user@email.com


SERVICE REPLICAS PORTS IMAGE
db      1        5432  postgres:9.4
redis   1        6379  redis:alpine
result  1        5001  dockersamples/examplevotingapp_result:before
vote    2        5000  dockersamples/examplevotingapp_vote:before
worker  1              dockersamples/examplevotingapp_worker

PARAMETER     VALUE
result.port   5001
vote.port     5000
vote.replicas 2
```

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/67098595-d4550c80-f1bc-11e9-9393-1ba502238fdd.png)

