### PR TITLE
Don't show ID as repository in image ls

### DIFF
--- a/internal/commands/image/list.go
+++ b/internal/commands/image/list.go
@@ -148,7 +148,7 @@ func getImageListColumns(options imageListOption) []imageListColumn {
 			if n, ok := p.ref.(reference.Named); ok {
 				return reference.FamiliarName(n)
 			}
-			return reference.FamiliarString(p.ref)
+			return "<none>"
 		}},
 		{"TAG", func(p pkg) string {
 			if t, ok := p.ref.(reference.Tagged); ok {

--- a/internal/commands/image/list_test.go
+++ b/internal/commands/image/list_test.go
@@ -75,19 +75,19 @@ func TestListCmd(t *testing.T) {
 	}{
 		{
 			name: "TestList",
-			expectedOutput: `REPOSITORY                                                       TAG    APP IMAGE ID APP NAME
-foo/bar                                                          <none> 3f825b2d0657 Digested App
-foo/bar                                                          1.0    9aae408ee04f Foo App
-a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087 <none> a855ac937f2e Quiet App
+			expectedOutput: `REPOSITORY TAG    APP IMAGE ID APP NAME
+foo/bar    <none> 3f825b2d0657 Digested App
+foo/bar    1.0    9aae408ee04f Foo App
+<none>     <none> a855ac937f2e Quiet App
 `,
 			options: imageListOption{},
 		},
 		{
 			name: "TestListWithDigests",
-			expectedOutput: `REPOSITORY                                                       TAG    DIGEST                                                                  APP IMAGE ID APP NAME
-foo/bar                                                          <none> sha256:b59492bb814012ca3d2ce0b6728242d96b4af41687cc82166a4b5d7f2d9fb865 3f825b2d0657 Digested App
-foo/bar                                                          1.0    <none>                                                                  9aae408ee04f Foo App
-a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087 <none> sha256:a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087 a855ac937f2e Quiet App
+			expectedOutput: `REPOSITORY TAG    DIGEST                                                                  APP IMAGE ID APP NAME
+foo/bar    <none> sha256:b59492bb814012ca3d2ce0b6728242d96b4af41687cc82166a4b5d7f2d9fb865 3f825b2d0657 Digested App
+foo/bar    1.0    <none>                                                                  9aae408ee04f Foo App
+<none>     <none> sha256:a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087 a855ac937f2e Quiet App
 `,
 			options: imageListOption{digests: true},
 		},


### PR DESCRIPTION
**- What I did**

When running `image ls` images without a repository no longer print
their ID as their repository.

**- How I did it**

If the image isn't a `reference.Named` then print `<none>` instead of the `FamiliarString` for the REPOSITORY column

**- How to verify it**

Pull an image from hub by digest and then run app image ls --digest. The image in question should show the digest prefixed by the algorithm type. E.g.

```
REPOSITORY   TAG    DIGEST          APP IMAGE ID APP NAME
<none>       <none> sha256:<digest> <id>         <name>
```

**- Description for the changelog**

`image ls` prints `<none>` in as the repository when the image does not have a tag

**- A picture of a cute animal (not mandatory)**

![animalissue2-1-43f2a278bdb53e2e](https://user-images.githubusercontent.com/22098752/68335776-04fdd700-00d5-11ea-82ab-c284b0e9f7c9.jpg)
