### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 .gradle
 coverage.html
 cover.out
+.vscode


### PR DESCRIPTION
**- What I did**

Added the .vscode directory to .gitignore so developers can have local launch files for debugging in vscode without risking committing them.

**- A picture of a cute animal (not mandatory but encouraged)**

![pp](https://user-images.githubusercontent.com/22098752/67385543-33cf6580-f58b-11e9-90f0-5562183a4c88.jpg)
