### PR TITLE
Update cnab-to-oci to v0.3.0-beta2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -289,7 +289,7 @@
   revision = "37f9a88c696ae81be14c1697bd083d6421b4933c"
 
 [[projects]]
-  digest = "1:3314fe819a33c59d1d8c25b35297da7d3137dadef098699e087c50be3ecdd867"
+  digest = "1:0e9b90a528fee13963349cafa370f9709e7f1ef0df9eea53f31659aff2385336"
   name = "github.com/docker/cnab-to-oci"
   packages = [
     "converter",
@@ -298,8 +298,8 @@
     "remotes",
   ]
   pruneopts = "NUT"
-  revision = "5a97c84cb618aae63d98e5fb29b3116fbb01d358"
-  version = "v0.3.0-beta1"
+  revision = "aee9731b9e2d6066455e601f249835b10d5f87b7"
+  version = "v0.3.0-beta2"
 
 [[projects]]
   digest = "1:d29e07dc6fff1d592442bdf6b947f3a89d418ac6d65344d4e048c64a7cdd511c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,7 +42,7 @@ required = ["github.com/wadey/gocovmerge"]
 
 [[override]]
   name = "github.com/docker/cnab-to-oci"
-  version = "v0.3.0-beta1"
+  version = "v0.3.0-beta2"
 
 [[override]]
   name = "github.com/containerd/containerd"

--- a/vendor/github.com/docker/cnab-to-oci/remotes/pull.go
+++ b/vendor/github.com/docker/cnab-to-oci/remotes/pull.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/remotes"
@@ -16,6 +17,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
 // Pull pulls a bundle from an OCI Image Index manifest
@@ -42,6 +44,9 @@ func getIndex(ctx context.Context, ref auth.Scope, resolver remotes.Resolver) (o
 	logger.Debug("Getting OCI Index Descriptor")
 	resolvedRef, indexDescriptor, err := resolver.Resolve(withMutedContext(ctx), ref.String())
 	if err != nil {
+		if errors.Cause(err) == errdefs.ErrNotFound {
+			return ocischemav1.Index{}, err
+		}
 		return ocischemav1.Index{}, fmt.Errorf("failed to resolve bundle manifest %q: %s", ref, err)
 	}
 	if indexDescriptor.MediaType != ocischemav1.MediaTypeImageIndex && indexDescriptor.MediaType != images.MediaTypeDockerSchema2ManifestList {

--- a/vendor/github.com/docker/cnab-to-oci/remotes/push.go
+++ b/vendor/github.com/docker/cnab-to-oci/remotes/push.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/docker/cli/cli/config/credentials"
+
 	"github.com/docker/cnab-to-oci/internal"
 
 	"github.com/docker/cli/cli/config"
@@ -291,8 +293,16 @@ func resolveAuthConfig(index *registrytypes.IndexInfo) configtypes.AuthConfig {
 		return configtypes.AuthConfig{}
 	}
 
+	// See https://github.com/docker/cli/blob/23446275646041f9b598d64c51be24d5d0e49376/cli/config/credentials/file_store.go#L32-L47
+	// We are looking for the hostname in the configuration, and if not we are trying with a pure hostname (so without
+	// http/https).
 	authConfig, ok := configs[hostName]
 	if !ok {
+		for reg, config := range configs {
+			if hostName == credentials.ConvertToHostname(reg) {
+				return config
+			}
+		}
 		return configtypes.AuthConfig{}
 	}
 	return authConfig


### PR DESCRIPTION
**- What I did**

Updates vendor of cnab-to-oci to v0.3.0-beta2:

* Push images using relocation map first, then from the bundle
* Fix Docker CLI authentication to registries for the push
* Simplify error message returned when pulling CNAB bundle that is not found

**- How to verify it**

Attempt to pull an app that does not exist. E.g. `docker app pull carolinebriaud/vapp`

The error message should now be simplified to:

`carolinebriaud/vapp: docker.io/carolinebriaud/vapp:latest: not found`

**- Description for the changelog**
Simplify error message returned when pulling CNAB bundle that is not found


**- A picture of a cute animal (not mandatory)**

![hedgehog-2019-11-07](https://user-images.githubusercontent.com/22098752/69623458-da030500-103a-11ea-832a-b4c0b0b1ca24.jpg)
