### PR TITLE
Rework docker app image ls and add the --digests flag

### DIFF
--- a/e2e/images_test.go
+++ b/e2e/images_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
-	"gotest.tools/fs"
 	"gotest.tools/icmd"
 )
 
@@ -54,8 +53,6 @@ func verifyImageIDListOutput(t *testing.T, cmd icmd.Cmd, count int, distinct int
 func TestImageList(t *testing.T) {
 	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
 		cmd := info.configuredCmd
-		dir := fs.NewDir(t, "")
-		defer dir.Remove()
 
 		insertBundles(t, cmd, info)
 
@@ -72,8 +69,6 @@ b-simple-app:latest           simple
 func TestImageListQuiet(t *testing.T) {
 	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
 		cmd := info.configuredCmd
-		dir := fs.NewDir(t, "")
-		defer dir.Remove()
 		insertBundles(t, cmd, info)
 		verifyImageIDListOutput(t, cmd, 3, 2)
 	})
@@ -82,8 +77,6 @@ func TestImageListQuiet(t *testing.T) {
 func TestImageListDigests(t *testing.T) {
 	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
 		cmd := info.configuredCmd
-		dir := fs.NewDir(t, "")
-		defer dir.Remove()
 		insertBundles(t, cmd, info)
 		expected := `APP IMAGE                     DIGEST APP NAME
 %s <none> push-pull
@@ -98,8 +91,6 @@ b-simple-app:latest           <none> simple
 func TestImageRm(t *testing.T) {
 	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
 		cmd := info.configuredCmd
-		dir := fs.NewDir(t, "")
-		defer dir.Remove()
 
 		insertBundles(t, cmd, info)
 

--- a/internal/commands/image/list.go
+++ b/internal/commands/image/list.go
@@ -17,7 +17,13 @@ import (
 )
 
 type imageListOption struct {
-	quiet bool
+	quiet   bool
+	digests bool
+}
+
+type imageListColumn struct {
+	header string
+	value  func(p pkg) string
 }
 
 func listCmd(dockerCli command.Cli) *cobra.Command {
@@ -42,6 +48,7 @@ func listCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only show numeric IDs")
+	flags.BoolVarP(&options.digests, "digests", "", false, "Show image digests")
 
 	return cmd
 }
@@ -60,7 +67,7 @@ func runList(dockerCli command.Cli, options imageListOption, bundleStore store.B
 	if options.quiet {
 		return printImageIDs(dockerCli, pkgs)
 	}
-	return printImages(dockerCli, pkgs)
+	return printImages(dockerCli, pkgs, options)
 }
 
 func getPackages(bundleStore store.BundleStore, references []reference.Reference) ([]pkg, error) {
@@ -82,12 +89,12 @@ func getPackages(bundleStore store.BundleStore, references []reference.Reference
 	return packages, nil
 }
 
-func printImages(dockerCli command.Cli, refs []pkg) error {
+func printImages(dockerCli command.Cli, refs []pkg, options imageListOption) error {
 	w := tabwriter.NewWriter(dockerCli.Out(), 0, 0, 1, ' ', 0)
-
-	printHeaders(w)
+	listColumns := getImageListColumns(options)
+	printHeaders(w, listColumns)
 	for _, ref := range refs {
-		printValues(w, ref)
+		printValues(w, ref, listColumns)
 	}
 
 	return w.Flush()
@@ -111,7 +118,7 @@ func printImageIDs(dockerCli command.Cli, refs []pkg) error {
 	return nil
 }
 
-func printHeaders(w io.Writer) {
+func printHeaders(w io.Writer, listColumns []imageListColumn) {
 	var headers []string
 	for _, column := range listColumns {
 		headers = append(headers, column.header)
@@ -119,7 +126,7 @@ func printHeaders(w io.Writer) {
 	fmt.Fprintln(w, strings.Join(headers, "\t"))
 }
 
-func printValues(w io.Writer, ref pkg) {
+func printValues(w io.Writer, ref pkg, listColumns []imageListColumn) {
 	var values []string
 	for _, column := range listColumns {
 		values = append(values, column.value(ref))
@@ -127,19 +134,25 @@ func printValues(w io.Writer, ref pkg) {
 	fmt.Fprintln(w, strings.Join(values, "\t"))
 }
 
-var (
-	listColumns = []struct {
-		header string
-		value  func(p pkg) string
-	}{
+func getImageListColumns(options imageListOption) []imageListColumn {
+	columns := []imageListColumn{
 		{"APP IMAGE", func(p pkg) string {
 			return reference.FamiliarString(p.ref)
 		}},
-		{"APP NAME", func(p pkg) string {
-			return p.bundle.Name
-		}},
 	}
-)
+	if options.digests {
+		columns = append(columns, imageListColumn{"DIGEST", func(p pkg) string {
+			if t, ok := p.ref.(reference.Digested); ok {
+				return t.Digest().String()
+			}
+			return "<none>"
+		}})
+	}
+	columns = append(columns, imageListColumn{"APP NAME", func(p pkg) string {
+		return p.bundle.Name
+	}})
+	return columns
+}
 
 type pkg struct {
 	ref    reference.Reference

--- a/internal/commands/image/list_test.go
+++ b/internal/commands/image/list_test.go
@@ -47,6 +47,55 @@ func (b *bundleStoreStubForListCmd) LookUp(refOrID string) (reference.Reference,
 }
 
 func TestListWithQuietFlag(t *testing.T) {
+	ref, err := store.FromString("a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087")
+	assert.NilError(t, err)
+	refs := []reference.Reference{
+		ref,
+		parseReference(t, "foo/bar:1.0"),
+	}
+	bundles := []bundle.Bundle{
+		{},
+		{
+			Version:       "1.0.0",
+			SchemaVersion: "1.0.0",
+			Name:          "Foo App",
+		},
+	}
+	expectedOutput := `a855ac937f2e
+9aae408ee04f
+`
+	testRunList(t, refs, bundles, imageListOption{quiet: true}, expectedOutput)
+}
+
+func TestListWithDigestsFlag(t *testing.T) {
+	refs := []reference.Reference{
+		parseReference(t, "foo/bar@sha256:b59492bb814012ca3d2ce0b6728242d96b4af41687cc82166a4b5d7f2d9fb865"),
+		parseReference(t, "foo/bar:1.0"),
+	}
+	bundles := []bundle.Bundle{
+		{
+			Name: "Digested App",
+		},
+		{
+			Version:       "1.0.0",
+			SchemaVersion: "1.0.0",
+			Name:          "Foo App",
+		},
+	}
+	expectedOutput := `APP IMAGE                                                                       DIGEST                                                                  APP NAME
+foo/bar@sha256:b59492bb814012ca3d2ce0b6728242d96b4af41687cc82166a4b5d7f2d9fb865 sha256:b59492bb814012ca3d2ce0b6728242d96b4af41687cc82166a4b5d7f2d9fb865 Digested App
+foo/bar:1.0                                                                     <none>                                                                  Foo App
+`
+	testRunList(t, refs, bundles, imageListOption{digests: true}, expectedOutput)
+}
+
+func parseReference(t *testing.T, s string) reference.Reference {
+	ref, err := reference.Parse(s)
+	assert.NilError(t, err)
+	return ref
+}
+
+func testRunList(t *testing.T, refs []reference.Reference, bundles []bundle.Bundle, options imageListOption, expectedOutput string) {
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)
 	dockerCli, err := command.NewDockerCli(command.WithOutputStream(w))
@@ -55,23 +104,12 @@ func TestListWithQuietFlag(t *testing.T) {
 		refMap:  make(map[reference.Reference]*bundle.Bundle),
 		refList: []reference.Reference{},
 	}
-	ref1, err := store.FromString("a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087")
+	for i, ref := range refs {
+		_, err = bundleStore.Store(ref, &bundles[i])
+		assert.NilError(t, err)
+	}
+	err = runList(dockerCli, options, bundleStore)
 	assert.NilError(t, err)
-	ref2, err := reference.Parse("foo/bar:1.0")
-	assert.NilError(t, err)
-	_, err = bundleStore.Store(ref1, &bundle.Bundle{})
-	assert.NilError(t, err)
-	_, err = bundleStore.Store(ref2, &bundle.Bundle{
-		Version:       "1.0.0",
-		SchemaVersion: "1.0.0",
-		Name:          "Foo App",
-	})
-	assert.NilError(t, err)
-	err = runList(dockerCli, imageListOption{quiet: true}, bundleStore)
-	assert.NilError(t, err)
-	expectedOutput := `a855ac937f2e
-9aae408ee04f
-`
 	w.Flush()
 	assert.Equal(t, buf.String(), expectedOutput)
 }


### PR DESCRIPTION
**- WIP**
Need to get an e2e or unit test that covers the digest.

**- What I did**

Reworked the image ls output to better match the `docker image ls` command. The output now has separate columns for REPOSITORY and TAG as well as an APP IMAGE ID column.

Added the --digests flag to image ls. This makes the image ls command print the image digests (if present) along with the other columns.

**- How I did it**

Made the columns list for `image ls` dynamic depending on what options are sent.
The digest is retrieved by attempted to cast to a `Digested` type (i.e. the image has been stored by digest rather than by tag or ID). If not then just prints `<none>`.

**- How to verify it**

Pull an image from hub by digest and then run `app image ls --digest`. The image in question should show the digest prefixed by the algorithm type. E.g.

```
REPOSITORY   TAG    DIGEST          APP IMAGE ID APP NAME
<repository> <none> sha256@<digest> <id>         <name>
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added the `--digests` flag to the `app image ls` command. When present, the command will print the image's digest or `<none>` if the image does not have a digest, along with other image details.

**- A picture of a cute animal (not mandatory but encouraged)**

![pp](https://user-images.githubusercontent.com/22098752/67465329-de539100-f63c-11e9-8361-d257f3eb32c3.jpg)
