### PR TITLE
Sort app image ls by created

### DIFF
--- a/e2e/images_test.go
+++ b/e2e/images_test.go
@@ -26,7 +26,7 @@ func assertImageListOutput(t *testing.T, cmd icmd.Cmd, expected string) {
 	stdout := result.Stdout()
 	match, err := regexp.MatchString(expected, stdout)
 	assert.NilError(t, err)
-	assert.Assert(t, match)
+	assert.Assert(t, match, expected, stdout)
 }
 
 func expectImageListOutput(t *testing.T, cmd icmd.Cmd, output string) {
@@ -222,24 +222,24 @@ c-simple-app        latest              [a-f0-9]{12}        simple              
 		cmd.Command = dockerCli.Command("app", "build", "--tag", "push-pull", filepath.Join("testdata", "push-pull"))
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED[ ]*
+push-pull           latest              [a-f0-9]{12}        push-pull           [La-z0-9 ]+ ago[ ]*
 a-simple-app        0.1                 [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
 a-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
 b-simple-app        0.2                 [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
 b-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
 c-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-push-pull           latest              [a-f0-9]{12}        push-pull           [La-z0-9 ]+ ago[ ]*
 `)
 
 		// can be tagged to an existing tag
 		dockerAppImageTag("push-pull", "b-simple-app:0.2")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED[ ]*
+b-simple-app        0.2                 [a-f0-9]{12}        push-pull           [La-z0-9 ]+ ago[ ]*
+push-pull           latest              [a-f0-9]{12}        push-pull           [La-z0-9 ]+ ago[ ]*
 a-simple-app        0.1                 [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
 a-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-b-simple-app        0.2                 [a-f0-9]{12}        push-pull           [La-z0-9 ]+ ago[ ]*
 b-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
 c-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-push-pull           latest              [a-f0-9]{12}        push-pull           [La-z0-9 ]+ ago[ ]*
 `)
 	})
 }

--- a/internal/commands/image/list.go
+++ b/internal/commands/image/list.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"sort"
 	"time"
 
 	"github.com/docker/app/internal/packager"
@@ -60,6 +61,7 @@ func runList(dockerCli command.Cli, options imageListOption, bundleStore store.B
 		Format: NewImageFormat(options.format, options.quiet, options.digests),
 	}
 
+	sortImages(images)
 	return Write(ctx, images)
 }
 
@@ -90,6 +92,18 @@ func getImageID(bundle *relocated.Bundle, ref reference.Reference) (string, erro
 		}
 	}
 	return stringid.TruncateID(id.String()), nil
+}
+
+func sortImages(images []imageDesc) {
+	sort.SliceStable(images, func(i, j int) bool {
+		if images[i].Created.IsZero() {
+			return false
+		}
+		if images[j].Created.IsZero() {
+			return true
+		}
+		return images[i].Created.After(images[j].Created)
+	})
 }
 
 type imageDesc struct {

--- a/internal/commands/image/list_test.go
+++ b/internal/commands/image/list_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/docker/app/internal/relocated"
 
@@ -124,6 +125,22 @@ a855ac937f2e
 			testRunList(t, refs, bundles, tc.options, tc.expectedOutput)
 		})
 	}
+}
+
+func TestSortImages(t *testing.T) {
+	images := []imageDesc{
+		{ID: "1", Created: time.Date(2016, time.August, 15, 0, 0, 0, 0, time.UTC)},
+		{ID: "2"},
+		{ID: "3"},
+		{ID: "4", Created: time.Date(2018, time.August, 15, 0, 0, 0, 0, time.UTC)},
+		{ID: "5", Created: time.Date(2017, time.August, 15, 0, 0, 0, 0, time.UTC)},
+	}
+	sortImages(images)
+	assert.Equal(t, "4", images[0].ID)
+	assert.Equal(t, "5", images[1].ID)
+	assert.Equal(t, "1", images[2].ID)
+	assert.Equal(t, "2", images[3].ID)
+	assert.Equal(t, "3", images[4].ID)
 }
 
 func parseReference(t *testing.T, s string) reference.Reference {


### PR DESCRIPTION
**- What I did**

Sorts apps by created date (if available) when running `app image ls` with the latest created apps coming first.

**- How I did it**

Before printing the images they are first sorted by checking the custom payload. If the bundles contain a docker custom payload that has a creation date then this is used to sort them. If only one bundle has a creation date then it is considered the newer one. A stable sort is used so that non-App bundles and tags do not get muddled.

**- How to verify it**

Build multiple App images. Run `docker app image ls`. The result should order the images by creation date.

**- Description for the changelog**

App images are sorted by creation date with the newest first when running `app image ls`

**- A picture of a cute animal (not mandatory)**

![bird-2019-11-19](https://user-images.githubusercontent.com/22098752/69252578-279af000-0bab-11ea-851d-28fda13aa52b.jpg)
