### PR TITLE
Remove extra flags on docker app inspect command

### DIFF
--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -70,14 +70,13 @@ type AppInfo struct {
 	Parameters   map[string]interface{} `yaml:"Parameters,omitempty" json:"Parameters,omitempty"`
 }
 
-func Inspect(out io.Writer, installation *store.Installation, outputFormat string, cliDefinedOrchestrator string) error {
+func Inspect(out io.Writer, installation *store.Installation, outputFormat string) error {
 	// Collect all the relevant information about the application
-	appInfo := GetAppInfo(installation, cliDefinedOrchestrator)
+	appInfo := GetAppInfo(installation)
 	return printAppInfo(out, appInfo, outputFormat)
 }
 
-func GetAppInfo(installation *store.Installation, cliDefinedOrchestrator string) AppInfo {
-	orchestrator := getOrchestrator(installation.Claim, cliDefinedOrchestrator)
+func GetAppInfo(installation *store.Installation) AppInfo {
 	return AppInfo{
 		Installation: Installation{
 			Name:         installation.Name,
@@ -86,7 +85,7 @@ func GetAppInfo(installation *store.Installation, cliDefinedOrchestrator string)
 			Revision:     installation.Revision,
 			LastAction:   installation.Result.Action,
 			Result:       installation.Result.Status,
-			Orchestrator: orchestrator,
+			Orchestrator: getOrchestrator(installation.Claim),
 		},
 		Application: Application{
 			Name:           installation.Bundle.Name,
@@ -232,11 +231,11 @@ func printSection(out io.Writer, len int, printer func(io.Writer), headers ...st
 	w.Flush()
 }
 
-func getOrchestrator(claim claim.Claim, cliDefaultOrchestrator string) string {
-	if orchestrator, ok := claim.Parameters[internal.ParameterOrchestratorName]; ok && orchestrator != "" {
+func getOrchestrator(claim claim.Claim) string {
+	if orchestrator, ok := claim.Parameters[internal.ParameterOrchestratorName]; ok && orchestrator != nil {
 		return orchestrator.(string)
 	}
-	return cliDefaultOrchestrator
+	return ""
 }
 
 func removeDockerAppParameters(parameters map[string]interface{}) map[string]interface{} {

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -170,7 +170,7 @@ func getInstallation() store.Installation {
 				"com.docker.app.args":                 "{}",
 				"com.docker.app.inspect-format":       "json",
 				"com.docker.app.kubernetes-namespace": "default",
-				"com.docker.app.orchestrator":         "",
+				"com.docker.app.orchestrator":         "swarm",
 				"com.docker.app.render-format":        "yaml",
 				"com.docker.app.share-registry-creds": false,
 				"port":                                "8080",
@@ -202,7 +202,7 @@ func TestInspect(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			var out bytes.Buffer
-			err := Inspect(&out, &i, testCase.format, "swarm")
+			err := Inspect(&out, &i, testCase.format)
 			assert.NilError(t, err)
 			golden.Assert(t, out.String(), fmt.Sprintf("inspect-app-%s.golden", testCase.name))
 		})


### PR DESCRIPTION
**- What I did**
`orchestrator` and `namespace` flags are not needed, as they are parameters stored in the claim so we can retrieve them. The user shouldn't be allowed to override them.

Also removed default orchestrator code for inspect, as orchestrator is not mandatory for every bundles (some bundles may just run on a single engine).

**- Description for the changelog**
- Removed `orchestrator` and `namespace` flags for `docker app inspect` command

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/31478878/69075940-b5070480-0a32-11ea-8fbc-7ea271e9bd6f.png)

