### PR TITLE
render command renders App image only

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -75,16 +75,14 @@ func testRenderApp(appPath string, env ...string) func(*testing.T) {
 	}
 }
 
-func TestRenderAppDirectoryFails(t *testing.T) {
+func TestRenderAppNotFound(t *testing.T) {
 	cmd, cleanup := dockerCli.createTestCmd()
 	defer cleanup()
-	appPath := filepath.Join("testdata", "envfile", "envfile.dockerapp")
 
-	cmd.Command = dockerCli.Command("app", "render", appPath)
-	icmd.RunCmd(cmd).Assert(t, icmd.Expected{
-		ExitCode: 1,
-		Err:      fmt.Sprintf("%q looks like a docker App directory and App must be built first before rendering", appPath),
-	})
+	appName := "non_existing_app:some_tag"
+	cmd.Command = dockerCli.Command("app", "render", appName)
+	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Expected{ExitCode: 1}).Combined(),
+		[]string{fmt.Sprintf("could not render %q: no such App image", appName)})
 }
 
 func TestRenderFormatters(t *testing.T) {

--- a/e2e/envfile_test.go
+++ b/e2e/envfile_test.go
@@ -12,7 +12,10 @@ func TestRenderWithEnvFile(t *testing.T) {
 	defer cleanup()
 	appPath := filepath.Join("testdata", "envfile", "envfile.dockerapp")
 
-	cmd.Command = dockerCli.Command("app", "render", appPath)
+	cmd.Command = dockerCli.Command("app", "build", "-f", appPath, "--tag", "a-simple-tag", "--no-resolve-image", ".")
+	icmd.RunCmd(cmd).Assert(t, icmd.Success)
+
+	cmd.Command = dockerCli.Command("app", "render", "a-simple-tag")
 	icmd.RunCmd(cmd).Assert(t, icmd.Expected{Out: `version: "3.7"
 services:
   db:

--- a/internal/commands/render.go
+++ b/internal/commands/render.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/docker/app/internal"
@@ -14,6 +13,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -78,10 +78,7 @@ func prepareCustomAction(actionName string, dockerCli command.Cli, appname strin
 	}
 	bundle, ref, err := cnab.GetBundle(dockerCli, bundleStore, appname)
 	if err != nil {
-		if strings.HasSuffix(appname, ".dockerapp") {
-			return nil, nil, nil, fmt.Errorf("%q looks like a docker App directory and App must be built first before rendering", appname)
-		}
-		return nil, nil, nil, err
+		return nil, nil, nil, errors.Wrapf(err, "could not render %q: no such App image", appname)
 	}
 	installation, err := appstore.NewInstallation("custom-action", ref.String())
 	if err != nil {

--- a/internal/commands/render.go
+++ b/internal/commands/render.go
@@ -28,10 +28,10 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 		Use:     "render [OPTIONS] APP_IMAGE",
 		Short:   "Render the Compose file for an App image",
 		Example: `$ docker app render myrepo/myapp:1.0.0 --set key=value --parameters-file myparam.yml`,
-		Args:    cli.RequiresMaxArgs(1),
+		Args:    cli.ExactArgs(1),
 		Hidden:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRender(dockerCli, firstOrEmpty(args), opts)
+			return runRender(dockerCli, args[0], opts)
 		},
 	}
 	opts.parametersOptions.addFlags(cmd.Flags())
@@ -75,11 +75,11 @@ func prepareCustomAction(actionName string, dockerCli command.Cli, appname strin
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	bundle, ref, err := cnab.ResolveBundle(dockerCli, bundleStore, appname)
+	bundle, ref, err := cnab.GetBundle(dockerCli, bundleStore, appname)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	installation, err := appstore.NewInstallation("custom-action", ref)
+	installation, err := appstore.NewInstallation("custom-action", ref.String())
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/commands/render.go
+++ b/internal/commands/render.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/docker/app/internal"
@@ -77,6 +78,9 @@ func prepareCustomAction(actionName string, dockerCli command.Cli, appname strin
 	}
 	bundle, ref, err := cnab.GetBundle(dockerCli, bundleStore, appname)
 	if err != nil {
+		if strings.HasSuffix(appname, ".dockerapp") {
+			return nil, nil, nil, fmt.Errorf("%q looks like a docker App directory and App must be built first before rendering", appname)
+		}
 		return nil, nil, nil, err
 	}
 	installation, err := appstore.NewInstallation("custom-action", ref.String())


### PR DESCRIPTION
**- What I did**
This PR ensure that the `docker app render` takes a App image reference argument and fails when a `.dockerapp` directory is used. If the image is not present locally in the bundle store, the App image is automatically fetched.

**- How to verify it**
Run `docker app render myapp.dockerapp` and verify it fails with an error indicating that App must be built first.
Run `docker app render myapp:mytag --set param=some_value` and verify the app is correctly rendered.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/470082/67945251-bfc23c80-fbde-11e9-8241-5be189721ab0.png)
