### PR TITLE
Introduce Arm64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN git clone https://github.com/docker/cli . && git checkout v${CLI_VERSION}
 RUN mkdir build
 RUN curl -fL https://download.docker.com/linux/static/${CLI_CHANNEL}/x86_64/docker-${CLI_VERSION}.tgz | tar xzO docker/docker > build/docker-linux-amd64 && chmod +x build/docker-linux-amd64
 RUN curl -fL https://download.docker.com/linux/static/${CLI_CHANNEL}/aarch64/docker-${CLI_VERSION}.tgz | tar xzO docker/docker > build/docker-linux-arm64 && chmod +x build/docker-linux-arm64
+RUN curl -fL https://download.docker.com/linux/static/${CLI_CHANNEL}/armhf/docker-${CLI_VERSION}.tgz | tar xzO docker/docker > build/docker-linux-arm && chmod +x build/docker-linux-arm
 RUN curl -fL https://download.docker.com/mac/static/${CLI_CHANNEL}/x86_64/docker-${CLI_VERSION}.tgz | tar xzO docker/docker > build/docker-darwin-amd64
 
 ARG GOPROXY
@@ -68,6 +69,7 @@ FROM scratch AS cross
 ARG PROJECT_PATH=/go/src/github.com/docker/app
 COPY --from=cross-build ${PROJECT_PATH}/bin/docker-app-linux docker-app-linux
 COPY --from=cross-build ${PROJECT_PATH}/bin/docker-app-linux-arm64 docker-app-linux-arm64
+COPY --from=cross-build ${PROJECT_PATH}/bin/docker-app-linux-arm docker-app-linux-arm
 COPY --from=cross-build ${PROJECT_PATH}/bin/docker-app-darwin docker-app-darwin
 COPY --from=cross-build ${PROJECT_PATH}/bin/docker-app-windows.exe docker-app-windows.exe
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM dockercore/golang-cross:1.12.9@sha256:3ea9dcef4dd2c46d80445c0b22d6177817f4cfce22c523cc12a5a1091cb37705 AS cli-build
 ENV DISABLE_WARN_OUTSIDE_CONTAINER=1
 ARG CLI_CHANNEL=stable
-ARG CLI_VERSION=19.03.4
+ARG CLI_VERSION=19.03.5
 
 RUN apt-get install -y -q --no-install-recommends \
   coreutils \
@@ -13,6 +13,7 @@ WORKDIR /go/src/github.com/docker/cli
 RUN git clone https://github.com/docker/cli . && git checkout v${CLI_VERSION}
 RUN mkdir build
 RUN curl -fL https://download.docker.com/linux/static/${CLI_CHANNEL}/x86_64/docker-${CLI_VERSION}.tgz | tar xzO docker/docker > build/docker-linux-amd64 && chmod +x build/docker-linux-amd64
+RUN curl -fL https://download.docker.com/linux/static/${CLI_CHANNEL}/aarch64/docker-${CLI_VERSION}.tgz | tar xzO docker/docker > build/docker-linux-arm64 && chmod +x build/docker-linux-arm64
 RUN curl -fL https://download.docker.com/mac/static/${CLI_CHANNEL}/x86_64/docker-${CLI_VERSION}.tgz | tar xzO docker/docker > build/docker-darwin-amd64
 
 ARG GOPROXY
@@ -45,7 +46,7 @@ RUN mkdir $GOPATH/src/gotest.tools && \
   ln -s gotestsum-linux /usr/local/bin/gotestsum
 # Source for cmd/test2json is part of the Go distribution and is
 # therefore available in the base image.
-RUN GOOS=linux   go build -o /usr/local/bin/test2json-linux       cmd/test2json && \
+RUN GOOS=linux go build -o /usr/local/bin/test2json-linux       cmd/test2json && \
   GOOS=darwin  go build -o /usr/local/bin/test2json-darwin      cmd/test2json && \
   GOOS=windows go build -o /usr/local/bin/test2json-windows.exe cmd/test2json
 RUN go get -d gopkg.in/mjibson/esc.v0 && \
@@ -66,6 +67,7 @@ RUN make TAG=${TAG} cross
 FROM scratch AS cross
 ARG PROJECT_PATH=/go/src/github.com/docker/app
 COPY --from=cross-build ${PROJECT_PATH}/bin/docker-app-linux docker-app-linux
+COPY --from=cross-build ${PROJECT_PATH}/bin/docker-app-linux-arm64 docker-app-linux-arm64
 COPY --from=cross-build ${PROJECT_PATH}/bin/docker-app-darwin docker-app-darwin
 COPY --from=cross-build ${PROJECT_PATH}/bin/docker-app-windows.exe docker-app-windows.exe
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@
                         dir('src/github.com/docker/app') {
                             checkout scm
                             ansiColor('xterm') {
-                                sh 'make -f docker.Makefile save-invocation-image'
+                                sh 'make -f docker.Makefile invocation-image save-invocation-image'
                                 sh 'make -f docker.Makefile INVOCATION_IMAGE_TAG=$TAG-coverage OUTPUT=coverage-invocation-image.tar save-invocation-image-tag'
                             }
                             dir('_build') {

--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -65,19 +65,21 @@ pipeline {
                         dir('src/github.com/docker/app') {
                             checkout scm
                             ansiColor('xterm') {
-                                sh 'make -f docker.Makefile save-invocation-image'
+                                sh 'make -f docker.Makefile invocation-image-cross save-invocation-image-cross'
                                 sh 'make -f docker.Makefile save-invocation-image-tag INVOCATION_IMAGE_TAG=$TAG-coverage OUTPUT=coverage-invocation-image.tar'
                             }
                             dir('_build') {
                                 stash name: 'invocation-image', includes: 'invocation-image.tar'
+                                stash name: 'invocation-image-arm64', includes: 'invocation-image-arm64.tar'
                                 stash name: 'coverage-invocation-image', includes: 'coverage-invocation-image.tar'
-                                archiveArtifacts 'invocation-image.tar'
+                                archiveArtifacts 'invocation-image*.tar'
                             }
                         }
                     }
                     post {
                         always {
                             sh 'docker rmi docker/cnab-app-base:$TAG'
+                            sh 'docker rmi docker/cnab-app-base:$TAG-arm64'
                             sh 'docker rmi docker/cnab-app-base:$TAG-coverage'
                             deleteDir()
                         }
@@ -250,6 +252,8 @@ pipeline {
                     dir('_build') {
                         unstash "invocation-image"
                         sh 'docker load -i invocation-image.tar'
+                        unstash "invocation-image-arm64"
+                        sh 'docker load -i invocation-image-arm64.tar'
                     }
                     ansiColor('xterm') {
                         sh 'make -f docker.Makefile push-invocation-image'
@@ -264,6 +268,7 @@ pipeline {
             post {
                 always {
                     sh 'docker rmi docker/cnab-app-base:$TAG'
+                    sh 'docker rmi docker/cnab-app-base:$TAG-arm64'
                     deleteDir()
                 }
             }

--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -59,7 +59,7 @@ pipeline {
                 }
                 stage('Invocation image'){
                     agent {
-                        label 'ubuntu-1804'
+                        label 'team-local && windows && linux-containers'
                     }
                     steps {
                         dir('src/github.com/docker/app') {

--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -71,6 +71,7 @@ pipeline {
                             dir('_build') {
                                 stash name: 'invocation-image', includes: 'invocation-image.tar'
                                 stash name: 'invocation-image-arm64', includes: 'invocation-image-arm64.tar'
+                                stash name: 'invocation-image-arm', includes: 'invocation-image-arm.tar'
                                 stash name: 'coverage-invocation-image', includes: 'coverage-invocation-image.tar'
                                 archiveArtifacts 'invocation-image*.tar'
                             }
@@ -80,6 +81,7 @@ pipeline {
                         always {
                             sh 'docker rmi docker/cnab-app-base:$TAG'
                             sh 'docker rmi docker/cnab-app-base:$TAG-arm64'
+                            sh 'docker rmi docker/cnab-app-base:$TAG-arm'
                             sh 'docker rmi docker/cnab-app-base:$TAG-coverage'
                             deleteDir()
                         }
@@ -254,6 +256,8 @@ pipeline {
                         sh 'docker load -i invocation-image.tar'
                         unstash "invocation-image-arm64"
                         sh 'docker load -i invocation-image-arm64.tar'
+                        unstash "invocation-image-arm"
+                        sh 'docker load -i invocation-image-arm.tar'
                     }
                     ansiColor('xterm') {
                         sh 'make -f docker.Makefile push-invocation-image'
@@ -269,6 +273,7 @@ pipeline {
                 always {
                     sh 'docker rmi docker/cnab-app-base:$TAG'
                     sh 'docker rmi docker/cnab-app-base:$TAG-arm64'
+                    sh 'docker rmi docker/cnab-app-base:$TAG-arm'
                     deleteDir()
                 }
             }

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ check_go_env:
 
 cross: cross-plugin ## cross-compile binaries (linux, darwin, windows)
 
-cross-plugin: bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-windows.exe
+cross-plugin: bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-windows.exe bin/$(BIN_NAME)-linux-arm64
 
 e2e-cross: bin/$(BIN_NAME)-e2e-linux bin/$(BIN_NAME)-e2e-darwin bin/$(BIN_NAME)-e2e-windows.exe
 
@@ -48,6 +48,10 @@ dynamic: bin/$(BIN_NAME)
 .PHONY: bin/$(BIN_NAME)-e2e-windows
 bin/$(BIN_NAME)-e2e-%.exe bin/$(BIN_NAME)-e2e-%: e2e bin/$(BIN_NAME)-%
 	GOOS=$* $(GO_TEST) -c -o $@ ./e2e/
+
+.PHONY: bin/$(BIN_NAME)-linux-arm64
+bin/$(BIN_NAME)-linux-arm64: cmd/$(BIN_NAME) check_go_env
+	GOOS=linux GOARCH=arm64 $(GO_BUILD) -o $@ ./$<
 
 .PHONY: bin/$(BIN_NAME)-windows
 bin/$(BIN_NAME)-%.exe bin/$(BIN_NAME)-%: cmd/$(BIN_NAME) check_go_env

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ check_go_env:
 
 cross: cross-plugin ## cross-compile binaries (linux, darwin, windows)
 
-cross-plugin: bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-windows.exe bin/$(BIN_NAME)-linux-arm64
+cross-plugin: bin/$(BIN_NAME)-linux bin/$(BIN_NAME)-darwin bin/$(BIN_NAME)-windows.exe bin/$(BIN_NAME)-linux-arm64 bin/$(BIN_NAME)-linux-arm
 
 e2e-cross: bin/$(BIN_NAME)-e2e-linux bin/$(BIN_NAME)-e2e-darwin bin/$(BIN_NAME)-e2e-windows.exe
 
@@ -52,6 +52,10 @@ bin/$(BIN_NAME)-e2e-%.exe bin/$(BIN_NAME)-e2e-%: e2e bin/$(BIN_NAME)-%
 .PHONY: bin/$(BIN_NAME)-linux-arm64
 bin/$(BIN_NAME)-linux-arm64: cmd/$(BIN_NAME) check_go_env
 	GOOS=linux GOARCH=arm64 $(GO_BUILD) -o $@ ./$<
+
+.PHONY: bin/$(BIN_NAME)-linux-arm
+bin/$(BIN_NAME)-linux-arm: cmd/$(BIN_NAME) check_go_env
+	GOOS=linux GOARCH=arm $(GO_BUILD) -o $@ ./$<
 
 .PHONY: bin/$(BIN_NAME)-windows
 bin/$(BIN_NAME)-%.exe bin/$(BIN_NAME)-%: cmd/$(BIN_NAME) check_go_env

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -40,6 +40,7 @@ cross: create_bin ## cross-compile binaries (linux, darwin, windows)
 	docker build $(BUILD_ARGS) --output type=local,dest=./bin/ --target=cross -t $(CROSS_IMAGE_NAME) .
 	@$(call chmod,+x,bin/$(BIN_NAME)-linux)
 	@$(call chmod,+x,bin/$(BIN_NAME)-linux-arm64)
+	@$(call chmod,+x,bin/$(BIN_NAME)-linux-arm)
 	@$(call chmod,+x,bin/$(BIN_NAME)-darwin)
 	@$(call chmod,+x,bin/$(BIN_NAME)-windows.exe)
 
@@ -62,6 +63,7 @@ tars:
 	tar --transform='flags=r;s|$(BIN_NAME)-linux|$(BIN_NAME)-plugin-linux|' -czf bin/$(BIN_NAME)-linux.tar.gz -C bin $(BIN_NAME)-linux
 	tar czf bin/$(BIN_NAME)-e2e-linux.tar.gz -C bin $(BIN_NAME)-e2e-linux
 	tar --transform='flags=r;s|$(BIN_NAME)-linux-arm64|$(BIN_NAME)-plugin-linux-arm64|' -czf bin/$(BIN_NAME)-linux-arm64.tar.gz -C bin $(BIN_NAME)-linux-arm64
+	tar --transform='flags=r;s|$(BIN_NAME)-linux-arm|$(BIN_NAME)-plugin-linux-arm|' -czf bin/$(BIN_NAME)-linux-arm.tar.gz -C bin $(BIN_NAME)-linux-arm
 	tar --transform='flags=r;s|$(BIN_NAME)-darwin|$(BIN_NAME)-plugin-darwin|' -czf bin/$(BIN_NAME)-darwin.tar.gz -C bin $(BIN_NAME)-darwin
 	tar czf bin/$(BIN_NAME)-e2e-darwin.tar.gz -C bin $(BIN_NAME)-e2e-darwin
 	tar --transform='flags=r;s|$(BIN_NAME)-windows|$(BIN_NAME)-plugin-windows|' -czf bin/$(BIN_NAME)-windows.tar.gz -C bin $(BIN_NAME)-windows.exe
@@ -126,7 +128,10 @@ invocation-image:
 invocation-image-arm64:
 	docker build -f Dockerfile.invocation-image $(BUILD_ARGS) --target=invocation -t $(CNAB_BASE_INVOCATION_IMAGE_NAME)-arm64 --platform=arm64 .
 
-invocation-image-cross: invocation-image invocation-image-arm64
+invocation-image-arm:
+	docker build -f Dockerfile.invocation-image $(BUILD_ARGS) --target=invocation -t $(CNAB_BASE_INVOCATION_IMAGE_NAME)-arm --platform=arm .
+
+invocation-image-cross: invocation-image invocation-image-arm64 invocation-image-arm
 
 save-invocation-image-tag:
 	docker tag $(CNAB_BASE_INVOCATION_IMAGE_NAME) docker/cnab-app-base:$(INVOCATION_IMAGE_TAG)
@@ -138,6 +143,7 @@ save-invocation-image:
 
 save-invocation-image-cross: save-invocation-image
 	docker save $(CNAB_BASE_INVOCATION_IMAGE_NAME)-arm64 -o $(CNAB_BASE_INVOCATION_IMAGE_PATH)-arm64.tar
+	docker save $(CNAB_BASE_INVOCATION_IMAGE_NAME)-arm -o $(CNAB_BASE_INVOCATION_IMAGE_PATH)-arm.tar
 
 push-invocation-image:
 	# tag and push linux/amd64
@@ -146,11 +152,14 @@ push-invocation-image:
 	# tag and push linux/arm64
 	docker tag $(CNAB_BASE_INVOCATION_IMAGE_NAME)-arm64 $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME)-arm64
 	docker push $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME)-arm64
+	# tag and push linux/armhf
+	docker tag $(CNAB_BASE_INVOCATION_IMAGE_NAME)-arm $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME)-arm
+	docker push $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME)-arm
 	# create and push manifest list
-	docker manifest create $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME) $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME) $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME)-arm64
+	docker manifest create $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME) $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME) $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME)-arm64 $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME)-arm
 	docker manifest push $(PUSH_CNAB_BASE_INVOCATION_IMAGE_NAME)
 
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
-.PHONY: lint test-e2e test-unit test cli-cross cross e2e-cross coverage coverage-run coverage-results shell build_dev_image tars vendor check-vendor schemas help invocation-image invocation-image-arm64 invocation-image-cross save-invocation-image save-invocation-image-tag push-invocation-image
+.PHONY: lint test-e2e test-unit test cli-cross cross e2e-cross coverage coverage-run coverage-results shell build_dev_image tars vendor check-vendor schemas help invocation-image invocation-image-arm invocation-image-arm64 invocation-image-cross save-invocation-image save-invocation-image-tag push-invocation-image

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -39,6 +39,7 @@ shell: build_dev_image ## run a shell in the docker build image
 cross: create_bin ## cross-compile binaries (linux, darwin, windows)
 	docker build $(BUILD_ARGS) --output type=local,dest=./bin/ --target=cross -t $(CROSS_IMAGE_NAME) .
 	@$(call chmod,+x,bin/$(BIN_NAME)-linux)
+	@$(call chmod,+x,bin/$(BIN_NAME)-linux-arm64)
 	@$(call chmod,+x,bin/$(BIN_NAME)-darwin)
 	@$(call chmod,+x,bin/$(BIN_NAME)-windows.exe)
 
@@ -60,6 +61,7 @@ e2e-cross: create_bin
 tars:
 	tar --transform='flags=r;s|$(BIN_NAME)-linux|$(BIN_NAME)-plugin-linux|' -czf bin/$(BIN_NAME)-linux.tar.gz -C bin $(BIN_NAME)-linux
 	tar czf bin/$(BIN_NAME)-e2e-linux.tar.gz -C bin $(BIN_NAME)-e2e-linux
+	tar --transform='flags=r;s|$(BIN_NAME)-linux-arm64|$(BIN_NAME)-plugin-linux-arm64|' -czf bin/$(BIN_NAME)-linux-arm64.tar.gz -C bin $(BIN_NAME)-linux-arm64
 	tar --transform='flags=r;s|$(BIN_NAME)-darwin|$(BIN_NAME)-plugin-darwin|' -czf bin/$(BIN_NAME)-darwin.tar.gz -C bin $(BIN_NAME)-darwin
 	tar czf bin/$(BIN_NAME)-e2e-darwin.tar.gz -C bin $(BIN_NAME)-e2e-darwin
 	tar --transform='flags=r;s|$(BIN_NAME)-windows|$(BIN_NAME)-plugin-windows|' -czf bin/$(BIN_NAME)-windows.tar.gz -C bin $(BIN_NAME)-windows.exe

--- a/e2e/compatibility_test.go
+++ b/e2e/compatibility_test.go
@@ -138,7 +138,11 @@ func TestBackwardsCompatibilityV1(t *testing.T) {
 				output = info.execCmd("/usr/bin/wget", "-O", "-", url)
 				return strings.Contains(output, `Hi there, I love Docker!`), nil
 			})
-			assert.NilError(t, err)
+			output = ""
+			if err != nil {
+				output = info.dockerCmd("stack", "ps", appName)
+			}
+			assert.NilError(t, err, output)
 		}
 
 		// Check status on install


### PR DESCRIPTION
**- What I did**
Introduce Arm64 support for docker-app.

**- How I did it**
- Cross build docker-app plugin to linux-amd64 platform
- Cross build cnab-app-base image to linux-arm64 platform
- Create a manifest list and push it to the hub using `docker manifest` commands

**- How to verify it**
- Push a test tag and check on Hub if the image is multi-arch.

**- Description for the changelog**
- Add Arm64 support for docker-app plugin
- docker/cnab-app-base is now a multi-arch image with linux/arm64 platform

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/31478878/69979421-99b9f000-152e-11ea-9242-e96266752e89.png)

