### PR TITLE
Fix remove image by Id

### DIFF
--- a/internal/store/bundle.go
+++ b/internal/store/bundle.go
@@ -116,7 +116,7 @@ func (b *bundleStore) Remove(ref reference.Reference) error {
 		if len(b.refsMap[id]) == 0 {
 			return fmt.Errorf("no such image %q", reference.FamiliarString(ref))
 		} else if len(b.refsMap[id]) > 1 {
-			return fmt.Errorf("unable to delete %s - App is referenced in multiple repositories", reference.FamiliarString(ref))
+			return fmt.Errorf("unable to delete %q - App is referenced in multiple repositories", reference.FamiliarString(ref))
 		}
 		ref = b.refsMap[id][0]
 	}

--- a/internal/store/bundle.go
+++ b/internal/store/bundle.go
@@ -112,6 +112,14 @@ func (b *bundleStore) List() ([]reference.Reference, error) {
 
 // Remove removes a bundle from the bundle store.
 func (b *bundleStore) Remove(ref reference.Reference) error {
+	if id, ok := ref.(ID); ok {
+		if len(b.refsMap[id]) == 0 {
+			return fmt.Errorf("no such image %q", reference.FamiliarString(ref))
+		} else if len(b.refsMap[id]) > 1 {
+			return fmt.Errorf("unable to delete %s - App is referenced in multiple repositories", reference.FamiliarString(ref))
+		}
+		ref = b.refsMap[id][0]
+	}
 	path, err := b.storePath(ref)
 	if err != nil {
 		return err


### PR DESCRIPTION
**- What I did**
Fix the `docker app image rm <id>`command with the following behavior
- if the id does not exist a "no such image" error is displayed
- if the id references multiple repositories a "App is referenced in multiple repositories" error is displayed
- if only one App is referenced by this id then this App is removed from the store

**- A picture of a cute animal (not mandatory)**
![i6W2VufoExaRznkM](https://user-images.githubusercontent.com/470082/68758455-25b2b900-060e-11ea-961b-9473b28b8e79.gif)

