### PR TITLE
use docker/reference.Store to manage tags/digest by app image ID

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -347,7 +347,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:61d8f5998565a7c687a03d7f93845975651a0e0a87a079b824a2905c125d9bd0"
+  digest = "1:2dc59dd841a809590c3b7d2366836870fb52d8cdd6c1943186fa05f8be4c8b9f"
   name = "github.com/docker/docker"
   packages = [
     "api",
@@ -387,6 +387,7 @@
     "pkg/term",
     "pkg/term/windows",
     "pkg/urlutil",
+    "reference",
     "registry",
     "registry/resumable",
   ]
@@ -1448,6 +1449,7 @@
     "github.com/docker/cli/cli/context/kubernetes",
     "github.com/docker/cli/cli/context/store",
     "github.com/docker/cli/cli/flags",
+    "github.com/docker/cli/cli/streams",
     "github.com/docker/cli/opts",
     "github.com/docker/cli/templates",
     "github.com/docker/cnab-to-oci/relocation",
@@ -1463,6 +1465,7 @@
     "github.com/docker/docker/pkg/namesgenerator",
     "github.com/docker/docker/pkg/stringid",
     "github.com/docker/docker/pkg/term",
+    "github.com/docker/docker/reference",
     "github.com/docker/docker/registry",
     "github.com/docker/go-units",
     "github.com/docker/go/canonical/json",
@@ -1491,6 +1494,7 @@
     "gotest.tools/icmd",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/client-go/kubernetes/typed/core/v1",
   ]
   solver-name = "gps-cdcl"

--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -122,9 +122,14 @@ func runWithDindSwarmAndRegistry(t *testing.T, todo func(dindSwarmAndRegistryInf
 	todo(runner)
 }
 
-func build(t *testing.T, cmd icmd.Cmd, dockerCli dockerCliCommand, ref, path string) {
-	cmd.Command = dockerCli.Command("app", "build", "-t", ref, path)
+func build(t *testing.T, cmd icmd.Cmd, dockerCli dockerCliCommand, ref, path string) string {
+	iidfile := fs.NewFile(t, "iid")
+	defer iidfile.Remove()
+	cmd.Command = dockerCli.Command("app", "build", "--iidfile", iidfile.Path(), "-t", ref, path)
 	icmd.RunCmd(cmd).Assert(t, icmd.Success)
+	bytes, err := ioutil.ReadFile(iidfile.Path())
+	assert.NilError(t, err)
+	return string(bytes)
 }
 
 // Container represents a docker container

--- a/e2e/images_test.go
+++ b/e2e/images_test.go
@@ -148,7 +148,7 @@ Deleted: b-simple-app:latest`,
 		cmd.Command = dockerCli.Command("app", "image", "rm", "b-simple-app")
 		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      `b-simple-app:latest: reference not found`,
+			Err:      `b-simple-app: reference not found`,
 		})
 
 		expectedOutput := "REPOSITORY          TAG                 APP IMAGE ID        APP NAME            \n"

--- a/e2e/pushpull_test.go
+++ b/e2e/pushpull_test.go
@@ -19,7 +19,7 @@ func TestPushUnknown(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "push", "unknown")
 		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      `could not push "unknown:latest": no such App image: failed to read bundle "docker.io/library/unknown:latest": unknown:latest: reference not found`,
+			Err:      `could not push "unknown": unknown: reference not found`,
 		})
 	})
 
@@ -27,7 +27,7 @@ func TestPushUnknown(t *testing.T) {
 		cmd.Command = dockerCli.Command("app", "push", "@")
 		icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      `could not push "@": invalid reference format`,
+			Err:      `could not push "@": could not parse "@" as a valid reference: invalid reference format`,
 		})
 	})
 }

--- a/e2e/relocation_test.go
+++ b/e2e/relocation_test.go
@@ -13,34 +13,6 @@ import (
 	"gotest.tools/icmd"
 )
 
-func TestRelocationMapCreatedOnPull(t *testing.T) {
-	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
-		cmd := info.configuredCmd
-		cfg := getDockerConfigDir(t, cmd)
-
-		path := filepath.Join("testdata", "local")
-		ref := info.registryAddress + "/test/local:a-tag"
-		bundlePath := filepath.Join(cfg, "app", "bundles", strings.Replace(info.registryAddress, ":", "_", 1), "test", "local", "_tags", "a-tag")
-
-		// Given a pushed application
-		build(t, cmd, dockerCli, ref, path)
-		cmd.Command = dockerCli.Command("app", "push", ref)
-		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		// And given application files are remove
-		assert.NilError(t, os.RemoveAll(bundlePath))
-		_, err := os.Stat(filepath.Join(bundlePath, image.BundleFilename))
-		assert.Assert(t, os.IsNotExist(err))
-
-		// When application is pulled
-		cmd.Command = dockerCli.Command("app", "pull", ref)
-		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-
-		// Then the relocation map should exist
-		_, err = os.Stat(filepath.Join(bundlePath, image.RelocationMapFilename))
-		assert.NilError(t, err)
-	})
-}
-
 func TestRelocationMapRun(t *testing.T) {
 	runWithDindSwarmAndRegistry(t, func(info dindSwarmAndRegistryInfo) {
 		cmd := info.configuredCmd
@@ -82,7 +54,12 @@ func TestRelocationMapRun(t *testing.T) {
 		t.Run("without-relocation-map", func(t *testing.T) {
 			name := "test-relocation-map-run-without-relocation-map"
 			// And given the relocation map is removed after the pull
-			assert.NilError(t, os.RemoveAll(filepath.Join(bundlePath, image.RelocationMapFilename)))
+			assert.NilError(t, filepath.Walk(filepath.Join(cfg, "app", "bundles", "contents"), func(path string, info os.FileInfo, err error) error {
+				if info.Name() == image.RelocationMapFilename {
+					os.Remove(path)
+				}
+				return nil
+			}))
 
 			// Then the application cannot be run
 			cmd.Command = dockerCli.Command("app", "run", "--name", name, ref)
@@ -98,19 +75,13 @@ func TestPushPulledApplication(t *testing.T) {
 
 		path := filepath.Join("testdata", "local")
 		ref := info.registryAddress + "/test/local:a-tag"
-		bundlePath := filepath.Join(cfg, "app", "bundles", strings.Replace(info.registryAddress, ":", "_", 1), "test", "local", "_tags", "a-tag")
 
 		// Given an application pushed on a registry
 		build(t, cmd, dockerCli, ref, path)
 		cmd.Command = dockerCli.Command("app", "push", ref)
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
 		// And given local images are removed
-		cmd.Command = dockerCli.Command("rmi", "web", "local:1.1.0-beta1-invoc", "worker")
-		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		// And given application files are remove
-		assert.NilError(t, os.RemoveAll(bundlePath))
-		_, err := os.Stat(filepath.Join(bundlePath, image.BundleFilename))
-		assert.Assert(t, os.IsNotExist(err))
+		assert.NilError(t, os.RemoveAll(filepath.Join(cfg, "app", "bundles")))
 
 		// And given application is pulled from the registry
 		cmd.Command = dockerCli.Command("app", "pull", ref)
@@ -119,13 +90,6 @@ func TestPushPulledApplication(t *testing.T) {
 		// Then the application can still be pushed
 		cmd.Command = dockerCli.Command("app", "push", ref)
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-
-		// If relocation map is removed
-		assert.NilError(t, os.RemoveAll(filepath.Join(bundlePath, image.RelocationMapFilename)))
-
-		// Then the application cannot be pushed
-		cmd.Command = dockerCli.Command("app", "push", ref)
-		icmd.RunCmd(cmd).Assert(t, icmd.Expected{ExitCode: 1})
 	})
 }
 

--- a/internal/cnab/cnab.go
+++ b/internal/cnab/cnab.go
@@ -123,7 +123,7 @@ func PullBundle(dockerCli command.Cli, imageStore appstore.ImageStore, tagRef re
 		return nil, err
 	}
 	relocatedBundle := &image.AppImage{Bundle: bndl, RelocationMap: relocationMap}
-	if _, err := imageStore.Store(tagRef, relocatedBundle); err != nil {
+	if _, err := imageStore.Store(relocatedBundle, tagRef); err != nil {
 		return nil, err
 	}
 	return relocatedBundle, nil

--- a/internal/commands/image/list_test.go
+++ b/internal/commands/image/list_test.go
@@ -22,7 +22,7 @@ type imageStoreStubForListCmd struct {
 	refList []reference.Reference
 }
 
-func (b *imageStoreStubForListCmd) Store(ref reference.Reference, bndl *image.AppImage) (reference.Digested, error) {
+func (b *imageStoreStubForListCmd) Store(bndl *image.AppImage, ref reference.Reference) (reference.Digested, error) {
 	b.refMap[ref] = bndl
 	b.refList = append(b.refList, ref)
 	return store.FromAppImage(bndl)
@@ -142,7 +142,7 @@ func testRunList(t *testing.T, refs []reference.Reference, bundles []image.AppIm
 		refList: []reference.Reference{},
 	}
 	for i, ref := range refs {
-		_, err = imageStore.Store(ref, &bundles[i])
+		_, err = imageStore.Store(&bundles[i], ref)
 		assert.NilError(t, err)
 	}
 	err = runList(dockerCli, options, imageStore)

--- a/internal/commands/image/tag.go
+++ b/internal/commands/image/tag.go
@@ -73,6 +73,6 @@ func storeBundle(bundle *image.AppImage, name string, imageStore store.ImageStor
 	if err != nil {
 		return err
 	}
-	_, err = imageStore.Store(cnabRef, bundle)
+	_, err = imageStore.Store(bundle, cnabRef)
 	return err
 }

--- a/internal/commands/image/tag_test.go
+++ b/internal/commands/image/tag_test.go
@@ -28,7 +28,7 @@ type imageStoreStub struct {
 	LookUpError  error
 }
 
-func (b *imageStoreStub) Store(ref reference.Reference, bndle *image.AppImage) (reference.Digested, error) {
+func (b *imageStoreStub) Store(img *image.AppImage, ref reference.Reference) (reference.Digested, error) {
 	defer func() {
 		b.StoredError = nil
 	}()

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -59,17 +59,21 @@ func runPush(dockerCli command.Cli, name string) error {
 	}
 
 	// Get the bundle
-	ref, err := reference.ParseDockerRef(name)
+	ref, err := imageStore.LookUp(name)
 	if err != nil {
 		return errors.Wrapf(err, "could not push %q", name)
 	}
+	named, ok := ref.(reference.Named)
+	if !ok {
+		return fmt.Errorf("could not push by ID. first tag your app image")
+	}
 
-	bndl, err := resolveReferenceAndBundle(imageStore, ref)
+	bndl, err := resolveReferenceAndBundle(imageStore, named)
 	if err != nil {
 		return err
 	}
 
-	cnabRef := reference.TagNameOnly(ref)
+	cnabRef := reference.TagNameOnly(named)
 
 	// Push the bundle
 	return pushBundle(dockerCli, bndl, cnabRef)

--- a/internal/packager/bundle.go
+++ b/internal/packager/bundle.go
@@ -82,7 +82,7 @@ func PersistInImageStore(ref reference.Reference, bndl *bundle.Bundle) (referenc
 	if err != nil {
 		return nil, err
 	}
-	return imageStore.Store(ref, image.FromBundle(bndl))
+	return imageStore.Store(image.FromBundle(bndl), ref)
 }
 
 func GetNamedTagged(tag string) (reference.NamedTagged, error) {

--- a/internal/store/digest.go
+++ b/internal/store/digest.go
@@ -44,28 +44,28 @@ func StringToNamedRef(s string) (reference.Named, error) {
 
 func FromString(s string) (ID, error) {
 	if ok := identifierRegexp.MatchString(s); !ok {
-		return ID{}, fmt.Errorf("could not parse %q as a valid reference", s)
+		return "", fmt.Errorf("could not parse %q as a valid reference", s)
 	}
+	return fromID(s), nil
+}
+
+func fromID(s string) ID {
 	digest := digest.NewDigestFromEncoded(digest.SHA256, s)
-	return ID{digest}, nil
+	return ID(digest)
 }
 
 func FromAppImage(img *image.AppImage) (ID, error) {
 	digest, err := ComputeDigest(img)
-	return ID{digest}, err
+	return ID(digest), err
 }
 
 // ID is an unique identifier for docker app image bundle, implementing reference.Reference
-type ID struct {
-	digest digest.Digest
-}
-
-var _ reference.Reference = ID{}
+type ID digest.Digest
 
 func (id ID) String() string {
-	return id.digest.Encoded()
+	return id.Digest().Encoded()
 }
 
 func (id ID) Digest() digest.Digest {
-	return id.digest
+	return digest.Digest(id)
 }

--- a/internal/store/digest_test.go
+++ b/internal/store/digest_test.go
@@ -21,21 +21,14 @@ func Test_storeByDigest(t *testing.T) {
 	assert.NilError(t, err)
 
 	bndl := image.FromBundle(&bundle.Bundle{Name: "bundle-name"})
-	ref := parseRefOrDie(t, "test/simple:1.0")
-	_, err = imageStore.Store(ref, bndl)
+	_, err = imageStore.Store(bndl, nil)
 	assert.NilError(t, err)
 
-	_, err = os.Stat(dockerConfigDir.Join("app", "bundles", "docker.io", "test", "simple", "_tags", "1.0", image.BundleFilename))
-	assert.NilError(t, err)
-
-	_, err = imageStore.Store(nil, bndl)
-	assert.NilError(t, err)
-
-	ids := dockerConfigDir.Join("app", "bundles", "_ids")
+	ids := dockerConfigDir.Join("app", "bundles", "contents", "sha256")
 	infos, err := ioutil.ReadDir(ids)
 	assert.NilError(t, err)
 	assert.Equal(t, len(infos), 1)
-	_, err = os.Stat(dockerConfigDir.Join("app", "bundles", "_ids", infos[0].Name(), image.BundleFilename))
+	_, err = os.Stat(dockerConfigDir.Join("app", "bundles", "contents", "sha256", infos[0].Name(), image.BundleFilename))
 	assert.NilError(t, err)
 }
 

--- a/vendor/github.com/docker/docker/reference/errors.go
+++ b/vendor/github.com/docker/docker/reference/errors.go
@@ -1,0 +1,25 @@
+package reference // import "github.com/docker/docker/reference"
+
+type notFoundError string
+
+func (e notFoundError) Error() string {
+	return string(e)
+}
+
+func (notFoundError) NotFound() {}
+
+type invalidTagError string
+
+func (e invalidTagError) Error() string {
+	return string(e)
+}
+
+func (invalidTagError) InvalidParameter() {}
+
+type conflictingTagError string
+
+func (e conflictingTagError) Error() string {
+	return string(e)
+}
+
+func (conflictingTagError) Conflict() {}

--- a/vendor/github.com/docker/docker/reference/store.go
+++ b/vendor/github.com/docker/docker/reference/store.go
@@ -1,0 +1,348 @@
+package reference // import "github.com/docker/docker/reference"
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/pkg/ioutils"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+var (
+	// ErrDoesNotExist is returned if a reference is not found in the
+	// store.
+	ErrDoesNotExist notFoundError = "reference does not exist"
+)
+
+// An Association is a tuple associating a reference with an image ID.
+type Association struct {
+	Ref reference.Named
+	ID  digest.Digest
+}
+
+// Store provides the set of methods which can operate on a reference store.
+type Store interface {
+	References(id digest.Digest) []reference.Named
+	ReferencesByName(ref reference.Named) []Association
+	AddTag(ref reference.Named, id digest.Digest, force bool) error
+	AddDigest(ref reference.Canonical, id digest.Digest, force bool) error
+	Delete(ref reference.Named) (bool, error)
+	Get(ref reference.Named) (digest.Digest, error)
+}
+
+type store struct {
+	mu sync.RWMutex
+	// jsonPath is the path to the file where the serialized tag data is
+	// stored.
+	jsonPath string
+	// Repositories is a map of repositories, indexed by name.
+	Repositories map[string]repository
+	// referencesByIDCache is a cache of references indexed by ID, to speed
+	// up References.
+	referencesByIDCache map[digest.Digest]map[string]reference.Named
+}
+
+// Repository maps tags to digests. The key is a stringified Reference,
+// including the repository name.
+type repository map[string]digest.Digest
+
+type lexicalRefs []reference.Named
+
+func (a lexicalRefs) Len() int      { return len(a) }
+func (a lexicalRefs) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a lexicalRefs) Less(i, j int) bool {
+	return a[i].String() < a[j].String()
+}
+
+type lexicalAssociations []Association
+
+func (a lexicalAssociations) Len() int      { return len(a) }
+func (a lexicalAssociations) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a lexicalAssociations) Less(i, j int) bool {
+	return a[i].Ref.String() < a[j].Ref.String()
+}
+
+// NewReferenceStore creates a new reference store, tied to a file path where
+// the set of references are serialized in JSON format.
+func NewReferenceStore(jsonPath string) (Store, error) {
+	abspath, err := filepath.Abs(jsonPath)
+	if err != nil {
+		return nil, err
+	}
+
+	store := &store{
+		jsonPath:            abspath,
+		Repositories:        make(map[string]repository),
+		referencesByIDCache: make(map[digest.Digest]map[string]reference.Named),
+	}
+	// Load the json file if it exists, otherwise create it.
+	if err := store.reload(); os.IsNotExist(err) {
+		if err := store.save(); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// AddTag adds a tag reference to the store. If force is set to true, existing
+// references can be overwritten. This only works for tags, not digests.
+func (store *store) AddTag(ref reference.Named, id digest.Digest, force bool) error {
+	if _, isCanonical := ref.(reference.Canonical); isCanonical {
+		return errors.WithStack(invalidTagError("refusing to create a tag with a digest reference"))
+	}
+	return store.addReference(reference.TagNameOnly(ref), id, force)
+}
+
+// AddDigest adds a digest reference to the store.
+func (store *store) AddDigest(ref reference.Canonical, id digest.Digest, force bool) error {
+	return store.addReference(ref, id, force)
+}
+
+func favorDigest(originalRef reference.Named) (reference.Named, error) {
+	ref := originalRef
+	// If the reference includes a digest and a tag, we must store only the
+	// digest.
+	canonical, isCanonical := originalRef.(reference.Canonical)
+	_, isNamedTagged := originalRef.(reference.NamedTagged)
+
+	if isCanonical && isNamedTagged {
+		trimmed, err := reference.WithDigest(reference.TrimNamed(canonical), canonical.Digest())
+		if err != nil {
+			// should never happen
+			return originalRef, err
+		}
+		ref = trimmed
+	}
+	return ref, nil
+}
+
+func (store *store) addReference(ref reference.Named, id digest.Digest, force bool) error {
+	ref, err := favorDigest(ref)
+	if err != nil {
+		return err
+	}
+
+	refName := reference.FamiliarName(ref)
+	refStr := reference.FamiliarString(ref)
+
+	if refName == string(digest.Canonical) {
+		return errors.WithStack(invalidTagError("refusing to create an ambiguous tag using digest algorithm as name"))
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	repository, exists := store.Repositories[refName]
+	if !exists || repository == nil {
+		repository = make(map[string]digest.Digest)
+		store.Repositories[refName] = repository
+	}
+
+	oldID, exists := repository[refStr]
+
+	if exists {
+		if oldID == id {
+			// Nothing to do. The caller may have checked for this using store.Get in advance, but store.mu was unlocked in the meantime, so this can legitimately happen nevertheless.
+			return nil
+		}
+
+		// force only works for tags
+		if digested, isDigest := ref.(reference.Canonical); isDigest {
+			return errors.WithStack(conflictingTagError("Cannot overwrite digest " + digested.Digest().String()))
+		}
+
+		if !force {
+			return errors.WithStack(
+				conflictingTagError(
+					fmt.Sprintf("Conflict: Tag %s is already set to image %s, if you want to replace it, please use the force option", refStr, oldID.String()),
+				),
+			)
+		}
+
+		if store.referencesByIDCache[oldID] != nil {
+			delete(store.referencesByIDCache[oldID], refStr)
+			if len(store.referencesByIDCache[oldID]) == 0 {
+				delete(store.referencesByIDCache, oldID)
+			}
+		}
+	}
+
+	repository[refStr] = id
+	if store.referencesByIDCache[id] == nil {
+		store.referencesByIDCache[id] = make(map[string]reference.Named)
+	}
+	store.referencesByIDCache[id][refStr] = ref
+
+	return store.save()
+}
+
+// Delete deletes a reference from the store. It returns true if a deletion
+// happened, or false otherwise.
+func (store *store) Delete(ref reference.Named) (bool, error) {
+	ref, err := favorDigest(ref)
+	if err != nil {
+		return false, err
+	}
+
+	ref = reference.TagNameOnly(ref)
+
+	refName := reference.FamiliarName(ref)
+	refStr := reference.FamiliarString(ref)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	repository, exists := store.Repositories[refName]
+	if !exists {
+		return false, ErrDoesNotExist
+	}
+
+	if id, exists := repository[refStr]; exists {
+		delete(repository, refStr)
+		if len(repository) == 0 {
+			delete(store.Repositories, refName)
+		}
+		if store.referencesByIDCache[id] != nil {
+			delete(store.referencesByIDCache[id], refStr)
+			if len(store.referencesByIDCache[id]) == 0 {
+				delete(store.referencesByIDCache, id)
+			}
+		}
+		return true, store.save()
+	}
+
+	return false, ErrDoesNotExist
+}
+
+// Get retrieves an item from the store by reference
+func (store *store) Get(ref reference.Named) (digest.Digest, error) {
+	if canonical, ok := ref.(reference.Canonical); ok {
+		// If reference contains both tag and digest, only
+		// lookup by digest as it takes precedence over
+		// tag, until tag/digest combos are stored.
+		if _, ok := ref.(reference.Tagged); ok {
+			var err error
+			ref, err = reference.WithDigest(reference.TrimNamed(canonical), canonical.Digest())
+			if err != nil {
+				return "", err
+			}
+		}
+	} else {
+		ref = reference.TagNameOnly(ref)
+	}
+
+	refName := reference.FamiliarName(ref)
+	refStr := reference.FamiliarString(ref)
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	repository, exists := store.Repositories[refName]
+	if !exists || repository == nil {
+		return "", ErrDoesNotExist
+	}
+
+	id, exists := repository[refStr]
+	if !exists {
+		return "", ErrDoesNotExist
+	}
+
+	return id, nil
+}
+
+// References returns a slice of references to the given ID. The slice
+// will be nil if there are no references to this ID.
+func (store *store) References(id digest.Digest) []reference.Named {
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	// Convert the internal map to an array for two reasons:
+	// 1) We must not return a mutable
+	// 2) It would be ugly to expose the extraneous map keys to callers.
+
+	var references []reference.Named
+	for _, ref := range store.referencesByIDCache[id] {
+		references = append(references, ref)
+	}
+
+	sort.Sort(lexicalRefs(references))
+
+	return references
+}
+
+// ReferencesByName returns the references for a given repository name.
+// If there are no references known for this repository name,
+// ReferencesByName returns nil.
+func (store *store) ReferencesByName(ref reference.Named) []Association {
+	refName := reference.FamiliarName(ref)
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+
+	repository, exists := store.Repositories[refName]
+	if !exists {
+		return nil
+	}
+
+	var associations []Association
+	for refStr, refID := range repository {
+		ref, err := reference.ParseNormalizedNamed(refStr)
+		if err != nil {
+			// Should never happen
+			return nil
+		}
+		associations = append(associations,
+			Association{
+				Ref: ref,
+				ID:  refID,
+			})
+	}
+
+	sort.Sort(lexicalAssociations(associations))
+
+	return associations
+}
+
+func (store *store) save() error {
+	// Store the json
+	jsonData, err := json.Marshal(store)
+	if err != nil {
+		return err
+	}
+	return ioutils.AtomicWriteFile(store.jsonPath, jsonData, 0600)
+}
+
+func (store *store) reload() error {
+	f, err := os.Open(store.jsonPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := json.NewDecoder(f).Decode(&store); err != nil {
+		return err
+	}
+
+	for _, repository := range store.Repositories {
+		for refStr, refID := range repository {
+			ref, err := reference.ParseNormalizedNamed(refStr)
+			if err != nil {
+				// Should never happen
+				continue
+			}
+			if store.referencesByIDCache[refID] == nil {
+				store.referencesByIDCache[refID] = make(map[string]reference.Named)
+			}
+			store.referencesByIDCache[refID][refStr] = ref
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**- What I did**
Used docker/reference to implement imageStore

**- How I did it**
only store images by ID, use docker/reference to track tags/digest

**- How to verify it**
e2e test suite cover most usages

**- Description for the changelog**
re-implemented bundle store

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/132757/70546806-3c4a2280-1b70-11ea-8b53-fabdcd0fbafd.png)

