### PR TITLE
Image inspect non-app CNABs

### DIFF
--- a/e2e/testdata/app-inspect.golden
+++ b/e2e/testdata/app-inspect.golden
@@ -1,16 +1,16 @@
 {
     "Metadata": {
-        "version": "1.1.0-beta1",
-        "name": "simple",
-        "description": "new fancy webapp with microservices",
-        "maintainers": [
+        "Version": "1.1.0-beta1",
+        "Name": "simple",
+        "Description": "new fancy webapp with microservices",
+        "Maintainers": [
             {
-                "name": "John Developer",
-                "email": "john.dev@example.com"
+                "Name": "John Developer",
+                "Email": "john.dev@example.com"
             },
             {
-                "name": "Jane Developer",
-                "email": "jane.dev@example.com"
+                "Name": "Jane Developer",
+                "Email": "jane.dev@example.com"
             }
         ]
     },

--- a/internal/commands/image/inspect.go
+++ b/internal/commands/image/inspect.go
@@ -10,6 +10,7 @@ import (
 	"github.com/deislabs/cnab-go/action"
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/cnab"
+	"github.com/docker/app/internal/inspect"
 	appstore "github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -88,7 +89,12 @@ func runInspect(dockerCli command.Cli, appname string, opts inspectOptions) erro
 
 	installation.SetParameter(internal.ParameterInspectFormatName, format)
 
-	if err := a.Run(&installation.Claim, nil); err != nil {
+	err = a.Run(&installation.Claim, nil)
+	if err == action.ErrUndefinedAction {
+		err = inspect.ImageInspectCNAB(os.Stdout, bndl.Bundle, format)
+	}
+
+	if err != nil {
 		return fmt.Errorf("inspect failed: %s\n%s", err, errBuf)
 	}
 	return nil

--- a/internal/commands/image/inspect.go
+++ b/internal/commands/image/inspect.go
@@ -69,33 +69,35 @@ func runInspect(dockerCli command.Cli, appname string, opts inspectOptions) erro
 	if err != nil {
 		return err
 	}
-	installation, err := appstore.NewInstallation("custom-action", ref.String(), bndl)
-	if err != nil {
-		return err
-	}
-	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, opts.InstallerContextOptions, os.Stdout)
-	if err != nil {
-		return err
-	}
-	a := &action.RunCustom{
-		Action: internal.ActionInspectName,
-		Driver: driverImpl,
-	}
 
 	format := "json"
 	if opts.pretty {
 		format = "pretty"
 	}
 
-	installation.SetParameter(internal.ParameterInspectFormatName, format)
-
-	err = a.Run(&installation.Claim, nil)
-	if err == action.ErrUndefinedAction {
-		err = inspect.ImageInspectCNAB(os.Stdout, bndl.Bundle, format)
+	installation, err := appstore.NewInstallation("custom-action", ref.String(), bndl)
+	if err != nil {
+		return err
 	}
 
-	if err != nil {
-		return fmt.Errorf("inspect failed: %s\n%s", err, errBuf)
+	if _, hasAction := installation.Bundle.Actions[internal.ActionInspectName]; hasAction {
+		driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, opts.InstallerContextOptions, os.Stdout)
+		if err != nil {
+			return err
+		}
+		a := &action.RunCustom{
+			Action: internal.ActionInspectName,
+			Driver: driverImpl,
+		}
+
+		installation.SetParameter(internal.ParameterInspectFormatName, format)
+		if err = a.Run(&installation.Claim, nil); err != nil {
+			return fmt.Errorf("inspect failed: %s\n%s", err, errBuf)
+		}
+	} else {
+		if err = inspect.ImageInspectCNAB(os.Stdout, bndl.Bundle, format); err != nil {
+			return fmt.Errorf("inspect failed: %s", err)
+		}
 	}
 	return nil
 }

--- a/internal/commands/inspect.go
+++ b/internal/commands/inspect.go
@@ -132,10 +132,6 @@ func getContextOrchestrator(dockerCli command.Cli, orchestratorFlag string) (com
 }
 
 func hasAction(bndl *bundle.Bundle, actionName string) bool {
-	for key := range bndl.Actions {
-		if key == actionName {
-			return true
-		}
-	}
-	return false
+	_, ok := bndl.Actions[actionName]
+	return ok
 }

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -114,6 +114,49 @@ func ImageInspect(out io.Writer, app *types.App, argParameters map[string]string
 	return printImageAppInfo(out, appInfo, outputFormat)
 }
 
+func ImageInspectCNAB(out io.Writer, bndl *bundle.Bundle, outputFormat string) error {
+	meta := metadata.AppMetadata{
+		Description: bndl.Description,
+		Name:        bndl.Name,
+		Version:     bndl.Version,
+		Maintainers: []metadata.Maintainer{},
+	}
+	for _, m := range bndl.Maintainers {
+		meta.Maintainers = append(meta.Maintainers, metadata.Maintainer{
+			Name:  m.Name,
+			Email: m.Email,
+		})
+	}
+
+	paramKeys := []string{}
+	params := map[string]string{}
+	for _, v := range bndl.Parameters {
+		paramKeys = append(paramKeys, v.Definition)
+		if d, ok := bndl.Definitions[v.Definition]; ok && d.Default != nil {
+			params[v.Definition] = fmt.Sprint(d.Default)
+		} else {
+			params[v.Definition] = ""
+		}
+	}
+
+	services := []Service{}
+	for k, v := range bndl.Images {
+		services = append(services, Service{
+			Name:  k,
+			Image: v.Image,
+		})
+	}
+
+	appInfo := ImageAppInfo{
+		Metadata:       meta,
+		parametersKeys: paramKeys,
+		Parameters:     params,
+		Services:       services,
+	}
+
+	return printImageAppInfo(out, appInfo, outputFormat)
+}
+
 func printAppInfo(out io.Writer, app AppInfo, format string) error {
 	switch format {
 	case "pretty":

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -2,6 +2,7 @@ package inspect
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -130,6 +131,22 @@ text: hello`),
 			testImageInspect(t, dir, testcase, "-json")
 		}
 	})
+}
+
+func TestImageInspectCNAB(t *testing.T) {
+	s := golden.Get(t, "bundle-json.golden")
+	var bndl bundle.Bundle
+	err := json.Unmarshal(s, &bndl)
+	assert.NilError(t, err)
+
+	expected := golden.Get(t, "inspect-bundle-json.golden")
+
+	outBuffer := new(bytes.Buffer)
+	err = ImageInspectCNAB(outBuffer, &bndl, "json")
+	assert.NilError(t, err)
+
+	result := outBuffer.String()
+	assert.Equal(t, string(expected), result)
 }
 
 func testImageInspect(t *testing.T, dir *fs.Dir, testcase inspectTestCase, suffix string) {

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -133,16 +133,24 @@ text: hello`),
 	})
 }
 
-func TestImageInspectCNAB(t *testing.T) {
+func TestImageInspectCNABFormatJSON(t *testing.T) {
+	testImageInspectCNAB(t, "json")
+}
+
+func TestImageInspectCNABFormatPretty(t *testing.T) {
+	testImageInspectCNAB(t, "pretty")
+}
+
+func testImageInspectCNAB(t *testing.T, format string) {
 	s := golden.Get(t, "bundle-json.golden")
 	var bndl bundle.Bundle
 	err := json.Unmarshal(s, &bndl)
 	assert.NilError(t, err)
 
-	expected := golden.Get(t, "inspect-bundle-json.golden")
+	expected := golden.Get(t, fmt.Sprintf("inspect-bundle-%s.golden", format))
 
 	outBuffer := new(bytes.Buffer)
-	err = ImageInspectCNAB(outBuffer, &bndl, "json")
+	err = ImageInspectCNAB(outBuffer, &bndl, format)
 	assert.NilError(t, err)
 
 	result := outBuffer.String()

--- a/internal/inspect/testdata/bundle-json.golden
+++ b/internal/inspect/testdata/bundle-json.golden
@@ -1,0 +1,183 @@
+{
+  "schemaVersion": "v1.0.0",
+  "name": "packing",
+  "version": "0.1.0",
+  "description": "hello",
+  "maintainers": [
+    {
+      "name": "dev1",
+      "email": "dev1@example.com"
+    },
+    {
+      "name": "dev2",
+      "email": "dev2@example.com"
+    }
+  ],
+  "invocationImages": [
+    {
+      "imageType": "docker",
+      "image": "test-image"
+    }
+  ],
+  "images": {
+    "app-watcher": {
+      "imageType": "docker",
+      "image": "watcher",
+      "description": "watcher"
+    },
+    "debug": {
+      "imageType": "docker",
+      "image": "busybox:latest",
+      "description": "busybox:latest"
+    },
+    "front": {
+      "imageType": "docker",
+      "image": "nginx",
+      "description": "nginx"
+    },
+    "monitor": {
+      "imageType": "docker",
+      "image": "busybox:latest",
+      "description": "busybox:latest"
+    }
+  },
+  "actions": {
+    "com.docker.app.inspect": {
+      "stateless": true
+    },
+    "com.docker.app.render": {
+      "stateless": true
+    },
+    "io.cnab.status": {},
+    "io.cnab.status+json": {}
+  },
+  "parameters": {
+    "com.docker.app.args": {
+      "definition": "com.docker.app.args",
+      "applyTo": [
+        "install",
+        "upgrade"
+      ],
+      "destination": {
+        "path": "/cnab/app/args.json"
+      }
+    },
+    "com.docker.app.inspect-format": {
+      "definition": "com.docker.app.inspect-format",
+      "applyTo": [
+        "com.docker.app.inspect"
+      ],
+      "destination": {
+        "env": "DOCKER_INSPECT_FORMAT"
+      }
+    },
+    "com.docker.app.kubernetes-namespace": {
+      "definition": "com.docker.app.kubernetes-namespace",
+      "applyTo": [
+        "install",
+        "upgrade",
+        "uninstall",
+        "io.cnab.status"
+      ],
+      "destination": {
+        "env": "DOCKER_KUBERNETES_NAMESPACE"
+      }
+    },
+    "com.docker.app.orchestrator": {
+      "definition": "com.docker.app.orchestrator",
+      "applyTo": [
+        "install",
+        "upgrade",
+        "uninstall",
+        "io.cnab.status"
+      ],
+      "destination": {
+        "env": "DOCKER_STACK_ORCHESTRATOR"
+      }
+    },
+    "com.docker.app.render-format": {
+      "definition": "com.docker.app.render-format",
+      "applyTo": [
+        "com.docker.app.render"
+      ],
+      "destination": {
+        "env": "DOCKER_RENDER_FORMAT"
+      }
+    },
+    "com.docker.app.share-registry-creds": {
+      "definition": "com.docker.app.share-registry-creds",
+      "destination": {
+        "env": "DOCKER_SHARE_REGISTRY_CREDS"
+      }
+    },
+    "watcher.cmd": {
+      "definition": "watcher.cmd",
+      "destination": {
+        "env": "docker_param1"
+      }
+    }
+  },
+  "credentials": {
+    "com.docker.app.registry-creds": {
+      "path": "/cnab/app/registry-creds.json"
+    },
+    "docker.context": {
+      "path": "/cnab/app/context.dockercontext"
+    }
+  },
+  "definitions": {
+    "com.docker.app.args": {
+      "default": "",
+      "description": "Arguments that are passed by file to the invocation image",
+      "title": "Arguments",
+      "type": "string"
+    },
+    "com.docker.app.inspect-format": {
+      "default": "json",
+      "description": "Output format for the inspect command",
+      "enum": [
+        "json",
+        "pretty"
+      ],
+      "title": "Inspect format",
+      "type": "string"
+    },
+    "com.docker.app.kubernetes-namespace": {
+      "default": "",
+      "description": "Namespace in which to deploy",
+      "title": "Namespace",
+      "type": "string"
+    },
+    "com.docker.app.orchestrator": {
+      "default": "",
+      "description": "Orchestrator on which to deploy",
+      "enum": [
+        "",
+        "swarm",
+        "kubernetes"
+      ],
+      "title": "Orchestrator",
+      "type": "string"
+    },
+    "com.docker.app.render-format": {
+      "default": "yaml",
+      "description": "Output format for the render command",
+      "enum": [
+        "yaml",
+        "json"
+      ],
+      "title": "Render format",
+      "type": "string"
+    },
+    "com.docker.app.share-registry-creds": {
+      "default": false,
+      "description": "Share registry credentials with the invocation image",
+      "title": "Share registry credentials",
+      "type": "boolean"
+    },
+    "watcher.cmd": {
+      "default": "foo",
+      "type": "string"
+    }
+  }
+}

--- a/internal/inspect/testdata/inspect-bundle-json.golden
+++ b/internal/inspect/testdata/inspect-bundle-json.golden
@@ -1,16 +1,16 @@
 {
     "Metadata": {
-        "version": "0.1.0",
-        "name": "packing",
-        "description": "hello",
-        "maintainers": [
+        "Version": "0.1.0",
+        "Name": "packing",
+        "Description": "hello",
+        "Maintainers": [
             {
-                "name": "dev1",
-                "email": "dev1@example.com"
+                "Name": "dev1",
+                "Email": "dev1@example.com"
             },
             {
-                "name": "dev2",
-                "email": "dev2@example.com"
+                "Name": "dev2",
+                "Email": "dev2@example.com"
             }
         ]
     },

--- a/internal/inspect/testdata/inspect-bundle-json.golden
+++ b/internal/inspect/testdata/inspect-bundle-json.golden
@@ -1,0 +1,44 @@
+{
+    "Metadata": {
+        "version": "0.1.0",
+        "name": "packing",
+        "description": "hello",
+        "maintainers": [
+            {
+                "name": "dev1",
+                "email": "dev1@example.com"
+            },
+            {
+                "name": "dev2",
+                "email": "dev2@example.com"
+            }
+        ]
+    },
+    "Services": [
+        {
+            "Name": "app-watcher",
+            "Image": "watcher"
+        },
+        {
+            "Name": "debug",
+            "Image": "busybox:latest"
+        },
+        {
+            "Name": "front",
+            "Image": "nginx"
+        },
+        {
+            "Name": "monitor",
+            "Image": "busybox:latest"
+        }
+    ],
+    "Parameters": {
+        "com.docker.app.args": "",
+        "com.docker.app.inspect-format": "json",
+        "com.docker.app.kubernetes-namespace": "",
+        "com.docker.app.orchestrator": "",
+        "com.docker.app.render-format": "yaml",
+        "com.docker.app.share-registry-creds": "false",
+        "watcher.cmd": "foo"
+    }
+}

--- a/internal/inspect/testdata/inspect-bundle-pretty.golden
+++ b/internal/inspect/testdata/inspect-bundle-pretty.golden
@@ -1,0 +1,24 @@
+version: 0.1.0
+name: packing
+description: hello
+maintainers:
+- name: dev1
+  email: dev1@example.com
+- name: dev2
+  email: dev2@example.com
+
+
+SERVICE     IMAGE
+app-watcher watcher
+debug       busybox:latest
+front       nginx
+monitor     busybox:latest
+
+PARAMETER                           VALUE
+com.docker.app.args                 
+com.docker.app.inspect-format       json
+com.docker.app.kubernetes-namespace 
+com.docker.app.orchestrator         
+com.docker.app.render-format        yaml
+com.docker.app.share-registry-creds false
+watcher.cmd                         foo

--- a/internal/inspect/testdata/inspect-full-json.golden
+++ b/internal/inspect/testdata/inspect-full-json.golden
@@ -1,12 +1,12 @@
 {
     "Metadata": {
-        "version": "0.1.0",
-        "name": "myapp",
-        "description": "some description",
-        "maintainers": [
+        "Version": "0.1.0",
+        "Name": "myapp",
+        "Description": "some description",
+        "Maintainers": [
             {
-                "name": "dev",
-                "email": "dev@example.com"
+                "Name": "dev",
+                "Email": "dev@example.com"
             }
         ]
     },

--- a/internal/inspect/testdata/inspect-no-description-json.golden
+++ b/internal/inspect/testdata/inspect-no-description-json.golden
@@ -1,11 +1,11 @@
 {
     "Metadata": {
-        "version": "0.1.0",
-        "name": "myapp",
-        "maintainers": [
+        "Version": "0.1.0",
+        "Name": "myapp",
+        "Maintainers": [
             {
-                "name": "dev",
-                "email": "dev@example.com"
+                "Name": "dev",
+                "Email": "dev@example.com"
             }
         ]
     }

--- a/internal/inspect/testdata/inspect-no-maintainers-json.golden
+++ b/internal/inspect/testdata/inspect-no-maintainers-json.golden
@@ -1,6 +1,6 @@
 {
     "Metadata": {
-        "version": "0.1.0",
-        "name": "myapp"
+        "Version": "0.1.0",
+        "Name": "myapp"
     }
 }

--- a/internal/inspect/testdata/inspect-no-parameters-json.golden
+++ b/internal/inspect/testdata/inspect-no-parameters-json.golden
@@ -1,12 +1,12 @@
 {
     "Metadata": {
-        "version": "0.1.0",
-        "name": "myapp",
-        "description": "some description",
-        "maintainers": [
+        "Version": "0.1.0",
+        "Name": "myapp",
+        "Description": "some description",
+        "Maintainers": [
             {
-                "name": "dev",
-                "email": "dev@example.com"
+                "Name": "dev",
+                "Email": "dev@example.com"
             }
         ]
     }

--- a/internal/inspect/testdata/inspect-overridden-json.golden
+++ b/internal/inspect/testdata/inspect-overridden-json.golden
@@ -1,7 +1,7 @@
 {
     "Metadata": {
-        "version": "0.1.0",
-        "name": "myapp"
+        "Version": "0.1.0",
+        "Name": "myapp"
     },
     "Services": [
         {

--- a/types/metadata/metadata.go
+++ b/types/metadata/metadata.go
@@ -8,8 +8,8 @@ import (
 
 // Maintainer represents one of the apps's maintainers
 type Maintainer struct {
-	Name  string `json:"name"`
-	Email string `json:"email,omitempty"`
+	Name  string
+	Email string `json:",omitempty"`
 }
 
 // Maintainers is a list of maintainers
@@ -35,13 +35,13 @@ func (m Maintainer) String() string {
 
 // AppMetadata is the format of the data found inside the metadata.yml file
 type AppMetadata struct {
-	Version     string      `json:"version"`
-	Name        string      `json:"name"`
-	Description string      `json:"description,omitempty"`
-	Maintainers Maintainers `json:"maintainers,omitempty"`
+	Version     string
+	Name        string
+	Description string      `json:",omitempty"`
+	Maintainers Maintainers `json:",omitempty"`
 }
 
-// Metadata extracts the docker-app metadata from the bundle
+// FromBundle extracts the docker-app metadata from the bundle
 func FromBundle(bndl *bundle.Bundle) AppMetadata {
 	meta := AppMetadata{
 		Name:        bndl.Name,


### PR DESCRIPTION
**- What I did**

Allow `image inspect` of CNABs not created with docker app. The command will output basic information that is read from the bundle.json file including:

* metadata (version, name, description, maintainers)
* services (name and image)
* parameters (including default values if present)

Metadata fields are now printed in PascalCase to match the other fields

**- How I did it**

The `image inspect` command first checks if the invocation image supports the custom `com.docker.app.inspect` command. If yes then this is called with the format as before. If not then it's not a Docker App bundle and the bundle file is parsed for the relevant information which is then printed using the same formatters as the Docker App inspect function.

**- How to verify it**

Manually create a CNAB, push it to hub with cnab-to-oci, and pull it with docker app. Use `docker app image inspect <cnab-id>` and confirm the output contains the metadata, services, and parameters.

You can also use `docker app image inspect <cnab-id> --pretty` to get a table view but 2 fields are removed (REPLICAS and PORTS)

**- Description for the changelog**

Allow `docker app image inspect` of CNAB bundles created without Docker App

**- A picture of a cute animal (not mandatory)**

![cat-2019-11-19](https://user-images.githubusercontent.com/22098752/69156593-90b33280-0adb-11ea-83e5-db6a65a34005.jpg)

