### PR TITLE
Docker app run runs only references

### DIFF
--- a/e2e/cnab_test.go
+++ b/e2e/cnab_test.go
@@ -50,7 +50,7 @@ func TestCallCustomStatusAction(t *testing.T) {
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 			// docker app install
-			cmd.Command = dockerCli.Command("app", "run", path.Join(testDir, "bundle.json"), "--name", testCase.name)
+			cmd.Command = dockerCli.Command("app", "run", "--cnab-bundle-json", path.Join(testDir, "bundle.json"), "--name", testCase.name)
 			icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 			// docker app uninstall
@@ -78,7 +78,7 @@ func TestCnabParameters(t *testing.T) {
 	}()
 
 	// docker app install
-	cmd.Command = dockerCli.Command("app", "run", path.Join(testDir, "bundle.json"), "--name", "cnab-parameters",
+	cmd.Command = dockerCli.Command("app", "run", "--cnab-bundle-json", path.Join(testDir, "bundle.json"), "--name", "cnab-parameters",
 		"--set", "boolParam=true",
 		"--set", "stringParam=value",
 		"--set", "intParam=42",

--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -43,7 +43,7 @@ func runWithDindSwarmAndRegistry(t *testing.T, todo func(dindSwarmAndRegistryInf
 	// Solution found is: fix the port of the registry to be the same internally and externally
 	// and run the dind container in the same network namespace: this way 127.0.0.1:<registry-port> both resolves to the registry from the client and from dind
 
-	swarm := NewContainer("docker:19.03.2-dind", 2375, "--insecure-registry", fmt.Sprintf("127.0.0.1:%d", registryPort))
+	swarm := NewContainer("docker:19.03.3-dind", 2375, "--insecure-registry", fmt.Sprintf("127.0.0.1:%d", registryPort))
 	swarm.Start(t, "--expose", strconv.FormatInt(int64(registryPort), 10),
 		"-p", fmt.Sprintf("%d:%d", registryPort, registryPort),
 		"-p", "2375",


### PR DESCRIPTION
**- What I did**

A new flag `--cnab-bundle-json` is added for running a CNAB bundle directly. Otherwise, a built app is ran.

**- How to verify it**

Run `docker app run --cnab-bundle-json e2e/testdata/cnab-without-status/bundle.json`.

**- Description for the changelog**
You can run a CNAB bundle with `docker app run --cnab-bundle-json BUNDLE`

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/67104661-a0331900-f1c7-11e9-9a61-c3ab239baec5.png)

