### PR TITLE
Warn user if the app bundle version differs with the current app version

### DIFF
--- a/internal/commands/image/inspect.go
+++ b/internal/commands/image/inspect.go
@@ -54,7 +54,6 @@ func inspectCmd(dockerCli command.Cli, installerContext *cliopts.InstallerContex
 }
 
 func runInspect(dockerCli command.Cli, appname string, opts inspectOptions, installerContext *cliopts.InstallerContextOptions) error {
-	defer muteDockerCli(dockerCli)()
 	s, err := appstore.NewApplicationStore(config.Dir())
 	if err != nil {
 		return err
@@ -82,6 +81,7 @@ func runInspect(dockerCli command.Cli, appname string, opts inspectOptions, inst
 		return err
 	}
 
+	defer muteDockerCli(dockerCli)()
 	if _, hasAction := installation.Bundle.Actions[internal.ActionInspectName]; hasAction {
 		driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, installerContext, os.Stdout)
 		if err != nil {

--- a/internal/commands/image/inspect.go
+++ b/internal/commands/image/inspect.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/docker/app/internal/packager"
+
 	"github.com/deislabs/cnab-go/action"
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/cliopts"
@@ -64,6 +66,9 @@ func runInspect(dockerCli command.Cli, appname string, opts inspectOptions, inst
 	bndl, ref, err := cnab.GetBundle(dockerCli, bundleStore, appname)
 
 	if err != nil {
+		return err
+	}
+	if err := packager.CheckAppVersion(dockerCli.Err(), bndl.Bundle); err != nil {
 		return err
 	}
 

--- a/internal/commands/image/render.go
+++ b/internal/commands/image/render.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/docker/app/internal/packager"
+
 	"github.com/deislabs/cnab-go/driver"
 
 	"github.com/deislabs/cnab-go/action"
@@ -91,11 +93,14 @@ func prepareCustomAction(actionName string,
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	bundle, ref, err := cnab.GetBundle(dockerCli, bundleStore, appname)
+	bndl, ref, err := cnab.GetBundle(dockerCli, bundleStore, appname)
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "could not render %q: no such App image", appname)
 	}
-	installation, err := appstore.NewInstallation("custom-action", ref.String(), bundle)
+	if err := packager.CheckAppVersion(dockerCli.Err(), bndl.Bundle); err != nil {
+		return nil, nil, nil, err
+	}
+	installation, err := appstore.NewInstallation("custom-action", ref.String(), bndl)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/commands/image/render.go
+++ b/internal/commands/image/render.go
@@ -1,20 +1,17 @@
 package image
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
 
-	"github.com/docker/app/internal/packager"
-
-	"github.com/deislabs/cnab-go/driver"
-
 	"github.com/deislabs/cnab-go/action"
+	"github.com/deislabs/cnab-go/driver"
 	"github.com/docker/app/internal"
 	bdl "github.com/docker/app/internal/bundle"
 	"github.com/docker/app/internal/cliopts"
 	"github.com/docker/app/internal/cnab"
+	"github.com/docker/app/internal/packager"
 	appstore "github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -49,8 +46,6 @@ func renderCmd(dockerCli command.Cli, installerContext *cliopts.InstallerContext
 }
 
 func runRender(dockerCli command.Cli, appname string, opts renderOptions, installerContext *cliopts.InstallerContextOptions) error {
-	defer muteDockerCli(dockerCli)()
-
 	var w io.Writer = os.Stdout
 	if opts.renderOutput != "-" {
 		f, err := os.Create(opts.renderOutput)
@@ -61,64 +56,51 @@ func runRender(dockerCli command.Cli, appname string, opts renderOptions, instal
 		w = f
 	}
 
-	cfgFunc := func(op *driver.Operation) error {
-		op.Out = w
-		return nil
-	}
-
-	action, installation, errBuf, err := prepareCustomAction(internal.ActionRenderName, dockerCli, appname, w, opts, installerContext)
+	s, err := appstore.NewApplicationStore(config.Dir())
 	if err != nil {
 		return err
 	}
-	installation.Parameters[internal.ParameterRenderFormatName] = opts.formatDriver
-
-	if err := action.Run(&installation.Claim, nil, cfgFunc, cnab.WithRelocationMap(installation)); err != nil {
-		return fmt.Errorf("render failed: %s\n%s", err, errBuf)
-	}
-	return nil
-}
-
-func prepareCustomAction(actionName string,
-	dockerCli command.Cli,
-	appname string,
-	stdout io.Writer,
-	opts renderOptions,
-	installerContext *cliopts.InstallerContextOptions) (*action.RunCustom, *appstore.Installation, *bytes.Buffer, error) {
-
-	s, err := appstore.NewApplicationStore(config.Dir())
-	if err != nil {
-		return nil, nil, nil, err
-	}
 	bundleStore, err := s.BundleStore()
 	if err != nil {
-		return nil, nil, nil, err
+		return err
 	}
 	bndl, ref, err := cnab.GetBundle(dockerCli, bundleStore, appname)
 	if err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "could not render %q: no such App image", appname)
+		return errors.Wrapf(err, "could not render %q: no such App image", appname)
 	}
 	if err := packager.CheckAppVersion(dockerCli.Err(), bndl.Bundle); err != nil {
-		return nil, nil, nil, err
+		return err
 	}
 	installation, err := appstore.NewInstallation("custom-action", ref.String(), bndl)
 	if err != nil {
-		return nil, nil, nil, err
+		return err
 	}
 
 	if err := bdl.MergeBundleParameters(installation,
 		bdl.WithFileParameters(opts.ParametersFiles),
 		bdl.WithCommandLineParameters(opts.Overrides),
 	); err != nil {
-		return nil, nil, nil, err
+		return err
 	}
 
-	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, installerContext, stdout)
+	defer muteDockerCli(dockerCli)()
+	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, installerContext, w)
 	if err != nil {
-		return nil, nil, nil, err
+		return err
 	}
-	a := &action.RunCustom{
-		Action: actionName,
+	action := &action.RunCustom{
+		Action: internal.ActionRenderName,
 		Driver: driverImpl,
 	}
-	return a, installation, errBuf, nil
+	installation.Parameters[internal.ParameterRenderFormatName] = opts.formatDriver
+
+	cfgFunc := func(op *driver.Operation) error {
+		op.Out = w
+		return nil
+	}
+
+	if err := action.Run(&installation.Claim, nil, cfgFunc, cnab.WithRelocationMap(installation)); err != nil {
+		return fmt.Errorf("render failed: %s\n%s", err, errBuf)
+	}
+	return nil
 }

--- a/internal/commands/inspect.go
+++ b/internal/commands/inspect.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/app/internal/cliopts"
 	"github.com/docker/app/internal/cnab"
 	"github.com/docker/app/internal/inspect"
+	"github.com/docker/app/internal/packager"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
@@ -51,7 +52,9 @@ func runInspect(dockerCli command.Cli, appName string, inspectOptions inspectOpt
 	if err != nil {
 		return err
 	}
-
+	if err := packager.CheckAppVersion(dockerCli.Err(), installation.Bundle); err != nil {
+		return err
+	}
 	creds, err := prepareCredentialSet(installation.Bundle, inspectOptions.CredentialSetOpts(dockerCli, credentialStore)...)
 	if err != nil {
 		return err

--- a/internal/commands/inspect.go
+++ b/internal/commands/inspect.go
@@ -43,7 +43,6 @@ func inspectCmd(dockerCli command.Cli, installerContext *cliopts.InstallerContex
 }
 
 func runInspect(dockerCli command.Cli, appName string, inspectOptions inspectOptions, installerContext *cliopts.InstallerContextOptions) error {
-	defer muteDockerCli(dockerCli)()
 	_, installationStore, credentialStore, err := prepareStores(dockerCli.CurrentContext())
 	if err != nil {
 		return err
@@ -60,6 +59,7 @@ func runInspect(dockerCli command.Cli, appName string, inspectOptions inspectOpt
 		return err
 	}
 
+	defer muteDockerCli(dockerCli)()
 	var buf bytes.Buffer
 	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, installerContext, &buf)
 	if err != nil {

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/docker/app/internal/cnab"
+	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -46,7 +47,9 @@ func runPull(dockerCli command.Cli, name string) error {
 	if err != nil {
 		return errors.Wrap(err, name)
 	}
-
+	if err := packager.CheckAppVersion(dockerCli.Err(), bndl.Bundle); err != nil {
+		return err
+	}
 	fmt.Fprintf(os.Stdout, "Successfully pulled %q (%s) from %s\n", bndl.Name, bndl.Version, ref.String())
 
 	return nil

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -42,8 +42,6 @@ func removeCmd(dockerCli command.Cli, installerContext *cliopts.InstallerContext
 }
 
 func runRemove(dockerCli command.Cli, installationName string, opts removeOptions, installerContext *cliopts.InstallerContextOptions) (mainErr error) {
-	defer muteDockerCli(dockerCli)()
-
 	_, installationStore, credentialStore, err := prepareStores(dockerCli.CurrentContext())
 	if err != nil {
 		return err
@@ -69,6 +67,8 @@ func runRemove(dockerCli command.Cli, installationName string, opts removeOption
 			fmt.Fprintf(os.Stderr, "deletion forced for running App %q\n", installationName)
 		}()
 	}
+
+	defer muteDockerCli(dockerCli)()
 	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, installerContext, os.Stdout)
 	if err != nil {
 		return err

--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/app/internal/cliopts"
 	"github.com/docker/app/internal/cnab"
+	"github.com/docker/app/internal/packager"
 
 	"github.com/deislabs/cnab-go/driver"
 
@@ -52,6 +53,10 @@ func runRemove(dockerCli command.Cli, installationName string, opts removeOption
 	if err != nil {
 		return err
 	}
+	if err := packager.CheckAppVersion(dockerCli.Err(), installation.Bundle); err != nil {
+		return err
+	}
+
 	if opts.force {
 		defer func() {
 			if mainErr == nil {

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/docker/app/internal/packager"
+
 	"github.com/docker/app/internal/relocated"
 
 	"github.com/deislabs/cnab-go/driver"
@@ -98,6 +100,9 @@ func runDockerApp(dockerCli command.Cli, appname string, opts runOptions, instal
 }
 
 func runBundle(dockerCli command.Cli, bndl *relocated.Bundle, opts runOptions, installerContext *cliopts.InstallerContextOptions, ref string) (err error) {
+	if err := packager.CheckAppVersion(dockerCli.Err(), bndl.Bundle); err != nil {
+		return err
+	}
 	_, installationStore, credentialStore, err := prepareStores(dockerCli.CurrentContext())
 	if err != nil {
 		return err

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/app/internal/bundle"
 	"github.com/docker/app/internal/cliopts"
 	"github.com/docker/app/internal/cnab"
+	"github.com/docker/app/internal/packager"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
@@ -63,6 +64,10 @@ func runUpdate(dockerCli command.Cli, installationName string, opts updateOption
 		}
 		installation.Bundle = b.Bundle
 	}
+	if err := packager.CheckAppVersion(dockerCli.Err(), installation.Bundle); err != nil {
+		return err
+	}
+
 	if err := bundle.MergeBundleParameters(installation,
 		bundle.WithFileParameters(opts.ParametersFiles),
 		bundle.WithCommandLineParameters(opts.Overrides),

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -41,8 +41,6 @@ func updateCmd(dockerCli command.Cli, installerContext *cliopts.InstallerContext
 }
 
 func runUpdate(dockerCli command.Cli, installationName string, opts updateOptions, installerContext *cliopts.InstallerContextOptions) error {
-	defer muteDockerCli(dockerCli)()
-
 	bundleStore, installationStore, credentialStore, err := prepareStores(dockerCli.CurrentContext())
 	if err != nil {
 		return err
@@ -76,6 +74,7 @@ func runUpdate(dockerCli command.Cli, installationName string, opts updateOption
 		return err
 	}
 
+	defer muteDockerCli(dockerCli)()
 	driverImpl, errBuf, err := cnab.SetupDriver(installation, dockerCli, installerContext, os.Stdout)
 	if err != nil {
 		return err

--- a/internal/packager/cnab.go
+++ b/internal/packager/cnab.go
@@ -172,7 +172,7 @@ func ToCNAB(app *types.App, invocationImageName string) (*bundle.Bundle, error) 
 		SchemaVersion: CNABVersion1_0_0,
 		Custom: map[string]interface{}{
 			internal.CustomDockerAppName: DockerAppCustom{
-				Version: DockerAppCustomVersionCurrent,
+				Version: DockerAppPayloadVersionCurrent,
 				Payload: payload,
 			},
 		},

--- a/internal/packager/cnab_test.go
+++ b/internal/packager/cnab_test.go
@@ -22,7 +22,7 @@ func TestToCNAB(t *testing.T) {
 	assert.NilError(t, err)
 	s := golden.Get(t, "bundle-json.golden")
 	expectedLiteral := regexp.QuoteMeta(string(s))
-	expected := fmt.Sprintf(expectedLiteral, DockerAppPayloadVersionCurrent, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z`, internal.Version)
+	expected := fmt.Sprintf(expectedLiteral, DockerAppPayloadVersionCurrent, internal.Version, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z`)
 	matches, err := regexp.Match(expected, actualJSON)
 	assert.NilError(t, err)
 	assert.Assert(t, matches)

--- a/internal/packager/cnab_test.go
+++ b/internal/packager/cnab_test.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/docker/app/internal"
+
 	"github.com/docker/app/types"
 	"gotest.tools/assert"
 	"gotest.tools/golden"
@@ -20,7 +22,7 @@ func TestToCNAB(t *testing.T) {
 	assert.NilError(t, err)
 	s := golden.Get(t, "bundle-json.golden")
 	expectedLiteral := regexp.QuoteMeta(string(s))
-	expected := fmt.Sprintf(expectedLiteral, DockerAppCustomVersionCurrent, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z`)
+	expected := fmt.Sprintf(expectedLiteral, DockerAppPayloadVersionCurrent, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z`, internal.Version)
 	matches, err := regexp.Match(expected, actualJSON)
 	assert.NilError(t, err)
 	assert.Assert(t, matches)

--- a/internal/packager/custom_test.go
+++ b/internal/packager/custom_test.go
@@ -42,7 +42,7 @@ func TestCustomPayloadNil(t *testing.T) {
 		},
 		{
 			testName: "NoPayload",
-			version:  DockerAppCustomVersionCurrent,
+			version:  DockerAppPayloadVersionCurrent,
 			payload:  nil,
 		},
 	}
@@ -58,12 +58,13 @@ func TestCustomPayloadNil(t *testing.T) {
 
 func TestCustomPayloadV1_0_0(t *testing.T) {
 	now := time.Now().UTC()
-	b := createBundle(t, DockerAppCustomVersion1_0_0, payloadV1_0{now})
+	b := createBundle(t, DockerAppPayloadVersion1_0_0, payloadV1_0{now, "version"})
 	payload, err := CustomPayload(&b)
 	assert.NilError(t, err)
 	v1, ok := payload.(payloadV1_0)
 	assert.Assert(t, ok)
 	assert.Assert(t, now.Equal(v1.CreatedTime()))
+	assert.Equal(t, "version", v1.AppVersion())
 }
 
 func createBundle(t *testing.T, version string, payload interface{}) bundle.Bundle {

--- a/internal/packager/custom_test.go
+++ b/internal/packager/custom_test.go
@@ -58,7 +58,7 @@ func TestCustomPayloadNil(t *testing.T) {
 
 func TestCustomPayloadV1_0_0(t *testing.T) {
 	now := time.Now().UTC()
-	b := createBundle(t, DockerAppPayloadVersion1_0_0, payloadV1_0{now, "version"})
+	b := createBundle(t, DockerAppPayloadVersion1_0_0, payloadV1_0{"version", now})
 	payload, err := CustomPayload(&b)
 	assert.NilError(t, err)
 	v1, ok := payload.(payloadV1_0)

--- a/internal/packager/testdata/bundle-json.golden
+++ b/internal/packager/testdata/bundle-json.golden
@@ -184,8 +184,8 @@
     "com.docker.app": {
       "version": "%s",
       "payload": {
-        "created": "%s",
-        "app-version": "%s"
+        "app-version": "%s",
+        "created": "%s"
       }
     }
   }

--- a/internal/packager/testdata/bundle-json.golden
+++ b/internal/packager/testdata/bundle-json.golden
@@ -184,7 +184,8 @@
     "com.docker.app": {
       "version": "%s",
       "payload": {
-        "created": "%s"
+        "created": "%s",
+        "app-version": "%s"
       }
     }
   }


### PR DESCRIPTION
**- What I did**
I now check current app version vs bundle app version if any and print a warning if it differs on the following commands:
- inspect
- pull
- rm
- run
- update
- image inspect
- image render

**- How I did it**
I stored a new field "app-version" in the bundle's custom payload section, so I can compare built app image with the current app binary version.

**- How to verify it**
* Build an app with this PR's binary
* Edit the produced bundle directly in the bundle store (`~/.docker/app/bundles/..../bundle.json`), find where the custom payload is and change the `app-version` field
* Inspect this application, the warning should be there

**- Description for the changelog**
- Warn user if the app bundle version differs with the current app version

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/31478878/69724849-0abb6b00-111d-11ea-9283-07683d152bc5.png)

