### PR TITLE
Introduce --quiet option

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1452,6 +1452,7 @@
     "github.com/docker/docker/pkg/archive",
     "github.com/docker/docker/pkg/jsonmessage",
     "github.com/docker/docker/pkg/namesgenerator",
+    "github.com/docker/docker/pkg/stringid",
     "github.com/docker/docker/pkg/term",
     "github.com/docker/docker/registry",
     "github.com/docker/go-units",

--- a/internal/commands/image/list_test.go
+++ b/internal/commands/image/list_test.go
@@ -26,10 +26,10 @@ type bundleStoreStubForListCmd struct {
 	refList []reference.Reference
 }
 
-func (b *bundleStoreStubForListCmd) Store(ref reference.Reference, bndle *bundle.Bundle) (reference.Reference, error) {
+func (b *bundleStoreStubForListCmd) Store(ref reference.Reference, bndle *bundle.Bundle) (reference.Digested, error) {
 	b.refMap[ref] = bndle
 	b.refList = append(b.refList, ref)
-	return ref, nil
+	return store.FromBundle(bndle)
 }
 
 func (b *bundleStoreStubForListCmd) Read(ref reference.Reference) (*bundle.Bundle, error) {

--- a/internal/commands/image/tag_test.go
+++ b/internal/commands/image/tag_test.go
@@ -15,16 +15,17 @@ type bundleStoreStub struct {
 	ReadError    error
 	StoredBundle string
 	StoredError  error
+	StoredID     reference.Digested
 }
 
-func (b *bundleStoreStub) Store(ref reference.Reference, bndle *bundle.Bundle) (reference.Reference, error) {
+func (b *bundleStoreStub) Store(ref reference.Reference, bndle *bundle.Bundle) (reference.Digested, error) {
 	defer func() {
 		b.StoredError = nil
 	}()
 
 	b.StoredBundle = ref.String()
 
-	return ref, b.StoredError
+	return b.StoredID, b.StoredError
 }
 
 func (b *bundleStoreStub) Read(ref reference.Reference) (*bundle.Bundle, error) {

--- a/internal/packager/bundle.go
+++ b/internal/packager/bundle.go
@@ -71,7 +71,7 @@ func MakeCNABImageName(appName, appVersion, suffix string) (string, error) {
 }
 
 // PersistInBundleStore do store a bundle with optional reference and return it's ID
-func PersistInBundleStore(ref reference.Reference, bndle *bundle.Bundle) (reference.Reference, error) {
+func PersistInBundleStore(ref reference.Reference, bndle *bundle.Bundle) (reference.Digested, error) {
 	appstore, err := store.NewApplicationStore(config.Dir())
 	if err != nil {
 		return nil, err

--- a/internal/store/digest.go
+++ b/internal/store/digest.go
@@ -32,21 +32,26 @@ func FromString(s string) (ID, error) {
 	if ok, _ := regexp.MatchString("[a-z0-9]{64}", s); !ok {
 		return ID{}, fmt.Errorf("could not parse '%s' as a valid reference", s)
 	}
-	return ID{s}, nil
+	digest := digest.NewDigestFromEncoded(digest.SHA256, s)
+	return ID{digest}, nil
 }
 
 func FromBundle(bndle *bundle.Bundle) (ID, error) {
 	digest, err := ComputeDigest(bndle)
-	return ID{digest.Encoded()}, err
+	return ID{digest}, err
 }
 
 // ID is an unique identifier for docker app image bundle, implementing reference.Reference
 type ID struct {
-	digest string
+	digest digest.Digest
 }
 
 var _ reference.Reference = ID{}
 
 func (id ID) String() string {
+	return id.digest.Encoded()
+}
+
+func (id ID) Digest() digest.Digest {
 	return id.digest
 }


### PR DESCRIPTION
**- What I did**
Introduce `--quiet` option to `docker app build`. Only output the image digest 

**- How I did it**
used os.DevNull to make BuildX quiet (as a quiet build is not supported https://github.com/docker/buildx/blob/master/commands/build.go#L76)

**- How to verify it**
run `docker app build --quiet .`, will only display the build ID

**- Description for the changelog**
Introduce docker app build `--quiet` option, equivalent to docker build


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/67306294-0507af80-f4f7-11e9-9a86-84f760c75daa.png)

