### PR TITLE
Make flag cnab-bunle-json experimental

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -72,6 +72,9 @@ func runCmd(dockerCli command.Cli) *cobra.Command {
 	cmd.Flags().StringVar(&opts.cnabBundle, "cnab-bundle-json", "", "Run a CNAB bundle instead of a Docker App")
 	cmd.Flags().StringArrayVar(&opts.labels, "label", nil, "Label to add to services")
 
+	//nolint:errcheck
+	cmd.Flags().SetAnnotation("cnab-bundle-json", "experimental", []string{"true"})
+
 	return cmd
 }
 


### PR DESCRIPTION
**- What I did**

Once app is GA and no longer hidden experimental we will want to hide
the cnab-bundle-json flag if the user didn't activate experimental
features. docker/cli was updated to latest that had the fix for cli
plugins to be able to get the client configuration (https://github.com/docker/cli/pull/2095)

**- How to verify it**

Can't really verify it for now, nor can I write a test for this...

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/99933/68479713-486e5780-0233-11ea-9ce0-3d250f5f298a.png)

