### PR TITLE
Remove CREATED from bundle.json

### DIFF
--- a/e2e/images_test.go
+++ b/e2e/images_test.go
@@ -65,10 +65,10 @@ func TestImageList(t *testing.T) {
 
 		insertBundles(t, cmd)
 
-		expected := `REPOSITORY                 TAG                 APP IMAGE ID        APP NAME            CREATED                  
-a-simple-app               latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-b-simple-app               latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-my.registry:5000/c-myapp   latest              [a-f0-9]{12}        push-pull           [La-z0-9 ]+ ago[ ]*
+		expected := `REPOSITORY                 TAG                 APP IMAGE ID        APP NAME            
+a-simple-app               latest              [a-f0-9]{12}        simple              
+b-simple-app               latest              [a-f0-9]{12}        simple              
+my.registry:5000/c-myapp   latest              [a-f0-9]{12}        push-pull           
 `
 
 		expectImageListOutput(t, cmd, expected)
@@ -87,10 +87,10 @@ func TestImageListDigests(t *testing.T) {
 	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
 		cmd := info.configuredCmd
 		insertBundles(t, cmd)
-		expected := `REPOSITORY                 TAG                 DIGEST              APP IMAGE ID        APP NAME                                CREATED                  
-a-simple-app               latest              <none>              [a-f0-9]{12}        simple                                  [La-z0-9 ]+ ago[ ]*
-b-simple-app               latest              <none>              [a-f0-9]{12}        simple                                  [La-z0-9 ]+ ago[ ]*
-my.registry:5000/c-myapp   latest              <none>              [a-f0-9]{12}        push-pull                               [La-z0-9 ]+ ago[ ]*
+		expected := `REPOSITORY                 TAG                 DIGEST              APP IMAGE ID        APP NAME                                
+a-simple-app               latest              <none>              [a-f0-9]{12}        simple                                  
+b-simple-app               latest              <none>              [a-f0-9]{12}        simple                                  
+my.registry:5000/c-myapp   latest              <none>              [a-f0-9]{12}        push-pull                               
 `
 		expectImageListDigestsOutput(t, cmd, expected)
 	})
@@ -121,7 +121,7 @@ func TestImageRmForce(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "image", "rm", "--force", imageID)
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-		expectedOutput := "REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED             \n"
+		expectedOutput := "REPOSITORY          TAG                 APP IMAGE ID        APP NAME            \n"
 		expectImageListOutput(t, cmd, expectedOutput)
 	})
 }
@@ -151,7 +151,7 @@ Deleted: b-simple-app:latest`,
 			Err:      `b-simple-app:latest: reference not found`,
 		})
 
-		expectedOutput := "REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED             \n"
+		expectedOutput := "REPOSITORY          TAG                 APP IMAGE ID        APP NAME            \n"
 		expectImageListOutput(t, cmd, expectedOutput)
 	})
 }
@@ -169,8 +169,8 @@ func TestImageTag(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "build", "--tag", "a-simple-app", filepath.Join("testdata", "simple"))
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
-		singleImageExpectation := `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED[ ]*
-a-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
+		singleImageExpectation := `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            
+a-simple-app        latest              [a-f0-9]{12}        simple              
 `
 		expectImageListOutput(t, cmd, singleImageExpectation)
 
@@ -219,63 +219,63 @@ a-simple-app        latest              [a-f0-9]{12}        simple              
 		// tag image with only names
 		dockerAppImageTag("a-simple-app", "b-simple-app")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED[ ]*
-a-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-b-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
+		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            
+a-simple-app        latest              [a-f0-9]{12}        simple              
+b-simple-app        latest              [a-f0-9]{12}        simple              
 `)
 
 		// target tag
 		dockerAppImageTag("a-simple-app", "a-simple-app:0.1")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED[ ]*
-a-simple-app        0.1                 [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-a-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-b-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
+		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            
+a-simple-app        0.1                 [a-f0-9]{12}        simple              
+a-simple-app        latest              [a-f0-9]{12}        simple              
+b-simple-app        latest              [a-f0-9]{12}        simple              
 `)
 
 		// source tag
 		dockerAppImageTag("a-simple-app:0.1", "c-simple-app")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED[ ]*
-a-simple-app        0.1                 [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-a-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-b-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-c-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
+		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            
+a-simple-app        0.1                 [a-f0-9]{12}        simple              
+a-simple-app        latest              [a-f0-9]{12}        simple              
+b-simple-app        latest              [a-f0-9]{12}        simple              
+c-simple-app        latest              [a-f0-9]{12}        simple              
 `)
 
 		// source and target tags
 		dockerAppImageTag("a-simple-app:0.1", "b-simple-app:0.2")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED[ ]*
-a-simple-app        0.1                 [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-a-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-b-simple-app        0.2                 [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-b-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-c-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
+		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            
+a-simple-app        0.1                 [a-f0-9]{12}        simple              
+a-simple-app        latest              [a-f0-9]{12}        simple              
+b-simple-app        0.2                 [a-f0-9]{12}        simple              
+b-simple-app        latest              [a-f0-9]{12}        simple              
+c-simple-app        latest              [a-f0-9]{12}        simple              
 `)
 
 		// given a new application
 		cmd.Command = dockerCli.Command("app", "build", "--tag", "push-pull", filepath.Join("testdata", "push-pull"))
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED[ ]*
-push-pull           latest              [a-f0-9]{12}        push-pull           [La-z0-9 ]+ ago[ ]*
-a-simple-app        0.1                 [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-a-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-b-simple-app        0.2                 [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-b-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-c-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
+		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            
+a-simple-app        0.1                 [a-f0-9]{12}        simple              
+a-simple-app        latest              [a-f0-9]{12}        simple              
+b-simple-app        0.2                 [a-f0-9]{12}        simple              
+b-simple-app        latest              [a-f0-9]{12}        simple              
+c-simple-app        latest              [a-f0-9]{12}        simple              
+push-pull           latest              [a-f0-9]{12}        push-pull           
 `)
 
 		// can be tagged to an existing tag
 		dockerAppImageTag("push-pull", "b-simple-app:0.2")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED[ ]*
-b-simple-app        0.2                 [a-f0-9]{12}        push-pull           [La-z0-9 ]+ ago[ ]*
-push-pull           latest              [a-f0-9]{12}        push-pull           [La-z0-9 ]+ ago[ ]*
-a-simple-app        0.1                 [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-a-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-b-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
-c-simple-app        latest              [a-f0-9]{12}        simple              [La-z0-9 ]+ ago[ ]*
+		expectImageListOutput(t, cmd, `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            
+a-simple-app        0.1                 [a-f0-9]{12}        simple              
+a-simple-app        latest              [a-f0-9]{12}        simple              
+b-simple-app        0.2                 [a-f0-9]{12}        push-pull           
+b-simple-app        latest              [a-f0-9]{12}        simple              
+c-simple-app        latest              [a-f0-9]{12}        simple              
+push-pull           latest              [a-f0-9]{12}        push-pull           
 `)
 	})
 }

--- a/internal/commands/image/formatter.go
+++ b/internal/commands/image/formatter.go
@@ -1,16 +1,13 @@
 package image
 
 import (
-	"time"
-
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/go-units"
 )
 
 const (
-	defaultImageTableFormat           = "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Name}}\t{{if .CreatedSince }}{{.CreatedSince}}{{else}}N/A{{end}}\t"
-	defaultImageTableFormatWithDigest = "table {{.Repository}}\t{{.Tag}}\t{{.Digest}}\t{{.ID}}\t{{.Name}}\t\t{{if .CreatedSince }}{{.CreatedSince}}{{else}}N/A{{end}}\t"
+	defaultImageTableFormat           = "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Name}}\t"
+	defaultImageTableFormatWithDigest = "table {{.Repository}}\t{{.Tag}}\t{{.Digest}}\t{{.ID}}\t{{.Name}}\t\t"
 
 	imageIDHeader    = "APP IMAGE ID"
 	repositoryHeader = "REPOSITORY"
@@ -69,12 +66,11 @@ type imageContext struct {
 func newImageContext() *imageContext {
 	imageCtx := imageContext{}
 	imageCtx.Header = formatter.SubHeaderContext{
-		"ID":           imageIDHeader,
-		"Name":         imageNameHeader,
-		"Repository":   repositoryHeader,
-		"Tag":          tagHeader,
-		"Digest":       digestHeader,
-		"CreatedSince": formatter.CreatedSinceHeader,
+		"ID":         imageIDHeader,
+		"Name":       imageNameHeader,
+		"Repository": repositoryHeader,
+		"Tag":        tagHeader,
+		"Digest":     digestHeader,
 	}
 	return &imageCtx
 }
@@ -116,11 +112,4 @@ func (c *imageContext) Digest() string {
 		return "<none>"
 	}
 	return c.i.Digest
-}
-
-func (c *imageContext) CreatedSince() string {
-	if c.i.Created.IsZero() {
-		return ""
-	}
-	return units.HumanDuration(time.Now().UTC().Sub(c.i.Created)) + " ago"
 }

--- a/internal/commands/image/list.go
+++ b/internal/commands/image/list.go
@@ -1,10 +1,6 @@
 package image
 
 import (
-	"sort"
-	"time"
-
-	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/internal/relocated"
 	"github.com/docker/app/internal/store"
 	"github.com/docker/cli/cli/command"
@@ -61,7 +57,6 @@ func runList(dockerCli command.Cli, options imageListOption, bundleStore store.B
 		Format: NewImageFormat(options.format, options.quiet, options.digests),
 	}
 
-	sortImages(images)
 	return Write(ctx, images)
 }
 
@@ -94,25 +89,12 @@ func getImageID(bundle *relocated.Bundle, ref reference.Reference) (string, erro
 	return stringid.TruncateID(id.String()), nil
 }
 
-func sortImages(images []imageDesc) {
-	sort.SliceStable(images, func(i, j int) bool {
-		if images[i].Created.IsZero() {
-			return false
-		}
-		if images[j].Created.IsZero() {
-			return true
-		}
-		return images[i].Created.After(images[j].Created)
-	})
-}
-
 type imageDesc struct {
-	ID         string    `json:"id,omitempty"`
-	Name       string    `json:"name,omitempty"`
-	Repository string    `json:"repository,omitempty"`
-	Tag        string    `json:"tag,omitempty"`
-	Digest     string    `json:"digest,omitempty"`
-	Created    time.Time `json:"created,omitempty"`
+	ID         string `json:"id,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Repository string `json:"repository,omitempty"`
+	Tag        string `json:"tag,omitempty"`
+	Digest     string `json:"digest,omitempty"`
 }
 
 func getImageDesc(bundle *relocated.Bundle, ref reference.Reference) imageDesc {
@@ -130,18 +112,11 @@ func getImageDesc(bundle *relocated.Bundle, ref reference.Reference) imageDesc {
 	if t, ok := ref.(reference.Digested); ok {
 		digest = t.Digest().String()
 	}
-	var created time.Time
-	if payload, err := packager.CustomPayload(bundle.Bundle); err == nil {
-		if createdPayload, ok := payload.(packager.CustomPayloadCreated); ok {
-			created = createdPayload.CreatedTime()
-		}
-	}
 	return imageDesc{
 		ID:         id,
 		Name:       bundle.Name,
 		Repository: repository,
 		Tag:        tag,
 		Digest:     digest,
-		Created:    created,
 	}
 }

--- a/internal/commands/image/list_test.go
+++ b/internal/commands/image/list_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/docker/app/internal/relocated"
 
@@ -84,10 +83,10 @@ func TestListCmd(t *testing.T) {
 	}{
 		{
 			name: "TestList",
-			expectedOutput: `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            CREATED             
-foo/bar             <none>              3f825b2d0657        Digested App        N/A                 
-foo/bar             1.0                 9aae408ee04f        Foo App             N/A                 
-<none>              <none>              a855ac937f2e        Quiet App           N/A                 
+			expectedOutput: `REPOSITORY          TAG                 APP IMAGE ID        APP NAME            
+foo/bar             <none>              3f825b2d0657        Digested App        
+foo/bar             1.0                 9aae408ee04f        Foo App             
+<none>              <none>              a855ac937f2e        Quiet App           
 `,
 			options: imageListOption{format: "table"},
 		},
@@ -103,10 +102,10 @@ a855ac937f2e        sha256:a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc
 		{
 			name: "TestListWithDigests",
 			//nolint:lll
-			expectedOutput: `REPOSITORY          TAG                 DIGEST                                                                    APP IMAGE ID        APP NAME                                CREATED             
-foo/bar             <none>              sha256:b59492bb814012ca3d2ce0b6728242d96b4af41687cc82166a4b5d7f2d9fb865   3f825b2d0657        Digested App                            N/A                 
-foo/bar             1.0                 <none>                                                                    9aae408ee04f        Foo App                                 N/A                 
-<none>              <none>              sha256:a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087   a855ac937f2e        Quiet App                               N/A                 
+			expectedOutput: `REPOSITORY          TAG                 DIGEST                                                                    APP IMAGE ID        APP NAME                                
+foo/bar             <none>              sha256:b59492bb814012ca3d2ce0b6728242d96b4af41687cc82166a4b5d7f2d9fb865   3f825b2d0657        Digested App                            
+foo/bar             1.0                 <none>                                                                    9aae408ee04f        Foo App                                 
+<none>              <none>              sha256:a855ac937f2ed375ba4396bbc49c4093e124da933acd2713fb9bc17d7562a087   a855ac937f2e        Quiet App                               
 `,
 			options: imageListOption{format: "table", digests: true},
 		},
@@ -125,22 +124,6 @@ a855ac937f2e
 			testRunList(t, refs, bundles, tc.options, tc.expectedOutput)
 		})
 	}
-}
-
-func TestSortImages(t *testing.T) {
-	images := []imageDesc{
-		{ID: "1", Created: time.Date(2016, time.August, 15, 0, 0, 0, 0, time.UTC)},
-		{ID: "2"},
-		{ID: "3"},
-		{ID: "4", Created: time.Date(2018, time.August, 15, 0, 0, 0, 0, time.UTC)},
-		{ID: "5", Created: time.Date(2017, time.August, 15, 0, 0, 0, 0, time.UTC)},
-	}
-	sortImages(images)
-	assert.Equal(t, "4", images[0].ID)
-	assert.Equal(t, "5", images[1].ID)
-	assert.Equal(t, "1", images[2].ID)
-	assert.Equal(t, "2", images[3].ID)
-	assert.Equal(t, "3", images[4].ID)
 }
 
 func parseReference(t *testing.T, s string) reference.Reference {

--- a/internal/packager/cnab_test.go
+++ b/internal/packager/cnab_test.go
@@ -22,7 +22,7 @@ func TestToCNAB(t *testing.T) {
 	assert.NilError(t, err)
 	s := golden.Get(t, "bundle-json.golden")
 	expectedLiteral := regexp.QuoteMeta(string(s))
-	expected := fmt.Sprintf(expectedLiteral, DockerAppPayloadVersionCurrent, internal.Version, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z`)
+	expected := fmt.Sprintf(expectedLiteral, DockerAppPayloadVersionCurrent, internal.Version)
 	matches, err := regexp.Match(expected, actualJSON)
 	assert.NilError(t, err)
 	assert.Assert(t, matches)

--- a/internal/packager/custom.go
+++ b/internal/packager/custom.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/app/internal"
@@ -28,23 +27,13 @@ type DockerAppCustom struct {
 	Payload json.RawMessage `json:"payload,omitempty"`
 }
 
-// CustomPayloadCreated is a custom payload with a created time
-type CustomPayloadCreated interface {
-	CreatedTime() time.Time
-}
-
 // CustomPayloadAppVersion is a custom payload with a docker app version
 type CustomPayloadAppVersion interface {
 	AppVersion() string
 }
 
 type payloadV1_0 struct {
-	Version string    `json:"app-version"`
-	Created time.Time `json:"created"`
-}
-
-func (p payloadV1_0) CreatedTime() time.Time {
-	return p.Created
+	Version string `json:"app-version"`
 }
 
 func (p payloadV1_0) AppVersion() string {
@@ -52,7 +41,7 @@ func (p payloadV1_0) AppVersion() string {
 }
 
 func newCustomPayload() (json.RawMessage, error) {
-	p := payloadV1_0{Created: time.Now().UTC(), Version: internal.Version}
+	p := payloadV1_0{Version: internal.Version}
 	j, err := json.Marshal(&p)
 	if err != nil {
 		return nil, err
@@ -60,7 +49,7 @@ func newCustomPayload() (json.RawMessage, error) {
 	return j, nil
 }
 
-// CheckAppVersion
+// CheckAppVersion prints a warning if the bundle was built with a different version of docker app
 func CheckAppVersion(stderr io.Writer, bndl *bundle.Bundle) error {
 	payload, err := CustomPayload(bndl)
 	if err != nil {

--- a/internal/packager/custom_test.go
+++ b/internal/packager/custom_test.go
@@ -3,7 +3,6 @@ package packager
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/app/internal"
@@ -11,7 +10,6 @@ import (
 )
 
 func TestNewCustomPayload(t *testing.T) {
-	start := time.Now().UTC()
 	payloadJSON, err := newCustomPayload()
 	assert.NilError(t, err)
 
@@ -19,9 +17,7 @@ func TestNewCustomPayload(t *testing.T) {
 	err = json.Unmarshal(payloadJSON, &payload)
 	assert.NilError(t, err)
 
-	end := time.Now().UTC()
-	assert.Assert(t, start.Before(payload.CreatedTime()) || start.Equal(payload.CreatedTime()))
-	assert.Assert(t, end.After(payload.CreatedTime()) || end.Equal(payload.CreatedTime()))
+	assert.Equal(t, internal.Version, payload.AppVersion())
 }
 
 func TestCustomPayloadNil(t *testing.T) {
@@ -57,13 +53,11 @@ func TestCustomPayloadNil(t *testing.T) {
 }
 
 func TestCustomPayloadV1_0_0(t *testing.T) {
-	now := time.Now().UTC()
-	b := createBundle(t, DockerAppPayloadVersion1_0_0, payloadV1_0{"version", now})
+	b := createBundle(t, DockerAppPayloadVersion1_0_0, payloadV1_0{"version"})
 	payload, err := CustomPayload(&b)
 	assert.NilError(t, err)
 	v1, ok := payload.(payloadV1_0)
 	assert.Assert(t, ok)
-	assert.Assert(t, now.Equal(v1.CreatedTime()))
 	assert.Equal(t, "version", v1.AppVersion())
 }
 

--- a/internal/packager/testdata/bundle-json.golden
+++ b/internal/packager/testdata/bundle-json.golden
@@ -184,8 +184,7 @@
     "com.docker.app": {
       "version": "%s",
       "payload": {
-        "app-version": "%s",
-        "created": "%s"
+        "app-version": "%s"
       }
     }
   }


### PR DESCRIPTION
**- What I did**

Removes the created date from the bundle.json and the image ls output

This has been done to make builds more reproducable as the current solution means the App Image ID will change on each build

We will look at re-adding the created date once the underlying bundle store has been updated.

**- How to verify it**

Build a Docker App and:

* Run `docker app image ls`: there should no longer be a CREATED column.
* Open the image's `bundle.json`: there should be no `custom:com.docker.app:payload:created` property.

**- Description for the changelog**

Removes custom created date from Docker App bundle.json so as to make builds more repeatable.

**- A picture of a cute animal (not mandatory)**

![animalissue2-1-43f2a278bdb53e2e](https://user-images.githubusercontent.com/22098752/70058212-6632a080-15d6-11ea-90ab-1eab48e4d00f.jpg)
