### PR TITLE
Remove poll-breaking assertion in e2e tests

### DIFF
--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -62,7 +62,6 @@ func runWithDindSwarmAndRegistry(t *testing.T, todo func(dindSwarmAndRegistryInf
 		}
 		cmd := icmd.Command(params[0], params[1:]...)
 		result := icmd.RunCmd(cmd)
-		result.Assert(t, icmd.Success)
 		return result.Combined()
 	}
 	// Func to execute docker cli commands


### PR DESCRIPTION
**- What I did**

Fixes #786 

Removed assertion of local-in-docker command result when running e2e tests in swarm. This function is only used by the compatibility tests which does it's own assertion in a poll (https://github.com/docker/app/blob/1cfb232b03cc23685b1dd68521cf0e6fcf1276ca/e2e/compatibility_test.go#L138). The removed assertion was breaking the poll flow stopping the test from being able to retry.

**- How I did it**

Removed `result.Assert` in the `runLocalCmd` which is used in the `TestBackwardsCompatibilityV1` to check if the app's port has been updated. Note that `TestBackwardsCompatibilityV1` is the only place that the `runLocalCmd` is used either through `runner.localCmd` or `runner.execCmd`.

**- How to verify it**

Run the `TestBackwardsCompatibilityV1` e2e test:
`make E2E_TESTS=TestBackwardsCompatibilityV1 -f docker.Makefile test-e2e`

The CI will check if all e2e tests pass

**- A picture of a cute animal (not mandatory)**

![kitten-2019-11-12](https://user-images.githubusercontent.com/22098752/70702630-6f062f00-1cc6-11ea-86c2-fa1e503759c8.jpg)

