### PR TITLE
Remove build time in binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,8 @@
 include vars.mk
 
-ifeq ($(BUILDTIME),)
-  BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
-endif
-ifeq ($(BUILDTIME),)
-  BUILDTIME := unknown
-  $(warning unable to set BUILDTIME. Set the value manually)
-endif
-
 LDFLAGS := "-s -w \
   -X $(PKG_NAME)/internal.GitCommit=$(COMMIT) \
-  -X $(PKG_NAME)/internal.Version=$(TAG)      \
-  -X $(PKG_NAME)/internal.BuildTime=$(BUILDTIME)"
+  -X $(PKG_NAME)/internal.Version=$(TAG)"
 
 EXEC_EXT :=
 ifeq ($(OS),Windows_NT)

--- a/internal/version.go
+++ b/internal/version.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-	"time"
 )
 
 var (
@@ -12,8 +11,6 @@ var (
 	Version = "unknown"
 	// GitCommit is the commit that this was built from.
 	GitCommit = "unknown"
-	// BuildTime is the time at which the binary was built.
-	BuildTime = "unknown"
 )
 
 // FullVersion returns a string of version information.
@@ -21,18 +18,8 @@ func FullVersion() string {
 	res := []string{
 		fmt.Sprintf("Version:               %s", Version),
 		fmt.Sprintf("Git commit:            %s", GitCommit),
-		fmt.Sprintf("Built:                 %s", reformatDate(BuildTime)),
 		fmt.Sprintf("OS/Arch:               %s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 
 	return strings.Join(res, "\n")
-}
-
-// FIXME(chris-crone): use function in docker/cli/cli/command/system/version.go.
-func reformatDate(buildTime string) string {
-	t, errTime := time.Parse(time.RFC3339Nano, buildTime)
-	if errTime == nil {
-		return t.Format(time.ANSIC)
-	}
-	return buildTime
 }

--- a/vars.mk
+++ b/vars.mk
@@ -11,7 +11,6 @@ ifeq ($(SHELL),sh.exe)
   rm = del /F /Q $(subst /,\,$(1)) > nul 2>&1 || (exit 0)
   rmdir = rmdir /S /Q $(subst /,\,$(1)) > nul 2>&1 || (exit 0)
   chmod =
-  BUILDTIME ?= unknown
   NULL := nul
 else
   # The no-op redirection forces make to shell out the commands instead of spawning a process as


### PR DESCRIPTION
**- What I did**
Replace build time in binary with commit time

**- How I did it**
By changing the date by the git commiter date in the Makefile

**- How to verify it**
```shell
$ docker app --version
```

**- Description for the changelog**
Replace build time in binary with commit time

**- A picture of a cute animal (not mandatory)**
![save-the-date-goat](https://user-images.githubusercontent.com/373485/71354936-be2d4900-257d-11ea-8971-170a887dd1fc.jpg)

