### PR TITLE
PR followup for add creation to bundles

### DIFF
--- a/internal/packager/cnab.go
+++ b/internal/packager/cnab.go
@@ -172,7 +172,7 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 		SchemaVersion: CNABVersion1_0_0,
 		Custom: map[string]interface{}{
 			internal.CustomDockerAppName: DockerAppCustom{
-				Version: DockerAppCustomVersion1_0_0,
+				Version: DockerAppCustomVersionCurrent,
 				Payload: payload,
 			},
 		},


### PR DESCRIPTION
**- What I did**

Set custom payload version to current version number.
Cleaned up app image ls tests.

**- How I did it**

Set the custom payload version to `DockerAppCustomVersionCurrent` when creating a new bundle so as to reduce the number of required changes when developing a new version of the custom payload.

Cleaned up app image ls tests to remove:

- Debug messages.
- No longer necessary distinct vs total count test for `image ls --quiet`. Addition of the creation date to the bundle ensures that the image ID will always be unique.

**- How to verify it**

There are no functional changes so the CI tests should cover the verification.

**- A picture of a cute animal (not mandatory)**
![kitten-2019-11-12](https://user-images.githubusercontent.com/22098752/68758140-2430c300-0605-11ea-9c97-143273dc97e2.jpg)

