### PR TITLE
Relocation the right way

### DIFF
--- a/cmd/cnab-run/bundle.go
+++ b/cmd/cnab-run/bundle.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/docker/app/internal/relocated"
+)
+
+const (
+	// bundlePath is where the CNAB runtime will put the actual Bundle definition
+	bundlePath = "/cnab/bundle.json"
+)
+
+func getBundle() (*bundle.Bundle, error) {
+	return relocated.BundleJSON(bundlePath)
+}

--- a/cmd/cnab-run/bundle.go
+++ b/cmd/cnab-run/bundle.go
@@ -3,13 +3,38 @@ package main
 import (
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/app/internal/relocated"
+	"github.com/docker/cnab-to-oci/relocation"
 )
 
 const (
 	// bundlePath is where the CNAB runtime will put the actual Bundle definition
 	bundlePath = "/cnab/bundle.json"
+	// relocationMapPath is where the CNAB runtime will put the relocation map
+	// See https://github.com/cnabio/cnab-spec/blob/master/103-bundle-runtime.md#image-relocation
+	relocationMapPath = "/cnab/app/relocation-mapping.json"
 )
 
 func getBundle() (*bundle.Bundle, error) {
 	return relocated.BundleJSON(bundlePath)
+}
+
+func getRelocationMap() (relocation.ImageRelocationMap, error) {
+	return relocated.RelocationMapJSON(relocationMapPath)
+}
+
+func getRelocatedBundle() (*relocated.Bundle, error) {
+	bndl, err := getBundle()
+	if err != nil {
+		return nil, err
+	}
+
+	relocationMap, err := getRelocationMap()
+	if err != nil {
+		return nil, err
+	}
+
+	return &relocated.Bundle{
+		Bundle:        bndl,
+		RelocationMap: relocationMap,
+	}, nil
 }

--- a/cmd/cnab-run/inspect.go
+++ b/cmd/cnab-run/inspect.go
@@ -15,11 +15,11 @@ func inspectAction(instanceName string) error {
 	}
 	defer app.Cleanup()
 
-	imageMap, err := getBundleImageMap()
+	bndl, err := getBundle()
 	if err != nil {
 		return err
 	}
 
 	parameters := packager.ExtractCNABParametersValues(packager.ExtractCNABParameterMapping(app.Parameters()), os.Environ())
-	return appinspect.ImageInspect(os.Stdout, app, parameters, imageMap)
+	return appinspect.ImageInspect(os.Stdout, app, parameters, bndl.Images)
 }

--- a/cmd/cnab-run/inspect.go
+++ b/cmd/cnab-run/inspect.go
@@ -15,11 +15,11 @@ func inspectAction(instanceName string) error {
 	}
 	defer app.Cleanup()
 
-	bndl, err := getBundle()
+	bndl, err := getRelocatedBundle()
 	if err != nil {
 		return err
 	}
 
 	parameters := packager.ExtractCNABParametersValues(packager.ExtractCNABParameterMapping(app.Parameters()), os.Environ())
-	return appinspect.ImageInspect(os.Stdout, app, parameters, bndl.Images)
+	return appinspect.ImageInspect(os.Stdout, app, parameters, bndl.RelocatedImages())
 }

--- a/cmd/cnab-run/install.go
+++ b/cmd/cnab-run/install.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/render"
@@ -17,12 +16,6 @@ import (
 	composetypes "github.com/docker/cli/cli/compose/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
-)
-
-const (
-	// imageMapFilePath is the path where the CNAB runtime will put the actual
-	// service to image mapping to use
-	imageMapFilePath = "/cnab/app/image-map.json"
 )
 
 func installAction(instanceName string) error {
@@ -42,12 +35,12 @@ func installAction(instanceName string) error {
 	if err != nil {
 		return err
 	}
-	imageMap, err := getBundleImageMap()
+	bndl, err := getBundle()
 	if err != nil {
 		return err
 	}
 	parameters := packager.ExtractCNABParametersValues(packager.ExtractCNABParameterMapping(app.Parameters()), os.Environ())
-	rendered, err := render.Render(app, parameters, imageMap)
+	rendered, err := render.Render(app, parameters, bndl.Images)
 	if err != nil {
 		return err
 	}
@@ -77,18 +70,6 @@ func getFlagset(orchestrator command.Orchestrator) *pflag.FlagSet {
 		result.String("namespace", os.Getenv(internal.DockerKubernetesNamespaceEnvVar), "")
 	}
 	return result
-}
-
-func getBundleImageMap() (map[string]bundle.Image, error) {
-	mapJSON, err := ioutil.ReadFile(imageMapFilePath)
-	if err != nil {
-		return nil, err
-	}
-	var result map[string]bundle.Image
-	if err := json.Unmarshal(mapJSON, &result); err != nil {
-		return nil, err
-	}
-	return result, nil
 }
 
 func addLabels(rendered *composetypes.Config) error {

--- a/cmd/cnab-run/install.go
+++ b/cmd/cnab-run/install.go
@@ -35,12 +35,12 @@ func installAction(instanceName string) error {
 	if err != nil {
 		return err
 	}
-	bndl, err := getBundle()
+	bndl, err := getRelocatedBundle()
 	if err != nil {
 		return err
 	}
 	parameters := packager.ExtractCNABParametersValues(packager.ExtractCNABParameterMapping(app.Parameters()), os.Environ())
-	rendered, err := render.Render(app, parameters, bndl.Images)
+	rendered, err := render.Render(app, parameters, bndl.RelocatedImages())
 	if err != nil {
 		return err
 	}

--- a/cmd/cnab-run/render.go
+++ b/cmd/cnab-run/render.go
@@ -19,7 +19,7 @@ func renderAction(instanceName string) error {
 	}
 	defer app.Cleanup()
 
-	imageMap, err := getBundleImageMap()
+	bndl, err := getBundle()
 	if err != nil {
 		return err
 	}
@@ -31,7 +31,7 @@ func renderAction(instanceName string) error {
 
 	parameters := packager.ExtractCNABParametersValues(packager.ExtractCNABParameterMapping(app.Parameters()), os.Environ())
 
-	rendered, err := render.Render(app, parameters, imageMap)
+	rendered, err := render.Render(app, parameters, bndl.Images)
 	if err != nil {
 		return err
 	}

--- a/cmd/cnab-run/render.go
+++ b/cmd/cnab-run/render.go
@@ -19,7 +19,7 @@ func renderAction(instanceName string) error {
 	}
 	defer app.Cleanup()
 
-	bndl, err := getBundle()
+	bndl, err := getRelocatedBundle()
 	if err != nil {
 		return err
 	}
@@ -31,7 +31,7 @@ func renderAction(instanceName string) error {
 
 	parameters := packager.ExtractCNABParametersValues(packager.ExtractCNABParameterMapping(app.Parameters()), os.Environ())
 
-	rendered, err := render.Render(app, parameters, bndl.Images)
+	rendered, err := render.Render(app, parameters, bndl.RelocatedImages())
 	if err != nil {
 		return err
 	}

--- a/internal/cnab/driver.go
+++ b/internal/cnab/driver.go
@@ -2,9 +2,12 @@ package cnab
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/docker/app/internal/cliopts"
 	"github.com/docker/app/internal/store"
@@ -130,4 +133,15 @@ func SetupDriver(installation *store.Installation, dockerCli command.Cli, opts *
 	}
 	driverImpl, errBuf := prepareDriver(dockerCli, bind, stdout)
 	return driverImpl, errBuf, nil
+}
+
+func WithRelocationMap(installation *store.Installation) func(op *driver.Operation) error {
+	return func(op *driver.Operation) error {
+		data, err := json.Marshal(installation.RelocationMap)
+		if err != nil {
+			return errors.Wrap(err, "could not marshal relocation map")
+		}
+		op.Files["/cnab/app/relocation-mapping.json"] = string(data)
+		return nil
+	}
 }

--- a/internal/cnab/driver.go
+++ b/internal/cnab/driver.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/docker/app/internal/cliopts"
-	store2 "github.com/docker/app/internal/store"
+	"github.com/docker/app/internal/store"
 
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/driver"
@@ -15,7 +15,7 @@ import (
 	"github.com/docker/app/internal"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/context/docker"
-	"github.com/docker/cli/cli/context/store"
+	cliContext "github.com/docker/cli/cli/context/store"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 )
@@ -39,7 +39,7 @@ func RequiredClaimBindMount(c claim.Claim, dockerCli command.Cli) (BindMount, er
 
 // RequiredBindMount Returns the path required to bind mount when running
 // the invocation image.
-func RequiredBindMount(targetContextName string, targetOrchestrator string, s store.Store) (BindMount, error) {
+func RequiredBindMount(targetContextName string, targetOrchestrator string, s cliContext.Store) (BindMount, error) {
 	if targetOrchestrator == "kubernetes" {
 		return BindMount{}, nil
 	}
@@ -119,7 +119,7 @@ func prepareDriver(dockerCli command.Cli, bindMount BindMount, stdout io.Writer)
 	return d, errBuf
 }
 
-func SetupDriver(installation *store2.Installation, dockerCli command.Cli, opts *cliopts.InstallerContextOptions, stdout io.Writer) (driver.Driver, *bytes.Buffer, error) {
+func SetupDriver(installation *store.Installation, dockerCli command.Cli, opts *cliopts.InstallerContextOptions, stdout io.Writer) (driver.Driver, *bytes.Buffer, error) {
 	dockerCli, err := opts.SetInstallerContext(dockerCli)
 	if err != nil {
 		return nil, nil, err

--- a/internal/commands/image/inspect.go
+++ b/internal/commands/image/inspect.go
@@ -88,7 +88,7 @@ func runInspect(dockerCli command.Cli, appname string, opts inspectOptions, inst
 		}
 
 		installation.SetParameter(internal.ParameterInspectFormatName, format)
-		if err = a.Run(&installation.Claim, nil); err != nil {
+		if err = a.Run(&installation.Claim, nil, cnab.WithRelocationMap(installation)); err != nil {
 			return fmt.Errorf("inspect failed: %s\n%s", err, errBuf)
 		}
 	} else {

--- a/internal/commands/image/render.go
+++ b/internal/commands/image/render.go
@@ -70,7 +70,7 @@ func runRender(dockerCli command.Cli, appname string, opts renderOptions, instal
 	}
 	installation.Parameters[internal.ParameterRenderFormatName] = opts.formatDriver
 
-	if err := action.Run(&installation.Claim, nil, cfgFunc); err != nil {
+	if err := action.Run(&installation.Claim, nil, cfgFunc, cnab.WithRelocationMap(installation)); err != nil {
 		return fmt.Errorf("render failed: %s\n%s", err, errBuf)
 	}
 	return nil

--- a/internal/commands/inspect.go
+++ b/internal/commands/inspect.go
@@ -73,7 +73,7 @@ func runInspect(dockerCli command.Cli, appName string, inspectOptions inspectOpt
 	} else {
 		return fmt.Errorf("inspect failed: status action is not supported by the App")
 	}
-	if err := a.Run(&installation.Claim, creds); err != nil {
+	if err := a.Run(&installation.Claim, creds, cnab.WithRelocationMap(installation)); err != nil {
 		return fmt.Errorf("inspect failed: %s\n%s", err, errBuf)
 	}
 

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -82,7 +82,7 @@ func runRemove(dockerCli command.Cli, installationName string, opts removeOption
 		op.Out = dockerCli.Out()
 		return nil
 	}
-	if err := uninst.Run(&installation.Claim, creds, cfgFunc); err != nil {
+	if err := uninst.Run(&installation.Claim, creds, cfgFunc, cnab.WithRelocationMap(installation)); err != nil {
 		if err2 := installationStore.Store(installation); err2 != nil {
 			return fmt.Errorf("%s while %s", err2, errBuf)
 		}

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -158,7 +158,7 @@ func runBundle(dockerCli command.Cli, bndl *relocated.Bundle, opts runOptions, i
 			op.Out = dockerCli.Out()
 			return nil
 		}
-		err = inst.Run(&installation.Claim, creds, cfgFunc)
+		err = inst.Run(&installation.Claim, creds, cfgFunc, cnab.WithRelocationMap(installation))
 	}
 	// Even if the installation failed, the installation is persisted with its failure status,
 	// so any installation needs a clean uninstallation.

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -89,7 +89,7 @@ func runUpdate(dockerCli command.Cli, installationName string, opts updateOption
 		op.Out = dockerCli.Out()
 		return nil
 	}
-	err = u.Run(&installation.Claim, creds, cfgFunc)
+	err = u.Run(&installation.Claim, creds, cfgFunc, cnab.WithRelocationMap(installation))
 	err2 := installationStore.Store(installation)
 	if err != nil {
 		return fmt.Errorf("Update failed: %s\n%s", err, errBuf)

--- a/internal/relocated/bundle.go
+++ b/internal/relocated/bundle.go
@@ -32,7 +32,7 @@ func FromBundle(bndl *bundle.Bundle) *Bundle {
 
 // BundleFromFile creates a relocated bundle based on the bundle file and relocation map.
 func BundleFromFile(filename string) (*Bundle, error) {
-	bndl, err := bundleJSON(filename)
+	bndl, err := BundleJSON(filename)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read bundle")
 	}
@@ -75,7 +75,7 @@ func (b *Bundle) Store(dir string) error {
 	return nil
 }
 
-func bundleJSON(bundlePath string) (*bundle.Bundle, error) {
+func BundleJSON(bundlePath string) (*bundle.Bundle, error) {
 	data, err := ioutil.ReadFile(bundlePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read file %s", bundlePath)

--- a/internal/store/installation.go
+++ b/internal/store/installation.go
@@ -39,7 +39,6 @@ func NewInstallation(name string, reference string, bndl *relocated.Bundle) (*In
 		Reference:     reference,
 		RelocationMap: bndl.RelocationMap,
 	}
-	i.applyRelocationMap()
 
 	return i, nil
 }
@@ -49,21 +48,6 @@ func NewInstallation(name string, reference string, bndl *relocated.Bundle) (*In
 func (i Installation) SetParameter(name string, value string) {
 	if _, ok := i.Bundle.Parameters[name]; ok {
 		i.Parameters[name] = value
-	}
-}
-
-func (i *Installation) applyRelocationMap() {
-	for idx, def := range i.Bundle.InvocationImages {
-		if img, ok := i.RelocationMap[def.Image]; ok {
-			def.Image = img
-			i.Bundle.InvocationImages[idx] = def
-		}
-	}
-	for name, def := range i.Bundle.Images {
-		if img, ok := i.RelocationMap[def.Image]; ok {
-			def.Image = img
-			i.Bundle.Images[name] = def
-		}
 	}
 }
 

--- a/internal/store/installation_test.go
+++ b/internal/store/installation_test.go
@@ -4,11 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/app/internal/relocated"
-
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/docker/cnab-to-oci/relocation"
-
 	"github.com/deislabs/cnab-go/claim"
 	"gotest.tools/assert"
 	"gotest.tools/fs"
@@ -42,69 +37,4 @@ func TestStoreAndReadInstallation(t *testing.T) {
 	actualInstallation, err := installationStore.Read("installation-name")
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expectedInstallation, actualInstallation)
-}
-
-func TestApplyingRelocationMap(t *testing.T) {
-	installation, _ := NewInstallation("name", "reference", &relocated.Bundle{
-		Bundle: &bundle.Bundle{
-			InvocationImages: []bundle.InvocationImage{
-				{
-					BaseImage: bundle.BaseImage{
-						Image: "localimage:1.0-invoc",
-					},
-				},
-			},
-			Images: map[string]bundle.Image{
-				"svc1": {
-					BaseImage: bundle.BaseImage{
-						Image: "svc-1:local",
-					},
-				},
-				"redis": {
-					BaseImage: bundle.BaseImage{
-						Image: "redis:latest",
-					},
-				},
-				"hello": {
-					BaseImage: bundle.BaseImage{
-						Image: "http-echo",
-					},
-				},
-			},
-		},
-		RelocationMap: relocation.ImageRelocationMap{
-			"localimage:1.0-invoc": "docker.io/repo/app:tag@sha256:9f9426498125d4017bdbdc861451bd447b9cb6d0c7a790093a65f508f45a1dd4",
-			"svc-1:local":          "docker.io/repo/app:tag@sha256:d14de6677360066fcb302892bf288b8a907fddb264f587189ea17e691284e58c",
-			"redis:latest":         "docker.io/repo/app:tag@sha256:e6e61849494c55a096cb48f7efb262271a50e2452b6a9e3553cf26f519f01d23",
-		},
-	})
-
-	expectedBundle := &bundle.Bundle{
-		InvocationImages: []bundle.InvocationImage{
-			{
-				BaseImage: bundle.BaseImage{
-					Image: "docker.io/repo/app:tag@sha256:9f9426498125d4017bdbdc861451bd447b9cb6d0c7a790093a65f508f45a1dd4",
-				},
-			},
-		},
-		Images: map[string]bundle.Image{
-			"svc1": {
-				BaseImage: bundle.BaseImage{
-					Image: "docker.io/repo/app:tag@sha256:d14de6677360066fcb302892bf288b8a907fddb264f587189ea17e691284e58c",
-				},
-			},
-			"redis": {
-				BaseImage: bundle.BaseImage{
-					Image: "docker.io/repo/app:tag@sha256:e6e61849494c55a096cb48f7efb262271a50e2452b6a9e3553cf26f519f01d23",
-				},
-			},
-			"hello": {
-				BaseImage: bundle.BaseImage{
-					Image: "http-echo",
-				},
-			},
-		},
-	}
-
-	assert.DeepEqual(t, expectedBundle, installation.Bundle)
 }


### PR DESCRIPTION
**- What I did**

Copy the relocation map in a dedicated file and apply it at runtime in the invocation image instead of modifying the service definition in the `Installation` object.

See https://github.com/cnabio/cnab-spec/blob/master/103-bundle-runtime.md#image-relocation

**- How I did it**

The relocation map is now stored under `/cnab/app/relocation-mapping.json` when we run commands.
Then the `cnab-run` binary will read it, apply it on top of the service image definition.

Note: the `/cnab/app/image-map.json` is not read anymore, all data already exist in `/cnab/bundle.json`

**- How to verify it**

_Without this version_

When you run a pulled App, read the installation file (under `~/.docker/app/installation/.../appname.json`). The image definition should contains relocated images (everything like `registry/repo:tag@sha256...`)

_With this version_

When you run a pulled App (must be build using this version to have the right `cnab-run` binary) and look at the installation file, the service images must not be the relocated ones but the one in the `bundle.json`.
But if you inspect the App Image, you should see the relocated images.

**- Description for the changelog**

