### PR TITLE
Move render command under image command

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -49,7 +49,7 @@ func testRenderApp(appPath string, env ...string) func(*testing.T) {
 		defer dir.Remove()
 
 		// Build the App
-		cmd.Command = dockerCli.Command("app", "build", ".", "--folder", filepath.Join(appPath, "my.dockerapp"), "--tag", "a-simple-tag", "--no-resolve-image")
+		cmd.Command = dockerCli.Command("app", "build", ".", "--file", filepath.Join(appPath, "my.dockerapp"), "--tag", "a-simple-tag", "--no-resolve-image")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 		// Render the App
@@ -57,7 +57,7 @@ func testRenderApp(appPath string, env ...string) func(*testing.T) {
 		data, err := ioutil.ReadFile(filepath.Join(appPath, "env.yml"))
 		assert.NilError(t, err)
 		assert.NilError(t, yaml.Unmarshal(data, &envParameters))
-		args := dockerCli.Command("app", "render", "a-simple-tag", "--parameters-file", filepath.Join(appPath, "parameters-0.yml"))
+		args := dockerCli.Command("app", "image", "render", "a-simple-tag", "--parameters-file", filepath.Join(appPath, "parameters-0.yml"))
 		for k, v := range envParameters {
 			args = append(args, "--set", fmt.Sprintf("%s=%s", k, v))
 		}
@@ -80,7 +80,7 @@ func TestRenderAppNotFound(t *testing.T) {
 	defer cleanup()
 
 	appName := "non_existing_app:some_tag"
-	cmd.Command = dockerCli.Command("app", "render", appName)
+	cmd.Command = dockerCli.Command("app", "image", "render", appName)
 	checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Expected{ExitCode: 1}).Combined(),
 		[]string{fmt.Sprintf("could not render %q: no such App image", appName)})
 }
@@ -93,11 +93,11 @@ func TestRenderFormatters(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "build", "--tag", "a-simple-tag", "--no-resolve-image", contextPath)
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-		cmd.Command = dockerCli.Command("app", "render", "--formatter", "json", "a-simple-tag")
+		cmd.Command = dockerCli.Command("app", "image", "render", "--formatter", "json", "a-simple-tag")
 		result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
 		golden.Assert(t, result.Stdout(), "expected-json-render.golden")
 
-		cmd.Command = dockerCli.Command("app", "render", "--formatter", "yaml", "a-simple-tag")
+		cmd.Command = dockerCli.Command("app", "image", "render", "--formatter", "yaml", "a-simple-tag")
 		result = icmd.RunCmd(cmd).Assert(t, icmd.Success)
 		golden.Assert(t, result.Stdout(), "expected-yaml-render.golden")
 	})

--- a/e2e/envfile_test.go
+++ b/e2e/envfile_test.go
@@ -15,7 +15,7 @@ func TestRenderWithEnvFile(t *testing.T) {
 	cmd.Command = dockerCli.Command("app", "build", "-f", appPath, "--tag", "a-simple-tag", "--no-resolve-image", ".")
 	icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-	cmd.Command = dockerCli.Command("app", "render", "a-simple-tag")
+	cmd.Command = dockerCli.Command("app", "image", "render", "a-simple-tag")
 	icmd.RunCmd(cmd).Assert(t, icmd.Expected{Out: `version: "3.7"
 services:
   db:

--- a/internal/cliopts/parameters.go
+++ b/internal/cliopts/parameters.go
@@ -1,0 +1,17 @@
+package cliopts
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// ParametersOptions are shared CLI options about docker app parameters
+type ParametersOptions struct {
+	ParametersFiles []string
+	Overrides       []string
+}
+
+// AddFlags adds the shared CLI flags to the given flag set
+func (o *ParametersOptions) AddFlags(flags *pflag.FlagSet) {
+	flags.StringArrayVar(&o.ParametersFiles, "parameters-file", []string{}, "Override parameters file")
+	flags.StringArrayVarP(&o.Overrides, "set", "s", []string{}, "Override parameter value")
+}

--- a/internal/commands/image/command.go
+++ b/internal/commands/image/command.go
@@ -17,6 +17,7 @@ func Cmd(dockerCli command.Cli) *cobra.Command {
 		rmCmd(),
 		tagCmd(),
 		inspectCmd(dockerCli),
+		renderCmd(dockerCli),
 	)
 
 	return cmd

--- a/internal/commands/image/render.go
+++ b/internal/commands/image/render.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/spf13/pflag"
+	"github.com/docker/app/internal/cliopts"
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/docker/app/internal"
@@ -20,18 +20,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type parametersOptions struct {
-	ParametersFiles []string
-	Overrides       []string
-}
-
-func (o *parametersOptions) addFlags(flags *pflag.FlagSet) {
-	flags.StringArrayVar(&o.ParametersFiles, "parameters-file", []string{}, "Override parameters file")
-	flags.StringArrayVarP(&o.Overrides, "set", "s", []string{}, "Override parameter value")
-}
-
 type renderOptions struct {
-	parametersOptions
+	cliopts.ParametersOptions
 	formatDriver string
 	renderOutput string
 }
@@ -48,7 +38,7 @@ func renderCmd(dockerCli command.Cli) *cobra.Command {
 			return runRender(dockerCli, args[0], opts)
 		},
 	}
-	opts.parametersOptions.addFlags(cmd.Flags())
+	opts.ParametersOptions.AddFlags(cmd.Flags())
 	cmd.Flags().StringVarP(&opts.renderOutput, "output", "o", "-", "Output file")
 	cmd.Flags().StringVar(&opts.formatDriver, "formatter", "yaml", "Configure the output format (yaml|json)")
 
@@ -68,7 +58,7 @@ func runRender(dockerCli command.Cli, appname string, opts renderOptions) error 
 		w = f
 	}
 
-	action, installation, errBuf, err := prepareCustomAction(internal.ActionRenderName, dockerCli, appname, w, opts.parametersOptions)
+	action, installation, errBuf, err := prepareCustomAction(internal.ActionRenderName, dockerCli, appname, w, opts.ParametersOptions)
 	if err != nil {
 		return err
 	}
@@ -80,7 +70,8 @@ func runRender(dockerCli command.Cli, appname string, opts renderOptions) error 
 	return nil
 }
 
-func prepareCustomAction(actionName string, dockerCli command.Cli, appname string, stdout io.Writer, paramsOpts parametersOptions) (*action.RunCustom, *appstore.Installation, *bytes.Buffer, error) {
+func prepareCustomAction(actionName string, dockerCli command.Cli, appname string, stdout io.Writer,
+	paramsOpts cliopts.ParametersOptions) (*action.RunCustom, *appstore.Installation, *bytes.Buffer, error) {
 	s, err := appstore.NewApplicationStore(config.Dir())
 	if err != nil {
 		return nil, nil, nil, err

--- a/internal/commands/image/render.go
+++ b/internal/commands/image/render.go
@@ -1,4 +1,4 @@
-package commands
+package image
 
 import (
 	"bytes"
@@ -6,8 +6,11 @@ import (
 	"io"
 	"os"
 
+	"github.com/spf13/pflag"
+
 	"github.com/deislabs/cnab-go/action"
 	"github.com/docker/app/internal"
+	bdl "github.com/docker/app/internal/bundle"
 	"github.com/docker/app/internal/cnab"
 	appstore "github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli"
@@ -16,6 +19,16 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
+
+type parametersOptions struct {
+	ParametersFiles []string
+	Overrides       []string
+}
+
+func (o *parametersOptions) addFlags(flags *pflag.FlagSet) {
+	flags.StringArrayVar(&o.ParametersFiles, "parameters-file", []string{}, "Override parameters file")
+	flags.StringArrayVarP(&o.Overrides, "set", "s", []string{}, "Override parameter value")
+}
 
 type renderOptions struct {
 	parametersOptions
@@ -86,9 +99,9 @@ func prepareCustomAction(actionName string, dockerCli command.Cli, appname strin
 	}
 	installation.Bundle = bundle
 
-	if err := mergeBundleParameters(installation,
-		withFileParameters(paramsOpts.parametersFiles),
-		withCommandLineParameters(paramsOpts.overrides),
+	if err := bdl.MergeBundleParameters(installation,
+		bdl.WithFileParameters(paramsOpts.ParametersFiles),
+		bdl.WithCommandLineParameters(paramsOpts.Overrides),
 	); err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -54,7 +54,6 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		removeCmd(dockerCli),
 		listCmd(dockerCli),
 		initCmd(dockerCli),
-		renderCmd(dockerCli),
 		validateCmd(),
 		pushCmd(dockerCli),
 		pullCmd(dockerCli),

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -110,16 +110,6 @@ func prepareBundleStore() (store.BundleStore, error) {
 	return bundleStore, nil
 }
 
-type parametersOptions struct {
-	parametersFiles []string
-	overrides       []string
-}
-
-func (o *parametersOptions) addFlags(flags *pflag.FlagSet) {
-	flags.StringArrayVar(&o.parametersFiles, "parameters-file", []string{}, "Override parameters file")
-	flags.StringArrayVarP(&o.overrides, "set", "s", []string{}, "Override parameter value")
-}
-
 type targetContextOptions struct {
 	targetContext string
 }

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/docker/cli/cli"
+	"github.com/docker/app/internal/cliopts"
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/bundle"
@@ -12,6 +12,7 @@ import (
 	bdl "github.com/docker/app/internal/bundle"
 	"github.com/docker/app/internal/cnab"
 	"github.com/docker/app/internal/store"
+	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/pkg/errors"
@@ -20,7 +21,7 @@ import (
 )
 
 type runOptions struct {
-	parametersOptions
+	cliopts.ParametersOptions
 	credentialOptions
 	orchestrator  string
 	kubeNamespace string
@@ -59,7 +60,7 @@ func runCmd(dockerCli command.Cli) *cobra.Command {
 			return runCnab(dockerCli, opts)
 		},
 	}
-	opts.parametersOptions.addFlags(cmd.Flags())
+	opts.ParametersOptions.AddFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.orchestrator, "orchestrator", "", "Orchestrator to install on (swarm, kubernetes)")
 	cmd.Flags().StringVar(&opts.kubeNamespace, "namespace", "default", "Kubernetes namespace to install into")
@@ -131,8 +132,8 @@ func runBundle(dockerCli command.Cli, bndl *bundle.Bundle, opts runOptions, ref 
 	installation.Bundle = bndl
 
 	if err := bdl.MergeBundleParameters(installation,
-		bdl.WithFileParameters(opts.parametersFiles),
-		bdl.WithCommandLineParameters(opts.overrides),
+		bdl.WithFileParameters(opts.ParametersFiles),
+		bdl.WithCommandLineParameters(opts.Overrides),
 		bdl.WithLabels(opts.labels),
 		bdl.WithOrchestratorParameters(opts.orchestrator, opts.kubeNamespace),
 		bdl.WithSendRegistryAuth(opts.sendRegistryAuth),

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/credentials"
+	bdl "github.com/docker/app/internal/bundle"
 	"github.com/docker/app/internal/cnab"
 	"github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli/command"
@@ -129,12 +130,12 @@ func runBundle(dockerCli command.Cli, bndl *bundle.Bundle, opts runOptions, ref 
 	driverImpl, errBuf := cnab.PrepareDriver(dockerCli, bind, nil)
 	installation.Bundle = bndl
 
-	if err := mergeBundleParameters(installation,
-		withFileParameters(opts.parametersFiles),
-		withCommandLineParameters(opts.overrides),
-		withLabels(opts.labels),
-		withOrchestratorParameters(opts.orchestrator, opts.kubeNamespace),
-		withSendRegistryAuth(opts.sendRegistryAuth),
+	if err := bdl.MergeBundleParameters(installation,
+		bdl.WithFileParameters(opts.parametersFiles),
+		bdl.WithCommandLineParameters(opts.overrides),
+		bdl.WithLabels(opts.labels),
+		bdl.WithOrchestratorParameters(opts.orchestrator, opts.kubeNamespace),
+		bdl.WithSendRegistryAuth(opts.sendRegistryAuth),
 	); err != nil {
 		return err
 	}

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/credentials"
+	"github.com/docker/app/internal/bundle"
 	"github.com/docker/app/internal/cnab"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
@@ -60,10 +61,10 @@ func runUpdate(dockerCli command.Cli, installationName string, opts updateOption
 		}
 		installation.Bundle = b
 	}
-	if err := mergeBundleParameters(installation,
-		withFileParameters(opts.parametersFiles),
-		withCommandLineParameters(opts.overrides),
-		withSendRegistryAuth(opts.sendRegistryAuth),
+	if err := bundle.MergeBundleParameters(installation,
+		bundle.WithFileParameters(opts.parametersFiles),
+		bundle.WithCommandLineParameters(opts.overrides),
+		bundle.WithSendRegistryAuth(opts.sendRegistryAuth),
 	); err != nil {
 		return err
 	}

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -7,13 +7,14 @@ import (
 	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/credentials"
 	"github.com/docker/app/internal/bundle"
+	"github.com/docker/app/internal/cliopts"
 	"github.com/docker/app/internal/cnab"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
 type updateOptions struct {
-	parametersOptions
+	cliopts.ParametersOptions
 	credentialOptions
 	bundleOrDockerApp string
 }
@@ -29,7 +30,7 @@ func updateCmd(dockerCli command.Cli) *cobra.Command {
 			return runUpdate(dockerCli, args[0], opts)
 		},
 	}
-	opts.parametersOptions.addFlags(cmd.Flags())
+	opts.ParametersOptions.AddFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.bundleOrDockerApp, "image", "", "Override the running App with another App image")
 
@@ -62,8 +63,8 @@ func runUpdate(dockerCli command.Cli, installationName string, opts updateOption
 		installation.Bundle = b
 	}
 	if err := bundle.MergeBundleParameters(installation,
-		bundle.WithFileParameters(opts.parametersFiles),
-		bundle.WithCommandLineParameters(opts.overrides),
+		bundle.WithFileParameters(opts.ParametersFiles),
+		bundle.WithCommandLineParameters(opts.Overrides),
 		bundle.WithSendRegistryAuth(opts.sendRegistryAuth),
 	); err != nil {
 		return err

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -4,18 +4,19 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/docker/app/internal/cliopts"
 	"github.com/docker/app/internal/compose"
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/render"
 	"github.com/docker/app/types"
 	"github.com/docker/cli/cli"
-	cliopts "github.com/docker/cli/opts"
+	dockercliopts "github.com/docker/cli/opts"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 type validateOptions struct {
-	parametersOptions
+	cliopts.ParametersOptions
 }
 
 func validateCmd() *cobra.Command {
@@ -29,19 +30,19 @@ func validateCmd() *cobra.Command {
 			return runValidate(args, opts)
 		},
 	}
-	opts.parametersOptions.addFlags(cmd.Flags())
+	opts.ParametersOptions.AddFlags(cmd.Flags())
 	return cmd
 }
 
 func runValidate(args []string, opts validateOptions) error {
 	app, err := packager.Extract(firstOrEmpty(args),
-		types.WithParametersFiles(opts.parametersFiles...),
+		types.WithParametersFiles(opts.ParametersFiles...),
 	)
 	if err != nil {
 		return err
 	}
 	defer app.Cleanup()
-	argParameters := cliopts.ConvertKVStringsToMap(opts.overrides)
+	argParameters := dockercliopts.ConvertKVStringsToMap(opts.Overrides)
 	_, err = render.Render(app, argParameters, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
**- What I did**
Remove the `render` command and move it as new `image` subcommand.

**- How I did it**
Move `render.go` into image package.
Bundle parameters merging algorithm is invoked from some root commands and `image render` command. Therefore the bundle parameters merging had to be move to a dedicated package in order to avoid go package cycles.

**- How to verify it**

- run `docker app render myapp:mytag` and ensure the command does not exist 
- run `docker app image render myapp:mytag` and verify the App is rendered

**- A picture of a cute animal (not mandatory)**

![image](https://user-images.githubusercontent.com/470082/68216701-9db32a80-ffe1-11e9-8f28-f4e2acfc8bf4.png)
