### PR TITLE
Add -f shorthand to app rm --force

### DIFF
--- a/internal/commands/remove.go
+++ b/internal/commands/remove.go
@@ -36,7 +36,7 @@ func removeCmd(dockerCli command.Cli, installerContext *cliopts.InstallerContext
 		},
 	}
 	opts.credentialOptions.addFlags(cmd.Flags())
-	cmd.Flags().BoolVar(&opts.force, "force", false, "Force the removal of a running App")
+	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Force the removal of a running App")
 
 	return cmd
 }


### PR DESCRIPTION
**- What I did**

Makes -f the shorthand for --force in `docker app rm`, same as in `docker rm` and `docker app image rm`

**- How I did it**

Use `BoolVarP` for the `force` option

**- How to verify it**

Run `docker app rm --help` The output should show `-f` as an alias for `--force` like so:

```
Options:
      --credential stringArray       Add a single credential, additive ontop of any --credential-set used
      --credential-set stringArray   Use a YAML file containing a credential set or a credential set present in the credential store
  -f, --force                        Force the removal of a running App
      --with-registry-auth           Sends registry auth
```

**- Description for the changelog**

Add -f shorthand to app rm --force

**- A picture of a cute animal (not mandatory)**

![weasel-2019-12-02](https://user-images.githubusercontent.com/22098752/69966287-fb1d9700-150d-11ea-97d9-7cfbd1debe51.jpg)

