### PR TITLE
APP-304 Update e2e tests using --folder flag

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -49,7 +49,7 @@ func testRenderApp(appPath string, env ...string) func(*testing.T) {
 		defer dir.Remove()
 
 		// Build the App
-		cmd.Command = dockerCli.Command("app", "build", ".", "--folder", filepath.Join(appPath, "my.dockerapp"), "--tag", "a-simple-tag", "--no-resolve-image")
+		cmd.Command = dockerCli.Command("app", "build", ".", "--file", filepath.Join(appPath, "my.dockerapp"), "--tag", "a-simple-tag", "--no-resolve-image")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 		// Render the App


### PR DESCRIPTION
**- What I did**
Updated the e2e tests that were using the --folder flag

**- How to verify it**
The e2e `TestRender/envvariables` test  should pass now.

**- A picture of a cute animal (not mandatory)**

![image](https://user-images.githubusercontent.com/809903/68292047-5ed9af00-008b-11ea-8ab5-546fa86ce757.png)

Signed-off-by: Anca Iordache anca.iordache@docker.com