### PR TITLE
Standardize column spacing in output

### DIFF
--- a/cmd/cnab-run/status.go
+++ b/cmd/cnab-run/status.go
@@ -179,7 +179,7 @@ func runningServices(cli command.Cli, instanceName string) ([]swarmtypes.Service
 }
 
 func printServices(out io.Writer, services []swarmtypes.Service) error {
-	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
+	w := tabwriter.NewWriter(out, 20, 2, 3, ' ', 0)
 	printHeaders(w)
 
 	for _, service := range services {

--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -106,7 +106,7 @@ func runList(dockerCli command.Cli, opts listOptions, installerContext *cliopts.
 		return tmpl.Execute(dockerCli.Out(), installations)
 	}
 
-	w := tabwriter.NewWriter(dockerCli.Out(), 0, 0, 1, ' ', 0)
+	w := tabwriter.NewWriter(dockerCli.Out(), 20, 1, 3, ' ', 0)
 	printHeaders(w)
 
 	for _, installation := range installations {

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -280,7 +280,7 @@ func printSection(out io.Writer, len int, printer func(io.Writer), headers ...st
 		return
 	}
 	fmt.Fprintln(out)
-	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
+	w := tabwriter.NewWriter(out, 20, 1, 3, ' ', 0)
 	fmt.Fprintln(w, strings.Join(headers, "\t"))
 	printer(w)
 	w.Flush()

--- a/internal/inspect/testdata/inspect-bundle-pretty.golden
+++ b/internal/inspect/testdata/inspect-bundle-pretty.golden
@@ -8,17 +8,17 @@ maintainers:
   email: dev2@example.com
 
 
-SERVICE     IMAGE
-app-watcher watcher
-debug       busybox:latest
-front       nginx
-monitor     busybox:latest
+SERVICE             IMAGE
+app-watcher         watcher
+debug               busybox:latest
+front               nginx
+monitor             busybox:latest
 
-PARAMETER                           VALUE
-com.docker.app.args                 
-com.docker.app.inspect-format       json
-com.docker.app.kubernetes-namespace 
-com.docker.app.orchestrator         
-com.docker.app.render-format        yaml
-com.docker.app.share-registry-creds false
-watcher.cmd                         foo
+PARAMETER                             VALUE
+com.docker.app.args                   
+com.docker.app.inspect-format         json
+com.docker.app.kubernetes-namespace   
+com.docker.app.orchestrator           
+com.docker.app.render-format          yaml
+com.docker.app.share-registry-creds   false
+watcher.cmd                           foo

--- a/internal/inspect/testdata/inspect-full.golden
+++ b/internal/inspect/testdata/inspect-full.golden
@@ -6,9 +6,9 @@ maintainers:
   email: dev@example.com
 
 
-SERVICE REPLICAS PORTS     IMAGE
-web1    2        8080-8100 nginx:latest
-web2    2        9080-9100 nginx:latest
+SERVICE             REPLICAS            PORTS               IMAGE
+web1                2                   8080-8100           nginx:latest
+web2                2                   9080-9100           nginx:latest
 
 NETWORK
 my-network1
@@ -22,9 +22,9 @@ SECRET
 my-secret1
 my-secret2
 
-PARAMETER VALUE
-port      8080
-text      hello
+PARAMETER           VALUE
+port                8080
+text                hello
 
-ATTACHMENT SIZE
-config.cfg 9B
+ATTACHMENT          SIZE
+config.cfg          9B

--- a/internal/inspect/testdata/inspect-overridden.golden
+++ b/internal/inspect/testdata/inspect-overridden.golden
@@ -4,8 +4,8 @@ description: ""
 maintainers: []
 
 
-SERVICE REPLICAS PORTS IMAGE
-web     1        80    nginx
+SERVICE             REPLICAS            PORTS               IMAGE
+web                 1                   80                  nginx
 
-PARAMETER VALUE
-web.port  80
+PARAMETER           VALUE
+web.port            80


### PR DESCRIPTION
**- What I did**

Standardizes the column spacing when writing tables to the output to have the same width and padding as with standard docker CLI commands
Includes both Docker App and invocation image outputs

**- How I did it**

Updated creation of tab writers to all have a min spacing of 20 and padding of 3.

**- How to verify it**

Run `docker app inspect my-app --pretty`. The tables below the metadata should have the new spacing.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Outputs printed as tables from Docker App commands now have standard spacing

**- A picture of a cute animal (not mandatory)**

![bird-2019-11-19](https://user-images.githubusercontent.com/22098752/69876664-12634700-12b8-11ea-97ba-590c5826fa29.jpg)

