### PR TITLE
Add services column to docker app ls command

### DIFF
--- a/e2e/commands_test.go
+++ b/e2e/commands_test.go
@@ -316,8 +316,8 @@ func TestDockerAppLifecycle(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "ls")
 		checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 			[]string{
-				`RUNNING APP\s+APP NAME\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
-				fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+failure\s+.+second[s]?\sago\s+.+second[s]?\sago\s+`, appName),
+				`RUNNING APP\s+APP NAME\s+SERVICES\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
+				fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+0/3\s+install\s+failure\s+.+second[s]?\sago\s+.+second[s]?\sago\s+`, appName),
 			})
 
 		// Upgrading a failed installation is not allowed
@@ -344,8 +344,8 @@ func TestDockerAppLifecycle(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "ls")
 		checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 			[]string{
-				`RUNNING APP\s+APP NAME\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
-				fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+install\s+success\s+.+second[s]?\sago\s+.+second[s]?\sago\s+`, appName),
+				`RUNNING APP\s+APP NAME\s+SERVICES\s+LAST ACTION\s+RESULT\s+CREATED\s+MODIFIED\s+REFERENCE`,
+				fmt.Sprintf(`%s\s+simple \(1.1.0-beta1\)\s+\d/3\s+install\s+success\s+.+second[s]?\sago\s+.+second[s]?\sago\s+`, appName),
 			})
 
 		// Installing again the same application is forbidden

--- a/e2e/pushpull_test.go
+++ b/e2e/pushpull_test.go
@@ -91,7 +91,7 @@ func TestPushPullInstall(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "ls")
 		checkContains(t, icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined(),
 			[]string{
-				fmt.Sprintf(`%s\s+push-pull \(1.1.0-beta1\)\s+install\s+success\s+.+second[s]?\sago\s+.+second[s]?\sago\s+%s`, t.Name(), ref+tag),
+				fmt.Sprintf(`%s\s+push-pull \(1.1.0-beta1\)\s+\d/1\s+install\s+success\s+.+second[s]?\sago\s+.+second[s]?\sago\s+%s`, t.Name(), ref+tag),
 			})
 
 		// install should fail (registry is stopped)

--- a/e2e/testdata/plugin-usage.golden
+++ b/e2e/testdata/plugin-usage.golden
@@ -4,7 +4,9 @@ Usage:	docker app [OPTIONS] COMMAND
 A tool to build, share and run a Docker App
 
 Options:
-      --version   Print version information
+      --installer-context string   Context on which the installer image
+                                   is ran (default "default")
+      --version                    Print version information
 
 Management Commands:
   image       Manage App images

--- a/internal/cnab/driver.go
+++ b/internal/cnab/driver.go
@@ -119,7 +119,7 @@ func prepareDriver(dockerCli command.Cli, bindMount BindMount, stdout io.Writer)
 	return d, errBuf
 }
 
-func SetupDriver(installation *store2.Installation, dockerCli command.Cli, opts cliopts.InstallerContextOptions, stdout io.Writer) (driver.Driver, *bytes.Buffer, error) {
+func SetupDriver(installation *store2.Installation, dockerCli command.Cli, opts *cliopts.InstallerContextOptions, stdout io.Writer) (driver.Driver, *bytes.Buffer, error) {
 	dockerCli, err := opts.SetInstallerContext(dockerCli)
 	if err != nil {
 		return nil, nil, err

--- a/internal/commands/image/command.go
+++ b/internal/commands/image/command.go
@@ -1,12 +1,13 @@
 package image
 
 import (
+	"github.com/docker/app/internal/cliopts"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
 // Cmd is the image top level command
-func Cmd(dockerCli command.Cli) *cobra.Command {
+func Cmd(dockerCli command.Cli, installerContext *cliopts.InstallerContextOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Short: "Manage App images",
 		Use:   "image",
@@ -16,8 +17,8 @@ func Cmd(dockerCli command.Cli) *cobra.Command {
 		listCmd(dockerCli),
 		rmCmd(),
 		tagCmd(),
-		inspectCmd(dockerCli),
-		renderCmd(dockerCli),
+		inspectCmd(dockerCli, installerContext),
+		renderCmd(dockerCli, installerContext),
 	)
 
 	return cmd

--- a/internal/commands/image/render.go
+++ b/internal/commands/image/render.go
@@ -76,7 +76,13 @@ func runRender(dockerCli command.Cli, appname string, opts renderOptions, instal
 	return nil
 }
 
-func prepareCustomAction(actionName string, dockerCli command.Cli, appname string, stdout io.Writer, opts renderOptions, installerContext *cliopts.InstallerContextOptions) (*action.RunCustom, *appstore.Installation, *bytes.Buffer, error) {
+func prepareCustomAction(actionName string,
+	dockerCli command.Cli,
+	appname string,
+	stdout io.Writer,
+	opts renderOptions,
+	installerContext *cliopts.InstallerContextOptions) (*action.RunCustom, *appstore.Installation, *bytes.Buffer, error) {
+
 	s, err := appstore.NewApplicationStore(config.Dir())
 	if err != nil {
 		return nil, nil, nil, err

--- a/internal/commands/inspect.go
+++ b/internal/commands/inspect.go
@@ -22,11 +22,10 @@ const inspectExample = `- $ docker app inspect my-running-app
 
 type inspectOptions struct {
 	credentialOptions
-	cliopts.InstallerContextOptions
 	pretty bool
 }
 
-func inspectCmd(dockerCli command.Cli) *cobra.Command {
+func inspectCmd(dockerCli command.Cli, installerContext *cliopts.InstallerContextOptions) *cobra.Command {
 	var opts inspectOptions
 	cmd := &cobra.Command{
 		Use:     "inspect [OPTIONS] RUNNING_APP",
@@ -34,16 +33,15 @@ func inspectCmd(dockerCli command.Cli) *cobra.Command {
 		Example: inspectExample,
 		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInspect(dockerCli, firstOrEmpty(args), opts)
+			return runInspect(dockerCli, args[0], opts, installerContext)
 		},
 	}
 	cmd.Flags().BoolVar(&opts.pretty, "pretty", false, "Pretty print the output")
 	opts.credentialOptions.addFlags(cmd.Flags())
-	opts.InstallerContextOptions.AddFlags(cmd.Flags())
 	return cmd
 }
 
-func runInspect(dockerCli command.Cli, appName string, inspectOptions inspectOptions) error {
+func runInspect(dockerCli command.Cli, appName string, inspectOptions inspectOptions, installerContext *cliopts.InstallerContextOptions) error {
 	defer muteDockerCli(dockerCli)()
 	_, installationStore, credentialStore, err := prepareStores(dockerCli.CurrentContext())
 	if err != nil {
@@ -60,7 +58,7 @@ func runInspect(dockerCli command.Cli, appName string, inspectOptions inspectOpt
 	}
 
 	var buf bytes.Buffer
-	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, inspectOptions.InstallerContextOptions, &buf)
+	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, installerContext, &buf)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"sort"
@@ -8,6 +9,10 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/deislabs/cnab-go/action"
+	"github.com/docker/app/internal"
+	"github.com/docker/app/internal/cliopts"
+	"github.com/docker/app/internal/cnab"
 	"github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -22,46 +27,70 @@ import (
 var (
 	listColumns = []struct {
 		header string
-		value  func(i *store.Installation) string
+		value  func(i Installation) string
 	}{
-		{"RUNNING APP", func(i *store.Installation) string { return i.Name }},
-		{"APP NAME", func(i *store.Installation) string { return fmt.Sprintf("%s (%s)", i.Bundle.Name, i.Bundle.Version) }},
-		{"LAST ACTION", func(i *store.Installation) string { return i.Result.Action }},
-		{"RESULT", func(i *store.Installation) string { return i.Result.Status }},
-		{"CREATED", func(i *store.Installation) string {
+		{"RUNNING APP", func(i Installation) string { return i.Name }},
+		{"APP NAME", func(i Installation) string { return fmt.Sprintf("%s (%s)", i.Bundle.Name, i.Bundle.Version) }},
+		{"SERVICES", printServices},
+		{"LAST ACTION", func(i Installation) string { return i.Result.Action }},
+		{"RESULT", func(i Installation) string { return i.Result.Status }},
+		{"CREATED", func(i Installation) string {
 			return fmt.Sprintf("%s ago", units.HumanDuration(time.Since(i.Created)))
 		}},
-		{"MODIFIED", func(i *store.Installation) string {
+		{"MODIFIED", func(i Installation) string {
 			return fmt.Sprintf("%s ago", units.HumanDuration(time.Since(i.Modified)))
 		}},
-		{"REFERENCE", func(i *store.Installation) string { return i.Reference }},
+		{"REFERENCE", func(i Installation) string { return i.Reference }},
 	}
 )
 
-func listCmd(dockerCli command.Cli) *cobra.Command {
-	var template string
+type listOptions struct {
+	template string
+}
+
+func listCmd(dockerCli command.Cli, installerContext *cliopts.InstallerContextOptions) *cobra.Command {
+	var opts listOptions
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS]",
 		Short:   "List running Apps",
 		Aliases: []string{"list"},
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(dockerCli, template)
+			return runList(dockerCli, opts, installerContext)
 		},
 	}
 
-	cmd.Flags().StringVarP(&template, "format", "f", "", "Format the output using the given syntax or Go template")
+	cmd.Flags().StringVarP(&opts.template, "format", "f", "", "Format the output using the given syntax or Go template")
 	cmd.Flags().SetAnnotation("format", "experimentalCLI", []string{"true"}) //nolint:errcheck
 	return cmd
 }
 
-func runList(dockerCli command.Cli, template string) error {
-	installations, err := getInstallations(dockerCli.CurrentContext(), config.Dir())
+func runList(dockerCli command.Cli, opts listOptions, installerContext *cliopts.InstallerContextOptions) error {
+	// initialize stores
+	appstore, err := store.NewApplicationStore(config.Dir())
+	if err != nil {
+		return err
+	}
+	targetContext := dockerCli.CurrentContext()
+	installationStore, err := appstore.InstallationStore(targetContext)
 	if err != nil {
 		return err
 	}
 
-	if template == "json" {
+	fetcher := &serviceFetcher{
+		dockerCli:        dockerCli,
+		opts:             opts,
+		installerContext: installerContext,
+	}
+	installations, err := getInstallations(installationStore, fetcher)
+	if installations == nil && err != nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+
+	if opts.template == "json" {
 		bytes, err := json.MarshalIndent(installations, "", "  ")
 		if err != nil {
 			return errors.Errorf("Failed to marshall json: %s", err)
@@ -69,8 +98,8 @@ func runList(dockerCli command.Cli, template string) error {
 		_, err = dockerCli.Out().Write(bytes)
 		return err
 	}
-	if template != "" {
-		tmpl, err := templates.Parse(template)
+	if opts.template != "" {
+		tmpl, err := templates.Parse(opts.template)
 		if err != nil {
 			return errors.Errorf("Template parsing error: %s", err)
 		}
@@ -94,7 +123,7 @@ func printHeaders(w io.Writer) {
 	fmt.Fprintln(w, strings.Join(headers, "\t"))
 }
 
-func printValues(w io.Writer, installation *store.Installation) {
+func printValues(w io.Writer, installation Installation) {
 	var values []string
 	for _, column := range listColumns {
 		values = append(values, column.value(installation))
@@ -102,30 +131,120 @@ func printValues(w io.Writer, installation *store.Installation) {
 	fmt.Fprintln(w, strings.Join(values, "\t"))
 }
 
-func getInstallations(targetContext, configDir string) ([]*store.Installation, error) {
-	appstore, err := store.NewApplicationStore(configDir)
-	if err != nil {
-		return nil, err
-	}
-	installationStore, err := appstore.InstallationStore(targetContext)
-	if err != nil {
-		return nil, err
-	}
+type Installation struct {
+	*store.Installation
+	Services appServices `json:",omitempty"`
+}
+
+func getInstallations(installationStore store.InstallationStore, fetcher ServiceFetcher) ([]Installation, error) {
 	installationNames, err := installationStore.List()
 	if err != nil {
 		return nil, err
 	}
-	installations := make([]*store.Installation, len(installationNames))
+	installations := make([]Installation, len(installationNames))
 	for i, name := range installationNames {
 		installation, err := installationStore.Read(name)
 		if err != nil {
 			return nil, err
 		}
-		installations[i] = installation
+		services, err := fetcher.getServices(installation)
+		if err != nil {
+			return nil, err
+		}
+		installations[i] = Installation{Installation: installation, Services: services}
 	}
 	// Sort installations with last modified first
 	sort.Slice(installations, func(i, j int) bool {
 		return installations[i].Modified.After(installations[j].Modified)
 	})
+
 	return installations, nil
+}
+
+type ServiceStatus struct {
+	DesiredTasks int
+	RunningTasks int
+}
+
+type appServices map[string]ServiceStatus
+
+type runningService struct {
+	Spec struct {
+		Name string
+	}
+	ServiceStatus ServiceStatus
+}
+
+type serviceFetcher struct {
+	dockerCli        command.Cli
+	opts             listOptions
+	installerContext *cliopts.InstallerContextOptions
+}
+
+type ServiceFetcher interface {
+	getServices(*store.Installation) (appServices, error)
+}
+
+func (s *serviceFetcher) getServices(installation *store.Installation) (appServices, error) {
+	defer muteDockerCli(s.dockerCli)()
+
+	// bundle without status action returns empty services
+	if !hasAction(installation.Bundle, internal.ActionStatusJSONName) {
+		return nil, nil
+	}
+	creds, err := prepareCredentialSet(installation.Bundle,
+		addDockerCredentials(s.dockerCli.CurrentContext(), s.dockerCli.ContextStore()),
+		addRegistryCredentials(false, s.dockerCli),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	driverImpl, errBuf, err := cnab.SetupDriver(installation, s.dockerCli, s.installerContext, &buf)
+	if err != nil {
+		return nil, err
+	}
+	a := &action.RunCustom{
+		Driver: driverImpl,
+		Action: internal.ActionStatusJSONName,
+	}
+	// fetch output from status JSON action and parse it
+	if err := a.Run(&installation.Claim, creds); err != nil {
+		return nil, fmt.Errorf("failed to get app %q status : %s\n%s", installation.Name, err, errBuf)
+	}
+	var runningServices []runningService
+	if err := json.Unmarshal(buf.Bytes(), &runningServices); err != nil {
+		return nil, err
+	}
+
+	services := make(appServices, len(installation.Bundle.Images))
+	for name := range installation.Bundle.Images {
+		services[name] = getRunningService(runningServices, installation.Name, name)
+	}
+
+	return services, nil
+}
+
+func getRunningService(services []runningService, app, name string) ServiceStatus {
+	for _, s := range services {
+		// swarm services are prefixed by app name
+		if s.Spec.Name == name || s.Spec.Name == fmt.Sprintf("%s_%s", app, name) {
+			return s.ServiceStatus
+		}
+	}
+	return ServiceStatus{}
+}
+
+func printServices(i Installation) string {
+	if len(i.Services) == 0 {
+		return "N/A"
+	}
+	var runningServices int
+	for _, s := range i.Services {
+		if s.RunningTasks > 0 {
+			runningServices++
+		}
+	}
+	return fmt.Sprintf("%d/%d", runningServices, len(i.Services))
 }

--- a/internal/commands/list_test.go
+++ b/internal/commands/list_test.go
@@ -7,18 +7,33 @@ import (
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/docker/app/internal/store"
 	"gotest.tools/assert"
-	"gotest.tools/fs"
 )
 
-func TestGetInstallationsSorted(t *testing.T) {
-	tmpDir := fs.NewDir(t, "")
-	defer tmpDir.Remove()
-	appstore, err := store.NewApplicationStore(tmpDir.Path())
-	assert.NilError(t, err)
-	installationStore, err := appstore.InstallationStore("my-context")
-	assert.NilError(t, err)
-	now := time.Now()
+type mockInstallationStore struct {
+	installations map[string]*store.Installation
+}
 
+func (m mockInstallationStore) List() ([]string, error) {
+	l := []string{}
+	for k := range m.installations {
+		l = append(l, k)
+	}
+	return l, nil
+}
+func (m mockInstallationStore) Store(installation *store.Installation) error { return nil }
+func (m mockInstallationStore) Read(installationName string) (*store.Installation, error) {
+	return m.installations[installationName], nil
+}
+func (m mockInstallationStore) Delete(installationName string) error { return nil }
+
+type stubServiceFetcher struct{}
+
+func (s stubServiceFetcher) getServices(*store.Installation) (appServices, error) {
+	return map[string]ServiceStatus{"service1": {DesiredTasks: 1, RunningTasks: 1}}, nil
+}
+
+func TestGetInstallationsSorted(t *testing.T) {
+	now := time.Now()
 	oldInstallation := &store.Installation{
 		Claim: claim.Claim{
 			Name:     "old-installation",
@@ -31,13 +46,48 @@ func TestGetInstallationsSorted(t *testing.T) {
 			Modified: now,
 		},
 	}
-	assert.NilError(t, installationStore.Store(newInstallation))
-	assert.NilError(t, installationStore.Store(oldInstallation))
-
-	installations, err := getInstallations("my-context", tmpDir.Path())
+	installationStore := mockInstallationStore{installations: map[string]*store.Installation{"old-installation": oldInstallation, "new-installation": newInstallation}}
+	installations, err := getInstallations(installationStore, &stubServiceFetcher{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(installations), 2)
 	// First installation is the last modified
 	assert.Equal(t, installations[0].Name, "new-installation")
+	assert.Equal(t, installations[0].Services["service1"].DesiredTasks, 1)
 	assert.Equal(t, installations[1].Name, "old-installation")
+	assert.Equal(t, installations[1].Services["service1"].RunningTasks, 1)
+}
+
+func TestPrintServices(t *testing.T) {
+	testCases := []struct {
+		name         string
+		installation Installation
+		expected     string
+	}{
+		{
+			"Failed installation",
+			Installation{},
+			"N/A",
+		},
+		{
+			"Non running service",
+			Installation{Services: map[string]ServiceStatus{
+				"service1": {DesiredTasks: 1, RunningTasks: 0},
+			}},
+			"0/1",
+		},
+		{
+			"Mixed running services and non running",
+			Installation{Services: map[string]ServiceStatus{
+				"service1": {DesiredTasks: 1, RunningTasks: 0},
+				"service2": {DesiredTasks: 5, RunningTasks: 1},
+			}},
+			"1/2",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			output := printServices(testCase.installation)
+			assert.Equal(t, testCase.expected, output)
+		})
+	}
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -96,13 +96,6 @@ func removeExperimentalCmdsAndFlags(cmd *cobra.Command) {
 	}
 }
 
-func firstOrEmpty(list []string) string {
-	if len(list) != 0 {
-		return list[0]
-	}
-	return ""
-}
-
 func muteDockerCli(dockerCli command.Cli) func() {
 	stdout := dockerCli.Out()
 	stderr := dockerCli.Err()

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -18,11 +18,10 @@ import (
 type updateOptions struct {
 	cliopts.ParametersOptions
 	credentialOptions
-	cliopts.InstallerContextOptions
 	bundleOrDockerApp string
 }
 
-func updateCmd(dockerCli command.Cli) *cobra.Command {
+func updateCmd(dockerCli command.Cli, installerContext *cliopts.InstallerContextOptions) *cobra.Command {
 	var opts updateOptions
 	cmd := &cobra.Command{
 		Use:     "update [OPTIONS] RUNNING_APP",
@@ -30,18 +29,17 @@ func updateCmd(dockerCli command.Cli) *cobra.Command {
 		Example: `$ docker app update myrunningapp --set key=value`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUpdate(dockerCli, args[0], opts)
+			return runUpdate(dockerCli, args[0], opts, installerContext)
 		},
 	}
 	opts.ParametersOptions.AddFlags(cmd.Flags())
 	opts.credentialOptions.addFlags(cmd.Flags())
-	opts.InstallerContextOptions.AddFlags(cmd.Flags())
 	cmd.Flags().StringVar(&opts.bundleOrDockerApp, "image", "", "Override the running App with another App image")
 
 	return cmd
 }
 
-func runUpdate(dockerCli command.Cli, installationName string, opts updateOptions) error {
+func runUpdate(dockerCli command.Cli, installationName string, opts updateOptions, installerContext *cliopts.InstallerContextOptions) error {
 	defer muteDockerCli(dockerCli)()
 
 	bundleStore, installationStore, credentialStore, err := prepareStores(dockerCli.CurrentContext())
@@ -73,7 +71,7 @@ func runUpdate(dockerCli command.Cli, installationName string, opts updateOption
 		return err
 	}
 
-	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, opts.InstallerContextOptions, os.Stdout)
+	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, installerContext, os.Stdout)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -62,3 +62,10 @@ func runValidate(args []string, opts validateOptions) error {
 	fmt.Fprintf(os.Stdout, "Validated %q\n", app.Path)
 	return nil
 }
+
+func firstOrEmpty(list []string) string {
+	if len(list) != 0 {
+		return list[0]
+	}
+	return ""
+}


### PR DESCRIPTION
**- What I did**
The current `docker app ls` command relies only on parsing claims in the local claim store and its last action, so it is totally uncorrelated with the current app status.

- List all the required services and the running services

**- How I did it**
- Tries to call status json action on all installed app and parses the json output with services description and their status. The `ls` command aggregates all those services, and counts how many are running and how many are desired (from the bundle).

**- How to verify it**
```
 $ docker app ls           
INSTALLATION          APPLICATION   SERVICES LAST ACTION RESULT  CREATED     MODIFIED    REFERENCE
socks                 socks (0.1)   13/13    install     success 4 hours ago 4 hours ago docker.io/library/sockshop:latest
sweet_cartwright      coins (0.1.0) N/A      install     failure 4 days ago  4 days ago  79390aac20c7945c22f18d3bc2a029a9a2aaf07aca6bef458ec18014085b010a
compassionate_mcnulty coins (0.1.0) N/A      install     success 11 days ago 11 days ago 79390aac20c7945c22f18d3bc2a029a9a2aaf07aca6bef458ec18014085b010a

$ docker ps               
CONTAINER ID        IMAGE                                COMMAND                  CREATED              STATUS              PORTS                                NAMES
6b93b1f4d147        weaveworksdemos/user-db:0.4.0        "/entrypoint.sh mong…"   54 seconds ago       Up 40 seconds       27017/tcp                            socks_user-db.1.ru12155gazmubn4ptz18ujelg
123a1d4a9737        weaveworksdemos/load-test:0.1.1      "/usr/local/bin/runL…"   About a minute ago   Up About a minute   8089/tcp                             socks_user-sim.1.f42swbjvlrbo8wp5q974nev9g
8f5f61e99639        weaveworksdemos/payment:0.4.3        "/app -port=80"          4 hours ago          Up 4 hours          80/tcp                               socks_payment.1.lsc40gglfm5qejdoebzyfsf16

$ docker kill 6b93b1f4d147
6b93b1f4d147

$ docker app ls           
INSTALLATION          APPLICATION   SERVICES LAST ACTION RESULT  CREATED     MODIFIED    REFERENCE
socks                 socks (0.1)   12/13    install     success 4 hours ago 4 hours ago docker.io/library/sockshop:latest
sweet_cartwright      coins (0.1.0) N/A      install     failure 4 days ago  4 days ago  79390aac20c7945c22f18d3bc2a029a9a2aaf07aca6bef458ec18014085b010a
compassionate_mcnulty coins (0.1.0) N/A      install     success 11 days ago 11 days ago 79390aac20c7945c22f18d3bc2a029a9a2aaf07aca6bef458ec18014085b010a
```


**- Description for the changelog**
- Add services column to docker app ls command

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/31478878/69251975-8ca61400-0bb2-11ea-8bf4-e7f53ecc4dc9.png)

