### PR TITLE
Add Jenkins timeout

### DIFF
--- a/Jenkinsfile.baguette
+++ b/Jenkinsfile.baguette
@@ -7,6 +7,7 @@ pipeline {
 
     options {
         skipDefaultCheckout(true)
+        timeout(time: 2, unit: 'HOURS')
     }
 
     environment {


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

**- What I did**

I've added a timeout to the Jenkins job, I saw https://ci.docker.com/teams-dsg/job/dsg/job/app/view/change-requests/job/PR-788/6/ running "forever".

**- How I did it**

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory)**

⏱