### PR TITLE
Added created date to app images

### DIFF
--- a/internal/commands/image/list.go
+++ b/internal/commands/image/list.go
@@ -6,14 +6,16 @@ import (
 	"io"
 	"strings"
 	"text/tabwriter"
+	"time"
 
+	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/internal/relocated"
-
 	"github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/pkg/stringid"
+	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
 )
 
@@ -176,6 +178,16 @@ func getImageListColumns(options imageListOption) []imageListColumn {
 		}},
 		imageListColumn{"APP NAME", func(p pkg) string {
 			return p.bundle.Name
+		}},
+		imageListColumn{"CREATED", func(p pkg) string {
+			payload, err := packager.CustomPayload(p.bundle.Bundle)
+			if err != nil {
+				return ""
+			}
+			if createdPayload, ok := payload.(packager.CustomPayloadCreated); ok {
+				return units.HumanDuration(time.Now().UTC().Sub(createdPayload.CreatedTime())) + " ago"
+			}
+			return ""
 		}},
 	)
 	return columns

--- a/internal/commands/image/list_test.go
+++ b/internal/commands/image/list_test.go
@@ -83,19 +83,19 @@ func TestListCmd(t *testing.T) {
 	}{
 		{
 			name: "TestList",
-			expectedOutput: `REPOSITORY TAG    APP IMAGE ID APP NAME
-foo/bar    <none> 3f825b2d0657 Digested App
-foo/bar    1.0    9aae408ee04f Foo App
-<none>     <none> a855ac937f2e Quiet App
+			expectedOutput: `REPOSITORY TAG    APP IMAGE ID APP NAME     CREATED
+foo/bar    <none> 3f825b2d0657 Digested App 
+foo/bar    1.0    9aae408ee04f Foo App      
+<none>     <none> a855ac937f2e Quiet App    
 `,
 			options: imageListOption{},
 		},
 		{
 			name: "TestListWithDigests",
-			expectedOutput: `REPOSITORY TAG    DIGEST                                                                  APP IMAGE ID APP NAME
-foo/bar    <none> sha256:b59492bb814012ca3d2ce0b6728242d96b4af41687cc82166a4b5d7f2d9fb865 3f825b2d0657 Digested App
-foo/bar    1.0    <none>                                                                  9aae408ee04f Foo App
-<none>     <none> sha256:a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087 a855ac937f2e Quiet App
+			expectedOutput: `REPOSITORY TAG    DIGEST                                                                  APP IMAGE ID APP NAME     CREATED
+foo/bar    <none> sha256:b59492bb814012ca3d2ce0b6728242d96b4af41687cc82166a4b5d7f2d9fb865 3f825b2d0657 Digested App 
+foo/bar    1.0    <none>                                                                  9aae408ee04f Foo App      
+<none>     <none> sha256:a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087 a855ac937f2e Quiet App    
 `,
 			options: imageListOption{digests: true},
 		},

--- a/internal/packager/cnab.go
+++ b/internal/packager/cnab.go
@@ -16,13 +16,6 @@ const (
 	CNABVersion1_0_0 = "v1.0.0"
 )
 
-// DockerAppCustom contains extension custom data that docker app injects
-// in the bundle.
-type DockerAppCustom struct {
-	Version string          `json:"version,omitempty"`
-	Payload json.RawMessage `json:"payload,omitempty"`
-}
-
 // DockerAppArgs represent the object passed to the invocation image
 // by Docker App.
 type DockerAppArgs struct {
@@ -170,11 +163,17 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 		return nil, err
 	}
 
+	payload, err := newCustomPayload()
+	if err != nil {
+		return nil, err
+	}
+
 	bndl := &bundle.Bundle{
 		SchemaVersion: CNABVersion1_0_0,
 		Custom: map[string]interface{}{
 			internal.CustomDockerAppName: DockerAppCustom{
-				Version: internal.Version,
+				Version: DockerAppCustomVersion1_0_0,
+				Payload: payload,
 			},
 		},
 		Credentials: map[string]bundle.Credential{

--- a/internal/packager/cnab_test.go
+++ b/internal/packager/cnab_test.go
@@ -3,9 +3,9 @@ package packager
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"testing"
 
-	"github.com/docker/app/internal"
 	"github.com/docker/app/types"
 	"gotest.tools/assert"
 	"gotest.tools/golden"
@@ -19,6 +19,9 @@ func TestToCNAB(t *testing.T) {
 	actualJSON, err := json.MarshalIndent(actual, "", "  ")
 	assert.NilError(t, err)
 	s := golden.Get(t, "bundle-json.golden")
-	expected := fmt.Sprintf(string(s), internal.Version)
-	assert.Equal(t, string(actualJSON), expected)
+	expectedLiteral := regexp.QuoteMeta(string(s))
+	expected := fmt.Sprintf(expectedLiteral, DockerAppCustomVersionCurrent, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z`)
+	matches, err := regexp.Match(expected, actualJSON)
+	assert.NilError(t, err)
+	assert.Assert(t, matches)
 }

--- a/internal/packager/custom.go
+++ b/internal/packager/custom.go
@@ -1,0 +1,84 @@
+package packager
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/docker/app/internal"
+)
+
+const (
+	// DockerAppCustomVersion1_0_0 is the custom payload version 1.0.0
+	DockerAppCustomVersion1_0_0 = "1.0.0"
+
+	// DockerAppCustomVersionCurrent the current payload version
+	DockerAppCustomVersionCurrent = DockerAppCustomVersion1_0_0
+)
+
+// DockerAppCustom contains extension custom data that docker app injects
+// in the bundle.
+type DockerAppCustom struct {
+	Version string          `json:"version,omitempty"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// CustomPayloadCreated is a custom payload with a created time
+type CustomPayloadCreated interface {
+	CreatedTime() time.Time
+}
+
+type payloadV1_0 struct {
+	Created time.Time `json:"created"`
+}
+
+func (p payloadV1_0) CreatedTime() time.Time {
+	return p.Created
+}
+
+func newCustomPayload() (json.RawMessage, error) {
+	p := payloadV1_0{Created: time.Now().UTC()}
+	j, err := json.Marshal(&p)
+	if err != nil {
+		return nil, err
+	}
+	return j, nil
+}
+
+// CustomPayload parses and returns the bundle's custom payload
+func CustomPayload(b *bundle.Bundle) (interface{}, error) {
+	custom, err := parseCustomPayload(b)
+	if err != nil {
+		return nil, err
+	}
+
+	switch version := custom.Version; version {
+	case DockerAppCustomVersion1_0_0:
+		var payload payloadV1_0
+		if err := json.Unmarshal(custom.Payload, &payload); err != nil {
+			return nil, err
+		}
+		return payload, nil
+	default:
+		return nil, nil
+	}
+}
+
+func parseCustomPayload(b *bundle.Bundle) (DockerAppCustom, error) {
+	customMap, ok := b.Custom[internal.CustomDockerAppName]
+	if !ok {
+		return DockerAppCustom{}, nil
+	}
+
+	customJSON, err := json.Marshal(customMap)
+	if err != nil {
+		return DockerAppCustom{}, err
+	}
+
+	var custom DockerAppCustom
+	if err = json.Unmarshal(customJSON, &custom); err != nil {
+		return DockerAppCustom{}, err
+	}
+
+	return custom, nil
+}

--- a/internal/packager/custom_test.go
+++ b/internal/packager/custom_test.go
@@ -1,0 +1,80 @@
+package packager
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/docker/app/internal"
+	"gotest.tools/assert"
+)
+
+func TestNewCustomPayload(t *testing.T) {
+	start := time.Now().UTC()
+	payloadJSON, err := newCustomPayload()
+	assert.NilError(t, err)
+
+	var payload payloadV1_0
+	err = json.Unmarshal(payloadJSON, &payload)
+	assert.NilError(t, err)
+
+	end := time.Now().UTC()
+	assert.Assert(t, start.Before(payload.CreatedTime()) || start.Equal(payload.CreatedTime()))
+	assert.Assert(t, end.After(payload.CreatedTime()) || end.Equal(payload.CreatedTime()))
+}
+
+func TestCustomPayloadNil(t *testing.T) {
+	testCases := []struct {
+		testName string
+		version  string
+		payload  interface{}
+	}{
+		{
+			testName: "NoVersion",
+			version:  "",
+			payload:  payloadV1_0{},
+		},
+		{
+			testName: "UnknownVersion",
+			version:  "unknown-version",
+			payload:  payloadV1_0{},
+		},
+		{
+			testName: "NoPayload",
+			version:  DockerAppCustomVersionCurrent,
+			payload:  nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			b := createBundle(t, "", payloadV1_0{})
+			payload, err := CustomPayload(&b)
+			assert.NilError(t, err)
+			assert.Assert(t, payload == nil)
+		})
+	}
+}
+
+func TestCustomPayloadV1_0_0(t *testing.T) {
+	now := time.Now().UTC()
+	b := createBundle(t, DockerAppCustomVersion1_0_0, payloadV1_0{now})
+	payload, err := CustomPayload(&b)
+	assert.NilError(t, err)
+	v1, ok := payload.(payloadV1_0)
+	assert.Assert(t, ok)
+	assert.Assert(t, now.Equal(v1.CreatedTime()))
+}
+
+func createBundle(t *testing.T, version string, payload interface{}) bundle.Bundle {
+	j, err := json.Marshal(payload)
+	assert.NilError(t, err)
+	return bundle.Bundle{
+		Custom: map[string]interface{}{
+			internal.CustomDockerAppName: DockerAppCustom{
+				Version: version,
+				Payload: j,
+			},
+		},
+	}
+}

--- a/internal/packager/testdata/bundle-json.golden
+++ b/internal/packager/testdata/bundle-json.golden
@@ -182,7 +182,10 @@
   },
   "custom": {
     "com.docker.app": {
-      "version": "%s"
+      "version": "%s",
+      "payload": {
+        "created": "%s"
+      }
     }
   }
 }


### PR DESCRIPTION
**- What I did**


Added a created date field to the custom payload of the bundle.json which is used to display the time since the app image was built in human readable format on `docker app image ls` as the `CREATED` column.

**- How I did it**

Created a v1.0 struct for the custom payload in bundle.json that stores the creation date at build time. A constant is used to track which version of the custom payload is to be deserialized rather than using the `docker app version`. This is to make it easier to check which struct matches which versions. 

As the entire bundle.json is deserialized at once the custom payload needs to be re-serialized before deserializing into the concrete type as it is stored as a simple `map[string]interface{}`.

The human readable output is done using the `github.com/docker/go-units` package, same as with `docker image ls`.

**- How to verify it**

Run a `docker app build`. The resulting bundle.json should have a custom section similar to the following:

```

	"custom": {
		"com.docker.app": {
			"payload": {
				"created": "2019-11-07T14:18:41.9539586Z"
			},
			"version": "1.0.0"
		}
	},
```

Note that the `created` field should be in UTC.

Running `docker app image ls` should print a `CREATED` column showing the amount of time since the app image was built or blank if the image was built using an older version of `docker app`. 

Example output:

```
REPOSITORY TAG    APP IMAGE ID APP NAME    CREATED
test1      latest acb44aed7b77 hello-world 4 days ago
test2      latest acb44aed7b77 hello-world Less than a second ago
rumpl/nick <none> 1d1a57daebbf voting-app
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added the creation date to the App bundle and prints the time since creation in the `docker app image ls` output

**- A picture of a cute animal (not mandatory)**

![kitten-2019-11-12](https://user-images.githubusercontent.com/22098752/68667804-c46fe480-053e-11ea-95b2-e66f8b0c01dc.jpg)


