### PR TITLE
Implement multi tag for build

### DIFF
--- a/internal/commands/build/compose.go
+++ b/internal/commands/build/compose.go
@@ -21,7 +21,7 @@ func parseCompose(app *types.App, contextPath string, options buildOptions) (map
 		return nil, nil, err
 	}
 
-	buildArgs := buildArgsToMap(options.args)
+	buildArgs := buildArgsToMap(options.args.GetAllOrEmpty())
 
 	pulledServices := []compose.ServiceConfig{}
 	opts := map[string]build.Options{}

--- a/internal/commands/build/compose_test.go
+++ b/internal/commands/build/compose_test.go
@@ -51,7 +51,7 @@ func Test_parseCompose(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			app, err := packager.Extract("testdata/" + tt.name)
 			assert.NilError(t, err)
-			got, _, err := parseCompose(app, "testdata", buildOptions{})
+			got, _, err := parseCompose(app, "testdata", newBuildOptions())
 			assert.NilError(t, err)
 			_, ok := got["dontwant"]
 			assert.Assert(t, !ok, "parseCompose() should have excluded 'dontwant' service")


### PR DESCRIPTION
Add multitag support for build

Note that with this implementation, building multiple times with different tags and building just one with multiple tags doesn't produce the same output. Check this:
[![asciicast](https://asciinema.org/a/284116.svg)](https://asciinema.org/a/284116)


**- What I did**
Added the option to use multiple tags to an `app image`

**- How I did it**
By turning the `tag` option into a list

**- How to verify it**
```shell
$ docker app build -t hello:v1 -t hello:v2 example/hello-world
```

**- Description for the changelog**
Add multitag support for build

**- A picture of a cute animal (not mandatory)**
![twin-goats](https://user-images.githubusercontent.com/373485/69810701-c4cdd800-11ec-11ea-9afa-50c5f1ceb53a.jpg)
