### PR TITLE
Only push applications from the local store

### DIFF
--- a/e2e/pushpull_test.go
+++ b/e2e/pushpull_test.go
@@ -11,6 +11,27 @@ import (
 	"gotest.tools/icmd"
 )
 
+func TestPushUnknown(t *testing.T) {
+	cmd, cleanup := dockerCli.createTestCmd()
+	defer cleanup()
+
+	t.Run("push unknown reference", func(t *testing.T) {
+		cmd.Command = dockerCli.Command("app", "push", "unknown")
+		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      `could not push "unknown:latest": no such App image: failed to read bundle "docker.io/library/unknown:latest": unknown:latest: reference not found`,
+		})
+	})
+
+	t.Run("push invalid reference", func(t *testing.T) {
+		cmd.Command = dockerCli.Command("app", "push", "@")
+		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      `could not push "@": invalid reference format`,
+		})
+	})
+}
+
 func TestPushInsecureRegistry(t *testing.T) {
 	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
 		path := filepath.Join("testdata", "local")


### PR DESCRIPTION
**- What I did**

`cnab.ResolveBundle` would try the local store first and pull if the app
is not found. This is not what we want when we push. We only want to
push local applications.

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/99933/68482037-f03a5400-0238-11ea-910a-11aa7b323484.png)

