### PR TITLE
--installer-context option is experimental

### DIFF
--- a/internal/cliopts/installerContext.go
+++ b/internal/cliopts/installerContext.go
@@ -22,6 +22,7 @@ func (o *InstallerContextOptions) AddFlags(flags *pflag.FlagSet) {
 		defaultContext = "default"
 	}
 	flags.StringVar(&o.installerContext, "installer-context", defaultContext, "Context on which the installer image is ran")
+	flags.SetAnnotation("installer-context", "experimentalCLI", []string{"true"}) //nolint:errcheck
 }
 
 func (o *InstallerContextOptions) SetInstallerContext(dockerCli command.Cli) (command.Cli, error) {

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -26,7 +26,7 @@ func validateCmd() *cobra.Command {
 		Short:       "Check that an App definition (.dockerapp) is syntactically correct",
 		Example:     `$ docker app validate myapp.dockerapp --set key=value --parameters-file myparam.yml`,
 		Args:        cli.RequiresMaxArgs(1),
-		Annotations: map[string]string{"experimental": "true"},
+		Annotations: map[string]string{"experimentalCLI": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runValidate(args, opts)
 		},


### PR DESCRIPTION
**- What I did**
Made `installer-context` option experimental

**- How I did it**
Annotate as experimental:true

**- How to verify it**
if experimental is disabled, option is not available

**- Description for the changelog**
`installer-context` option is experimental

**- A picture of a cute animal (not mandatory)**

![image](https://user-images.githubusercontent.com/132757/68482835-ae121200-023a-11ea-969a-df80cd0bfe39.png)
