### PR TITLE
Fix folder name in example voting app README

### DIFF
--- a/examples/voting-app/README.md
+++ b/examples/voting-app/README.md
@@ -170,7 +170,7 @@ Create a `prod` folder to store the parameters you would use for
 production. Create a new `prod-parameters.yml` file in the `prod` folder.
 
 ```shell
-$ mkdir parameters
+$ mkdir prod 
 $ tree
 .
 ├── docker-compose.yml


### PR DESCRIPTION
Signed-off-by: Kristian Theilgaard <kristian.theilgaard@gmail.com>

Tiny fix for folder typo in voting-app example.
