### PR TITLE
Clean path before validating app

### DIFF
--- a/internal/names.go
+++ b/internal/names.go
@@ -95,7 +95,7 @@ func AppNameFromDir(dirName string) string {
 // DirNameFromAppName takes an application name and returns the
 // corresponding directory name
 func DirNameFromAppName(appName string) string {
-	if strings.HasSuffix(strings.TrimSuffix(appName, "/"), AppExtension) {
+	if strings.HasSuffix(filepath.Clean(appName), AppExtension) {
 		return appName
 	}
 	return appName + AppExtension

--- a/internal/names_test.go
+++ b/internal/names_test.go
@@ -37,6 +37,7 @@ func TestDirNameFromAppName(t *testing.T) {
 		{name: "", expected: ".dockerapp"},
 		{name: "foo/bar", expected: "foo/bar.dockerapp"},
 		{name: "foo/bar.dockerapp", expected: "foo/bar.dockerapp"},
+		{name: "foo/bar.dockerapp/", expected: "foo/bar.dockerapp/"},
 		// FIXME(vdemeester) we should fail here
 		{name: "foo/bar/", expected: "foo/bar/.dockerapp"},
 		{name: "/foo/bar.dockerapp", expected: "/foo/bar.dockerapp"},


### PR DESCRIPTION
**- What I did**

Clean the App name while getting the directory path so that pathing works with trailing slashes on both Unix and Windows machines 

**- How I did it**

Use filepath.Clean() to clean the path arg in docker app validate so that the path is correctly tested on both Unix and Windows machines.

**- How to verify it**

On Windows run

`.\bin\docker-app-windows.exe app validate .\examples\cnab-simple\hello.dockerapp\`

The command should succeed

**- Description for the changelog**

`docker app validate` will no longer fail on Windows when the supplied App path has a trailing backslash

**- A picture of a cute animal (not mandatory)**

![kitten-2019-11-12](https://user-images.githubusercontent.com/22098752/69630931-4e42a600-1045-11ea-881d-10787ea02796.jpg)

