### PR TITLE
Use docker build output for binaries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
                                         archiveArtifacts 'bin/*.tar.gz'
                                     }
                                 } finally {
-                                    def clean_images = /docker image ls --format="{{.Repository}}:{{.Tag}}" '*$BUILD_TAG*' | xargs docker image rm -f/
+                                    def clean_images = /docker image ls --format="{{.Repository}}:{{.Tag}}" '*$BUILD_TAG*' | xargs --no-run-if-empty  docker image rm -f/
                                     sh clean_images
                                 }
                             }

--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -45,7 +45,7 @@ pipeline {
                                     }
                                     archiveArtifacts 'bin/*.tar.gz'
                                 } finally {
-                                    def clean_images = /docker image ls --format="{{.Repository}}:{{.Tag}}" '*$TAG*' | xargs docker image rm -f/
+                                    def clean_images = /docker image ls --format="{{.Repository}}:{{.Tag}}" '*$TAG*' | xargs --no-run-if-empty  docker image rm -f/
                                     sh clean_images
                                 }
                             }

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -37,40 +37,19 @@ shell: build_dev_image ## run a shell in the docker build image
 	docker run -ti --rm $(DEV_IMAGE_NAME) bash
 
 cross: create_bin ## cross-compile binaries (linux, darwin, windows)
-	docker build $(BUILD_ARGS) --target=cross -t $(CROSS_IMAGE_NAME) .
-	docker create --name $(CROSS_CTNR_NAME) $(CROSS_IMAGE_NAME) noop
-	docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-linux
-	docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-darwin
-	docker cp $(CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-windows.exe bin/$(BIN_NAME)-windows.exe
-	docker rm $(CROSS_CTNR_NAME)
+	docker build $(BUILD_ARGS) --output type=local,dest=./bin/ --target=cross -t $(CROSS_IMAGE_NAME) .
 	@$(call chmod,+x,bin/$(BIN_NAME)-linux)
 	@$(call chmod,+x,bin/$(BIN_NAME)-darwin)
 	@$(call chmod,+x,bin/$(BIN_NAME)-windows.exe)
 
 cli-cross: create_bin
-	docker build $(BUILD_ARGS) --target=build -t $(CLI_IMAGE_NAME) .
-	docker create --name $(CLI_CNTR_NAME) $(CLI_IMAGE_NAME) noop
-	docker cp $(CLI_CNTR_NAME):/go/src/github.com/docker/cli/build/docker-linux-amd64 bin/docker-linux
-	docker cp $(CLI_CNTR_NAME):/go/src/github.com/docker/cli/build/docker-darwin-amd64 bin/docker-darwin
-	docker cp $(CLI_CNTR_NAME):/go/src/github.com/docker/cli/build/docker-windows-amd64 bin/docker-windows.exe
-	docker rm $(CLI_CNTR_NAME)
+	docker build $(BUILD_ARGS) --output type=local,dest=./bin/ --target=cli -t $(CLI_IMAGE_NAME) .
 	@$(call chmod,+x,bin/docker-linux)
 	@$(call chmod,+x,bin/docker-darwin)
 	@$(call chmod,+x,bin/docker-windows.exe)
 
 e2e-cross: create_bin
-	docker build $(BUILD_ARGS) --target=e2e-cross -t $(E2E_CROSS_IMAGE_NAME)  .
-	docker create --name $(E2E_CROSS_CTNR_NAME) $(E2E_CROSS_IMAGE_NAME) noop
-	docker cp $(E2E_CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-e2e-linux bin/$(BIN_NAME)-e2e-linux
-	docker cp $(E2E_CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-e2e-darwin bin/$(BIN_NAME)-e2e-darwin
-	docker cp $(E2E_CROSS_CTNR_NAME):$(PKG_PATH)/bin/$(BIN_NAME)-e2e-windows.exe bin/$(BIN_NAME)-e2e-windows.exe
-	docker cp $(E2E_CROSS_CTNR_NAME):/usr/local/bin/gotestsum-linux bin/gotestsum-linux
-	docker cp $(E2E_CROSS_CTNR_NAME):/usr/local/bin/gotestsum-darwin bin/gotestsum-darwin
-	docker cp $(E2E_CROSS_CTNR_NAME):/usr/local/bin/gotestsum-windows.exe bin/gotestsum-windows.exe
-	docker cp $(E2E_CROSS_CTNR_NAME):/usr/local/bin/test2json-linux bin/test2json-linux
-	docker cp $(E2E_CROSS_CTNR_NAME):/usr/local/bin/test2json-darwin bin/test2json-darwin
-	docker cp $(E2E_CROSS_CTNR_NAME):/usr/local/bin/test2json-windows.exe bin/test2json-windows.exe
-	docker rm $(E2E_CROSS_CTNR_NAME)
+	docker build $(BUILD_ARGS) --output type=local,dest=./bin/ --target=e2e-cross -t $(E2E_CROSS_IMAGE_NAME)  .
 	@$(call chmod,+x,bin/$(BIN_NAME)-e2e-linux)
 	@$(call chmod,+x,bin/$(BIN_NAME)-e2e-darwin)
 	@$(call chmod,+x,bin/gotestsum-linux)

--- a/docs/yaml/Dockerfile
+++ b/docs/yaml/Dockerfile
@@ -18,7 +18,6 @@ RUN build/yaml-docs-generator \
 FROM scratch
 ARG PROJECT=github.com/docker/app
 ARG PROJECT_PATH=/go/src/${PROJECT}
-ENV PROJECT_PATH=${PROJECT_PATH}
 # CMD cannot be nil so we set it to empty string
 CMD  [""]
 COPY --from=base ${PROJECT_PATH}/docs/reference /docs/reference


### PR DESCRIPTION
**- What I did**
Leveraged `docker build --output` to get artefacts from images. This means that we can avoid doing `docker build && docker container create && docker cp && docker rm`.

**- How I did it**

**- How to verify it**
Existing tests should all pass.

**- Description for the changelog**
N/A


**- A picture of a cute animal (not mandatory but encouraged)**

