### PR TITLE
Create a context for the progress printer

### DIFF
--- a/internal/commands/build/build.go
+++ b/internal/commands/build/build.go
@@ -169,7 +169,9 @@ func buildImageUsingBuildx(app *types.App, contextPath string, opt buildOptions,
 		out = os.NewFile(dockerCli.Out().FD(), "/dev/stdout")
 	}
 
-	pw := progress.NewPrinter(ctx, out, opt.progress)
+	ctx2, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	pw := progress.NewPrinter(ctx2, out, opt.progress)
 
 	// We rely on buildx "docker" builder integrated in docker engine, so don't need a DockerAPI here
 	resp, err := build.Build(ctx, driverInfo, buildopts, nil, dockerCli.ConfigFile(), pw)


### PR DESCRIPTION
We call cancel on the context once we finished so that it will stop
printing stuff. This *could* fix APP-349 and could fix the errors with
status code 141 that we see on our CI.
