### PR TITLE
Introduce --iidfile option

### DIFF
--- a/internal/packager/bundle.go
+++ b/internal/packager/bundle.go
@@ -70,6 +70,7 @@ func MakeCNABImageName(appName, appVersion, suffix string) (string, error) {
 	return name, nil
 }
 
+// PersistInBundleStore do store a bundle with optional reference and return it's ID
 func PersistInBundleStore(ref reference.Reference, bndle *bundle.Bundle) (reference.Reference, error) {
 	appstore, err := store.NewApplicationStore(config.Dir())
 	if err != nil {

--- a/internal/version.go
+++ b/internal/version.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	// Version is the git tag that this was built from.
-	Version = "unknown"
+	Version = "v0.9.0-zeta1-20-g29f299f945"
 	// GitCommit is the commit that this was built from.
 	GitCommit = "unknown"
 	// BuildTime is the time at which the binary was built.


### PR DESCRIPTION
**- What I did**
Introduce `--iidfile` option to store built app image ID in a file

**- How I did it**
Copy pasted option from the docker CLI

**- How to verify it**
run `docker app build --iidfile foo .`
`foo` file contains a single line with image ID, matching the one reported on console at the end of the build.

**- Description for the changelog**
Introduce `--iidfile` option to store built app image ID in a file

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/67266477-a91a3800-f4b0-11e9-8f3e-586571366b73.png)

