### PR TITLE
Feat run labels

### DIFF
--- a/cmd/cnab-run/install.go
+++ b/cmd/cnab-run/install.go
@@ -96,9 +96,8 @@ func addLabels(rendered *composetypes.Config) error {
 	if err != nil {
 		return err
 	}
-	a := packager.DockerAppArgs{}
-	err = json.Unmarshal(args, &a)
-	if err != nil {
+	var a packager.DockerAppArgs
+	if err := json.Unmarshal(args, &a); err != nil {
 		return err
 	}
 	for k, v := range a.Labels {

--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -208,7 +208,6 @@ func TestRunWithLabels(t *testing.T) {
 			"myapp_db", "myapp_web", "myapp_api",
 		}
 		for _, service := range services {
-			fmt.Printf("%q", service)
 			cmd.Command = dockerCli.Command("inspect", service)
 			icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 				ExitCode: 0,

--- a/internal/commands/image/list.go
+++ b/internal/commands/image/list.go
@@ -107,7 +107,7 @@ func printImageIDs(dockerCli command.Cli, refs []pkg) error {
 		}
 		fmt.Fprintln(&buf, stringid.TruncateID(id.String()))
 	}
-	fmt.Fprintf(dockerCli.Out(), buf.String())
+	fmt.Fprint(dockerCli.Out(), buf.String())
 	return nil
 }
 

--- a/internal/commands/image/list_test.go
+++ b/internal/commands/image/list_test.go
@@ -14,12 +14,6 @@ import (
 	"github.com/docker/distribution/reference"
 )
 
-type mockRef string
-
-func (ref mockRef) String() string {
-	return string(ref)
-}
-
 type bundleStoreStubForListCmd struct {
 	refMap map[reference.Reference]*bundle.Bundle
 	// in order to keep the reference in the same order between tests

--- a/internal/commands/parameters.go
+++ b/internal/commands/parameters.go
@@ -49,6 +49,11 @@ func withCommandLineParameters(overrides []string) mergeBundleOpt {
 
 func withLabels(labels []string) mergeBundleOpt {
 	return func(c *mergeBundleConfig) error {
+		for _, l := range labels {
+			if strings.HasPrefix(l, internal.Namespace) {
+				return errors.Errorf("labels cannot start with %q", internal.Namespace)
+			}
+		}
 		l := packager.DockerAppArgs{
 			Labels: cliopts.ConvertKVStringsToMap(labels),
 		}

--- a/internal/commands/parameters.go
+++ b/internal/commands/parameters.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/internal/store"
 	"github.com/docker/app/types/parameters"
 	cliopts "github.com/docker/cli/opts"
@@ -40,6 +42,22 @@ func withCommandLineParameters(overrides []string) mergeBundleOpt {
 		d := cliopts.ConvertKVStringsToMap(overrides)
 		for k, v := range d {
 			c.params[k] = v
+		}
+		return nil
+	}
+}
+
+func withLabels(labels []string) mergeBundleOpt {
+	return func(c *mergeBundleConfig) error {
+		l := packager.DockerAppArgs{
+			Labels: cliopts.ConvertKVStringsToMap(labels),
+		}
+		out, err := json.Marshal(l)
+		if err != nil {
+			return err
+		}
+		if _, ok := c.bundle.Parameters[internal.ParameterArgs]; ok {
+			c.params[internal.ParameterArgs] = string(out)
 		}
 		return nil
 	}

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -25,6 +25,7 @@ type runOptions struct {
 	kubeNamespace string
 	stackName     string
 	cnabBundle    string
+	labels        []string
 }
 
 const longDescription = `Run an App from an App image.`
@@ -59,10 +60,11 @@ func runCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
-	cmd.Flags().StringVar(&opts.orchestrator, "orchestrator", "", "Orchestrator to run on (swarm, kubernetes)")
-	cmd.Flags().StringVar(&opts.kubeNamespace, "namespace", "default", "Kubernetes namespace in which to run the App")
-	cmd.Flags().StringVar(&opts.stackName, "name", "", "Name of the running App")
-	cmd.Flags().StringVar(&opts.cnabBundle, "cnab-bundle-json", "", "Run a CNAB bundle instead of a Docker App image")
+	cmd.Flags().StringVar(&opts.orchestrator, "orchestrator", "", "Orchestrator to install on (swarm, kubernetes)")
+	cmd.Flags().StringVar(&opts.kubeNamespace, "namespace", "default", "Kubernetes namespace to install into")
+	cmd.Flags().StringVar(&opts.stackName, "name", "", "Assign a name to the installation")
+	cmd.Flags().StringVar(&opts.cnabBundle, "cnab-bundle-json", "", "Run a CNAB bundle instead of a Docker App")
+	cmd.Flags().StringArrayVar(&opts.labels, "label", nil, "Label to add to services")
 
 	return cmd
 }
@@ -130,6 +132,7 @@ func runBundle(dockerCli command.Cli, bndl *bundle.Bundle, opts runOptions, ref 
 	if err := mergeBundleParameters(installation,
 		withFileParameters(opts.parametersFiles),
 		withCommandLineParameters(opts.overrides),
+		withLabels(opts.labels),
 		withOrchestratorParameters(opts.orchestrator, opts.kubeNamespace),
 		withSendRegistryAuth(opts.sendRegistryAuth),
 	); err != nil {

--- a/internal/names.go
+++ b/internal/names.go
@@ -52,6 +52,8 @@ const (
 	ParameterRenderFormatName = Namespace + "render-format"
 	// ParameterInspectFormatName is the name of the parameter containing the inspect format
 	ParameterInspectFormatName = Namespace + "inspect-format"
+	// ParameterArgs is the name of the parameter containing labels to be applied to service containers
+	ParameterArgs = Namespace + "args"
 	// ParameterShareRegistryCredsName is the name of the parameter which indicates if credentials should be shared
 	ParameterShareRegistryCredsName = Namespace + "share-registry-creds"
 
@@ -67,6 +69,8 @@ const (
 	// DockerInspectFormatEnvVar is the environment variable set by the CNAB runtime to select
 	// the inspect output format.
 	DockerInspectFormatEnvVar = "DOCKER_INSPECT_FORMAT"
+
+	DockerArgsPath = "/cnab/app/args.json"
 
 	// CustomDockerAppName is the custom variable set by Docker App to
 	// save custom informations

--- a/internal/packager/cnab.go
+++ b/internal/packager/cnab.go
@@ -38,8 +38,8 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 		internal.ParameterArgs: {
 			Type:        "string",
 			Default:     "",
-			Title:       "Labels",
-			Description: "Labels to apply to service containers",
+			Title:       "Arguments",
+			Description: "Arguments that are passed by file to the invocation image",
 		},
 		internal.ParameterOrchestratorName: {
 			Type: "string",

--- a/internal/packager/cnab.go
+++ b/internal/packager/cnab.go
@@ -23,11 +23,24 @@ type DockerAppCustom struct {
 	Payload json.RawMessage `json:"payload,omitempty"`
 }
 
+// DockerAppArgs represent the object passed to the invocation image
+// by Docker App.
+type DockerAppArgs struct {
+	// Labels are the labels to add to containers on run
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
 // ToCNAB creates a CNAB bundle from an app package
 func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) {
 	mapping := ExtractCNABParameterMapping(app.Parameters())
 	flatParameters := app.Parameters().Flatten()
 	definitions := definition.Definitions{
+		internal.ParameterArgs: {
+			Type:        "string",
+			Default:     "",
+			Title:       "Labels",
+			Description: "Labels to apply to service containers",
+		},
 		internal.ParameterOrchestratorName: {
 			Type: "string",
 			Enum: []interface{}{
@@ -73,6 +86,16 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 		},
 	}
 	parameters := map[string]bundle.Parameter{
+		internal.ParameterArgs: {
+			Destination: &bundle.Location{
+				Path: internal.DockerArgsPath,
+			},
+			ApplyTo: []string{
+				"install",
+				"upgrade",
+			},
+			Definition: internal.ParameterArgs,
+		},
 		internal.ParameterOrchestratorName: {
 			Destination: &bundle.Location{
 				EnvironmentVariable: internal.DockerStackOrchestratorEnvVar,

--- a/internal/packager/testdata/bundle-json.golden
+++ b/internal/packager/testdata/bundle-json.golden
@@ -51,6 +51,16 @@
     "io.cnab.status": {}
   },
   "parameters": {
+    "com.docker.app.args": {
+      "definition": "com.docker.app.args",
+      "applyTo": [
+        "install",
+        "upgrade"
+      ],
+      "destination": {
+        "path": "/cnab/app/args.json"
+      }
+    },
     "com.docker.app.inspect-format": {
       "definition": "com.docker.app.inspect-format",
       "applyTo": [
@@ -115,6 +125,12 @@
     }
   },
   "definitions": {
+    "com.docker.app.args": {
+      "default": "",
+      "description": "Arguments that are passed by file to the invocation image",
+      "title": "Arguments",
+      "type": "string"
+    },
     "com.docker.app.inspect-format": {
       "default": "json",
       "description": "Output format for the inspect command",


### PR DESCRIPTION
**- What I did**
 Added `--label` flag when running an application

This will add the given labels to all the containers inside the
application (except for the invocation image). The labels are passed
over by file, this is to be able to easely add new parameters in the
future and limit the explosion of parameters we have in our bundle


**- Description for the changelog**
Add labels to service containers with the `--label` flag on `run`.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/67582483-23b1b480-f74a-11e9-8b69-5a0953a5d7df.png)

