### PR TITLE
Add note to enable BuildKit to build in docker

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -69,8 +69,12 @@ Please refer to its documentation if you need to update a dependency.
 ## Build using Docker
 
 If you don't have Go installed but Docker is present, you can also use
-`docker.Makefile` to build `docker-app` and run tests. This
-`docker.Makefile` is used by our continuous integration too.
+`docker.Makefile` to build `docker-app` and run tests.
+
+To use `docker.Makefile` you will need to enable BuildKit.
+This is done by setting the environment variable `DOCKER_BUILDKIT=1`
+
+This `docker.Makefile` is used by our continuous integration too.
 
 ```sh
 make -f docker.Makefile           # builds cross binaries build and tests


### PR DESCRIPTION
**- What I did**

Adds a note in the "Build using Docker" section of BUILDING.md to explain that BuildKit is required and how to enable it.

**- A picture of a cute animal (not mandatory)**

![hedgehog-2019-11-07](https://user-images.githubusercontent.com/22098752/68384501-a3c71980-014f-11ea-9d6e-209ee13b7e11.jpg)

