### PR TITLE
Add a seed for better randomness

### DIFF
--- a/cmd/cnab-run/main.go
+++ b/cmd/cnab-run/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/docker/app/internal"
 )
@@ -38,6 +40,7 @@ func getCnabAction() (cnabAction, string, error) {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	action, actionName, err := getCnabAction()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error while parsing CNAB operation: %s", err)

--- a/cmd/docker-app/main.go
+++ b/cmd/docker-app/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"math/rand"
+	"time"
+
 	"github.com/docker/app/internal"
 	app "github.com/docker/app/internal/commands"
 	"github.com/docker/cli/cli-plugins/manager"
@@ -10,6 +13,7 @@ import (
 )
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	plugin.Run(func(dockerCli command.Cli) *cobra.Command {
 		cmd := app.NewRootCmd("app", dockerCli)
 		originalPreRun := cmd.PersistentPreRunE

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -1,0 +1,27 @@
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/icmd"
+)
+
+func TestRunTwice(t *testing.T) {
+	// Test that we are indeed generating random app names
+	// We had a problem where the second run would fail with an error
+	// "Installation "gallant_poitras" already exists, use 'docker app update' instead"
+	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
+		cmd := info.configuredCmd
+		contextPath := filepath.Join("testdata", "simple")
+
+		cmd.Command = dockerCli.Command("app", "build", "--tag", "myapp", contextPath)
+		icmd.RunCmd(cmd).Assert(t, icmd.Success)
+
+		cmd.Command = dockerCli.Command("app", "run", "myapp", "--set", "web_port=8080")
+		icmd.RunCmd(cmd).Assert(t, icmd.Success)
+
+		cmd.Command = dockerCli.Command("app", "run", "myapp", "--set", "web_port=8081")
+		icmd.RunCmd(cmd).Assert(t, icmd.Success)
+	})
+}


### PR DESCRIPTION

**- What I did**

Added a call to `rand.Seed`

Without the seed the rand.Intn will always start from the same place and
return the same application name

**- How to verify it**

Without this change run:
```
$ docker app run APP1
$ docker app run APP2
```
The second one would fail with a message: `Installation "gallant_poitras" already exists, use 'docker app update' instead`

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/99933/68762043-990bf900-0615-11ea-90c6-8e53096b0485.png)

