### PR TITLE
Picture of animal in PR should really be optional

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,5 +26,5 @@ pull request for inclusion in the changelog:
 -->
 
 
-**- A picture of a cute animal (not mandatory but encouraged)**
+**- A picture of a cute animal (not mandatory)**
 


### PR DESCRIPTION
Because it's only folklore and should not be a blocker.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/app/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Just removed the `but encouraged` about picture of animal in PR template

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
